### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/gaoharimran29-glitch/AynOps/security/code-scanning/6](https://github.com/gaoharimran29-glitch/AynOps/security/code-scanning/6)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is minimally scoped.  
Best fix here: set workflow-level permissions to:

- `contents: read`

This satisfies `actions/checkout` and keeps token access restricted. Since all jobs in this file are test-only and there is only one job, root-level permissions is the simplest, least invasive change.

**File to edit:** `.github/workflows/tests.yml`  
**Region:** after the `on:` triggers and before `jobs:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
