### PR TITLE
docs : fix typo wihtout -> without in contributing.md

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -79,7 +79,7 @@ Run the tests:
 ```bash
 pytest tests/test_my_tool.py -v
 ```
-All tests should pass wihtout any warning or error.
+All tests should pass without any warning or error.
 
 Every new tool must include at least:
 


### PR DESCRIPTION
Fixes #30

Changed "wihtout" to "without" on line 82 of contributing.md
