### PR TITLE
Add CVE lookup and IP reputation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ This is a **local MCP server** — it runs on your machine and connects to Claud
 | `port_scan` | Nmap-powered port scanner with service/version detection and security warnings |
 | `ssl_inspect` | Inspect SSL/TLS certificate — issuer, expiry, cipher strength, SANs, TLS version |
 | `tech_stack_detect` | Fingerprint web server, CMS, JS frameworks, CDN, analytics, and security headers |
+| `cve_lookup` | Search the NVD database for known CVEs affecting a software name and version |
+| `ip_reputation` | Check whether an IP address has AbuseIPDB abuse reports |
 | `full_recon` | Orchestrates all 5 tools in parallel and returns combined results for Claude to analyze |
 
 ---
@@ -151,7 +153,11 @@ Run DNS enumeration on github.com
 Scan ports on scanme.nmap.org
 Inspect the SSL certificate of stripe.com
 Detect the tech stack of wordpress.org
+Look up CVEs for apache 2.4.49
+Check the reputation of IP 1.2.3.4
 ```
+
+> `ip_reputation` requires an AbuseIPDB API key in the `ABUSEIPDB_API_KEY` environment variable.
 
 ### Port scan types
 

--- a/main.py
+++ b/main.py
@@ -3,6 +3,8 @@ import whois
 import re
 import nmap
 import dns.resolver
+import ipaddress
+import os
 import ssl
 import socket
 import requests
@@ -17,6 +19,31 @@ mcp = FastMCP("CyberSecurity-MCP-Server")
 def is_valid_domain(domain: str) -> bool:
     pattern = r"^(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$"
     return re.match(pattern, domain) is not None
+
+def get_cvss_details(cve: dict) -> dict:
+    metrics = cve.get("metrics", {})
+    metric_groups = (
+        metrics.get("cvssMetricV31")
+        or metrics.get("cvssMetricV30")
+        or metrics.get("cvssMetricV2")
+        or []
+    )
+
+    if not metric_groups:
+        return {"severity": "Unknown", "score": None}
+
+    metric = metric_groups[0]
+    cvss_data = metric.get("cvssData", {})
+
+    return {
+        "severity": metric.get("baseSeverity") or cvss_data.get("baseSeverity") or "Unknown",
+        "score": cvss_data.get("baseScore"),
+    }
+
+def get_english_description(cve: dict) -> str:
+    descriptions = cve.get("descriptions", [])
+    english = next((item for item in descriptions if item.get("lang") == "en"), None)
+    return english.get("value", "") if english else ""
 
 # TOOL 1 — WHOIS LOOKUP
 @mcp.tool()
@@ -368,8 +395,114 @@ def tech_stack_detect(domain: str) -> dict:
         return {"success": False, "error": str(e)}
 
 
+# TOOL 6 — CVE LOOKUP
+@mcp.tool()
+def cve_lookup(software: str, version: str) -> dict:
+    """
+    Look up known CVEs for a software name and version using the NVD API.
+    """
+    software = software.strip()
+    version = version.strip()
+
+    if not software or not version:
+        return {"success": False, "error": "Software and version are required"}
+
+    try:
+        response = requests.get(
+            "https://services.nvd.nist.gov/rest/json/cves/2.0",
+            params={"keywordSearch": f"{software} {version}"},
+            timeout=15,
+            headers={"User-Agent": "CyberSecurity-MCP-Server/1.0"},
+        )
+        response.raise_for_status()
+        data = response.json()
+
+        cves = []
+        for item in data.get("vulnerabilities", []):
+            cve = item.get("cve", {})
+            cvss = get_cvss_details(cve)
+            cves.append({
+                "cve_id": cve.get("id"),
+                "severity": cvss["severity"],
+                "score": cvss["score"],
+                "published": cve.get("published"),
+                "last_modified": cve.get("lastModified"),
+                "description": get_english_description(cve),
+            })
+
+        return {
+            "success": True,
+            "software": software,
+            "version": version,
+            "total_results": data.get("totalResults", len(cves)),
+            "cves": cves,
+        }
+
+    except requests.exceptions.HTTPError as e:
+        return {"success": False, "error": f"NVD API request failed: {str(e)}"}
+    except requests.exceptions.Timeout:
+        return {"success": False, "error": "NVD API request timed out"}
+    except requests.exceptions.RequestException as e:
+        return {"success": False, "error": f"Could not connect to NVD API: {str(e)}"}
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
+# TOOL 7 — IP REPUTATION CHECK
+@mcp.tool()
+def ip_reputation(ip_address: str) -> dict:
+    """
+    Check whether an IP address is reported as malicious using AbuseIPDB.
+    Requires ABUSEIPDB_API_KEY in the environment.
+    """
+    try:
+        ip = str(ipaddress.ip_address(ip_address.strip()))
+    except ValueError:
+        return {"success": False, "error": "Invalid IP address format"}
+
+    api_key = os.getenv("ABUSEIPDB_API_KEY")
+    if not api_key:
+        return {
+            "success": False,
+            "error": "ABUSEIPDB_API_KEY environment variable is required",
+        }
+
+    try:
+        response = requests.get(
+            "https://api.abuseipdb.com/api/v2/check",
+            params={"ipAddress": ip, "maxAgeInDays": 90},
+            headers={"Key": api_key, "Accept": "application/json"},
+            timeout=15,
+        )
+        response.raise_for_status()
+        data = response.json().get("data", {})
+
+        abuse_score = data.get("abuseConfidenceScore", 0)
+        return {
+            "success": True,
+            "ip": ip,
+            "is_malicious": abuse_score >= 25,
+            "abuse_confidence_score": abuse_score,
+            "total_reports": data.get("totalReports", 0),
+            "country": data.get("countryCode"),
+            "isp": data.get("isp"),
+            "domain": data.get("domain"),
+            "usage_type": data.get("usageType"),
+            "last_reported_at": data.get("lastReportedAt"),
+        }
+
+    except requests.exceptions.HTTPError as e:
+        return {"success": False, "error": f"AbuseIPDB API request failed: {str(e)}"}
+    except requests.exceptions.Timeout:
+        return {"success": False, "error": "AbuseIPDB API request timed out"}
+    except requests.exceptions.RequestException as e:
+        return {"success": False, "error": f"Could not connect to AbuseIPDB API: {str(e)}"}
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
 # ─────────────────────────────────────────────
-# TOOL 6 — FULL RECON (runs all 5 tools)
+# TOOL 8 — FULL RECON (runs all 5 tools)
 # ─────────────────────────────────────────────
 
 @mcp.tool()

--- a/test_security_tools.py
+++ b/test_security_tools.py
@@ -1,0 +1,84 @@
+import os
+import unittest
+from unittest.mock import Mock, patch
+
+from main import cve_lookup, ip_reputation
+
+
+class SecurityToolTests(unittest.TestCase):
+    @patch("main.requests.get")
+    def test_cve_lookup_returns_nvd_results(self, mock_get):
+        response = Mock()
+        response.json.return_value = {
+            "totalResults": 1,
+            "vulnerabilities": [
+                {
+                    "cve": {
+                        "id": "CVE-2021-41773",
+                        "published": "2021-10-05T12:15:07.000",
+                        "lastModified": "2024-11-21T05:31:44.123",
+                        "descriptions": [{"lang": "en", "value": "Path traversal vulnerability"}],
+                        "metrics": {
+                            "cvssMetricV31": [
+                                {
+                                    "baseSeverity": "CRITICAL",
+                                    "cvssData": {"baseScore": 9.8},
+                                }
+                            ]
+                        },
+                    }
+                }
+            ],
+        }
+        mock_get.return_value = response
+
+        result = cve_lookup("apache", "2.4.49")
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["software"], "apache")
+        self.assertEqual(result["version"], "2.4.49")
+        self.assertEqual(result["cves"][0]["cve_id"], "CVE-2021-41773")
+        self.assertEqual(result["cves"][0]["severity"], "CRITICAL")
+        self.assertEqual(result["cves"][0]["score"], 9.8)
+        mock_get.assert_called_once()
+
+    def test_ip_reputation_requires_valid_ip_and_api_key(self):
+        self.assertFalse(ip_reputation("not-an-ip")["success"])
+
+        with patch.dict(os.environ, {}, clear=True):
+            result = ip_reputation("1.2.3.4")
+
+        self.assertFalse(result["success"])
+        self.assertIn("ABUSEIPDB_API_KEY", result["error"])
+
+    @patch.dict(os.environ, {"ABUSEIPDB_API_KEY": "test-key"})
+    @patch("main.requests.get")
+    def test_ip_reputation_maps_abuseipdb_response(self, mock_get):
+        response = Mock()
+        response.json.return_value = {
+            "data": {
+                "ipAddress": "1.2.3.4",
+                "abuseConfidenceScore": 95,
+                "totalReports": 342,
+                "countryCode": "CN",
+                "isp": "Example ISP",
+                "domain": "example.net",
+                "usageType": "Data Center/Web Hosting/Transit",
+                "lastReportedAt": "2026-05-01T00:00:00+00:00",
+            }
+        }
+        mock_get.return_value = response
+
+        result = ip_reputation("1.2.3.4")
+
+        self.assertTrue(result["success"])
+        self.assertTrue(result["is_malicious"])
+        self.assertEqual(result["abuse_confidence_score"], 95)
+        self.assertEqual(result["total_reports"], 342)
+        self.assertEqual(result["country"], "CN")
+        self.assertEqual(result["isp"], "Example ISP")
+        mock_get.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #1.
Fixes #2.

This adds both requested MCP tools:
- `cve_lookup(software: str, version: str) -> dict` queries the NVD CVE 2.0 API without requiring an API key and returns CVE ID, severity, score, dates, and description.
- `ip_reputation(ip_address: str) -> dict` validates IPv4/IPv6 input and checks AbuseIPDB using the `ABUSEIPDB_API_KEY` environment variable.

I also updated the README tool table/usage examples and added unit tests that mock the external APIs so the test suite does not require live NVD or AbuseIPDB calls.

Validation:
- `uv run python -m unittest test_security_tools.py` passes: 3 tests
- `uv run python -m py_compile main.py test_security_tools.py` passes
- `git diff --check` passes