### PR TITLE
fix: support forked pull requests in GitHub Actions

### DIFF
--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -1,15 +1,16 @@
 name: PR Size Labeler
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
+
+permissions:
+  pull-requests: write
+  issues: write
 
 jobs:
   size:
     runs-on: ubuntu-latest
-
-    permissions:
-      pull-requests: write
 
     steps:
       - uses: actions/github-script@v8

--- a/.github/workflows/pr-welcome.yml
+++ b/.github/workflows/pr-welcome.yml
@@ -1,32 +1,38 @@
 name: Welcome Pull Requests
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
   welcome:
     runs-on: ubuntu-latest
 
-    permissions:
-      pull-requests: write
-
     steps:
-      - name: Comment on PR
+      - name: Welcome first-time contributors
         uses: actions/github-script@v8
         with:
           script: |
+            const pr = context.payload.pull_request;
+
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              body: [
-                "🎉 Thanks for your contribution!",
-                "",
-                "Checklist:",
-                "- [ ] Documentation updated",
-                "- [ ] No secrets included",
-                "- [ ] requirements.txt updated (if applicable)",
-                "- [ ] .env.example updated (if applicable)"
-              ].join("\n")
-            })
+              issue_number: pr.number,
+              body: `🎉 Thanks for your contribution to AynOps!
+
+Hello @${pr.user.login}, thank you for opening this pull request. We appreciate your effort in improving the project.
+
+Before requesting a review, please ensure that:
+
+- [ ] Documentation has been updated (if applicable)
+- [ ] No secrets or sensitive information have been committed
+- [ ] Dependencies have been updated appropriately (if applicable)
+- [ ] \`.env.example\` has been updated (if applicable)
+
+A maintainer will review your contribution soon. Thanks again for being a part of the AynOps community! 🚀`
+            });


### PR DESCRIPTION
## Summary

This PR fixes GitHub Actions workflows that were failing on pull requests opened from forks.

### Changes made

* Updated the **PR Size Labeler** workflow to work correctly with forked pull requests.
* Updated the **Welcome Pull Requests** workflow to allow posting welcome comments on forked PRs.
* Added the necessary workflow permissions for labeling and commenting.

### Problem

External contributors were seeing the following error in GitHub Actions:

```text
Resource not accessible by integration (403)
```

This occurred because workflows triggered by `pull_request` events on forked repositories receive restricted permissions, preventing them from adding labels or posting comments.

### Solution

Switched the affected workflows to use `pull_request_target` and configured the required permissions while ensuring that no contributor code is checked out or executed.

### Testing

* Verified that the workflows execute without accessing contributor code.
* Confirmed that the changes address the permission issue encountered in previous pull requests.

Closes the CI issues affecting external contributors.
