### PR TITLE
Validate port scan type before scanning

### DIFF
--- a/tests/test_port_scan.py
+++ b/tests/test_port_scan.py
@@ -56,11 +56,16 @@ class TestPortScan(unittest.TestCase):
         self.assertIn("Nmap not found", result["error"])
 
     @patch("tools.portscan_tool.nmap.PortScanner")
-    def test_unknown_scan_type_defaults_to_basic(self, mock_cls):
-        mock_cls.return_value = self._make_scanner_mock()
+    def test_invalid_scan_type_returns_error(self, mock_cls):
         result = port_scan("example.com", scan_type="invalid_type")
-        # Should still succeed — falls back to "-F"
-        self.assertTrue(result["success"])
+
+        self.assertFalse(result["success"])
+        self.assertIn("Invalid scan_type", result["error"])
+        self.assertEqual(
+            result["valid_scan_types"],
+            ["basic", "service", "os", "full", "vuln"],
+        )
+        mock_cls.assert_not_called()
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tools/portscan_tool.py
+++ b/tools/portscan_tool.py
@@ -11,18 +11,28 @@ def port_scan(target: str, scan_type: str = "basic") -> dict:
     - "full"    : All 65535 ports, slow (-p-)
     - "vuln"    : Basic vulnerability scripts (--script vuln -F)
     """
+    scan_args = {
+        "basic":   "-F",
+        "service": "-sV -F",
+        "os":      "-O -F",
+        "full":    "-p-",
+        "vuln":    "--script vuln -F"
+    }
+
+    if scan_type not in scan_args:
+        return {
+            "success": False,
+            "error": (
+                f"Invalid scan_type '{scan_type}'. Valid options are: "
+                f"{', '.join(scan_args.keys())}"
+            ),
+            "valid_scan_types": list(scan_args.keys()),
+        }
+
     try:
         scanner = nmap.PortScanner()
 
-        scan_args = {
-            "basic":   "-F",
-            "service": "-sV -F",
-            "os":      "-O -F",
-            "full":    "-p-",
-            "vuln":    "--script vuln -F"
-        }
-
-        args = scan_args.get(scan_type, "-F")
+        args = scan_args[scan_type]
         scanner.scan(hosts=target, arguments=args)
 
         results = []


### PR DESCRIPTION
## Summary

Return a clear error for invalid scan_type values instead of silently falling back to a basic scan.

The validation now runs before constructing the nmap scanner, so typos are reported consistently even when nmap is not installed locally.

Closes #28