### PR TITLE
feat: add tests for headers_analyzer and integrate into full_recon (#50)

### DIFF
--- a/tests/test_full_recon.py
+++ b/tests/test_full_recon.py
@@ -17,7 +17,7 @@ class TestFullRecon(unittest.TestCase):
     @patch("tools.fullrecon_tool.tech_stack_detect", return_value={"success": True, "technologies": {}})
     @patch("tools.fullrecon_tool.asn_lookup", return_value={"success": True, "asn": "AS12345"})
     @patch("tools.fullrecon_tool.ct_summary", return_value={"success": True, "total_unique_subdomains": 10, "sample_subdomains": ["api.example.com"]})
-    def test_full_recon_calls_all_tools(self, mock_headers, mock_ct, mock_asn, mock_tech, mock_ssl, mock_ports, mock_dns, mock_whois):
+    def test_full_recon_calls_all_tools(self, mock_ct, mock_asn, mock_tech, mock_ssl, mock_ports, mock_dns, mock_whois, mock_headers):
         result = full_recon("example.com")
 
         self.assertTrue(result["success"])
@@ -50,7 +50,8 @@ class TestFullRecon(unittest.TestCase):
     @patch("tools.fullrecon_tool.tech_stack_detect", return_value={"success": True})
     @patch("tools.fullrecon_tool.asn_lookup", return_value={"success": True})
     @patch("tools.fullrecon_tool.ct_summary", return_value={"success": True})
-    def test_full_recon_tool_failure_isolated(self, mock_ct , mock_asn , mock_tech, mock_ssl, mock_ports, mock_dns, mock_whois):
+    @patch("tools.fullrecon_tool.headers_analyzer", return_value={"success": True})
+    def test_full_recon_tool_failure_isolated(self, mock_headers, mock_ct, mock_asn, mock_tech, mock_ssl, mock_ports, mock_dns, mock_whois):
         """One tool crashing must not crash the whole recon."""
         result = full_recon("example.com")
 
@@ -68,7 +69,8 @@ class TestFullRecon(unittest.TestCase):
     @patch("tools.fullrecon_tool.tech_stack_detect", return_value={"success": True})
     @patch("tools.fullrecon_tool.asn_lookup", return_value={"success": True})
     @patch("tools.fullrecon_tool.ct_summary", return_value={"success": True})
-    def test_full_recon_scanned_at_is_iso_format(self, *_):
+    @patch("tools.fullrecon_tool.headers_analyzer", return_value={"success": True})
+    def test_full_recon_scanned_at_is_iso_format(self, mock_headers, mock_ct, mock_asn, mock_tech, mock_ssl, mock_ports, mock_dns, mock_whois):
         from datetime import datetime
         result = full_recon("example.com")
         # Should be parseable ISO timestamp ending in Z

--- a/tests/test_full_recon.py
+++ b/tests/test_full_recon.py
@@ -9,6 +9,7 @@ class TestFullRecon(unittest.TestCase):
         self.assertFalse(result["success"])
         self.assertIn("error", result)
 
+    @patch("tools.fullrecon_tool.headers_analyzer", return_value={"success": True, "domain": "example.com", "headers": {}})
     @patch("tools.fullrecon_tool.whois_lookup", return_value={"success": True, "domain": "example.com"})
     @patch("tools.fullrecon_tool.dns_enumeration", return_value={"success": True, "records": {}})
     @patch("tools.fullrecon_tool.port_scan", return_value={"success": True, "results": []})
@@ -16,7 +17,7 @@ class TestFullRecon(unittest.TestCase):
     @patch("tools.fullrecon_tool.tech_stack_detect", return_value={"success": True, "technologies": {}})
     @patch("tools.fullrecon_tool.asn_lookup", return_value={"success": True, "asn": "AS12345"})
     @patch("tools.fullrecon_tool.ct_summary", return_value={"success": True, "total_unique_subdomains": 10, "sample_subdomains": ["api.example.com"]})
-    def test_full_recon_calls_all_tools(self, mock_ct, mock_asn, mock_tech, mock_ssl, mock_ports, mock_dns, mock_whois):
+    def test_full_recon_calls_all_tools(self, mock_headers, mock_ct, mock_asn, mock_tech, mock_ssl, mock_ports, mock_dns, mock_whois):
         result = full_recon("example.com")
 
         self.assertTrue(result["success"])
@@ -32,7 +33,7 @@ class TestFullRecon(unittest.TestCase):
         self.assertIn("techstack", result["results"])
         self.assertIn("asn", result["results"])
         self.assertIn("ct_logs", result["results"])
-
+        self.assertIn("headers", result["results"])
         mock_whois.assert_called_once_with("example.com")
         mock_dns.assert_called_once_with("example.com")
         mock_ssl.assert_called_once_with("example.com")
@@ -40,6 +41,7 @@ class TestFullRecon(unittest.TestCase):
         mock_ports.assert_called_once_with("example.com", "service")
         mock_asn.assert_called_once_with("example.com")
         mock_ct.assert_called_once_with("example.com")
+        mock_headers.assert_called_once_with("example.com")
 
     @patch("tools.fullrecon_tool.whois_lookup", side_effect=Exception("WHOIS exploded"))
     @patch("tools.fullrecon_tool.dns_enumeration", return_value={"success": True})

--- a/tests/test_headers_tool.py
+++ b/tests/test_headers_tool.py
@@ -95,6 +95,17 @@ class TestHeadersAnalyzer(unittest.TestCase):
         self.assertEqual(csp["severity"], "high")
 
     @patch("tools.headers_tool.urllib.request.OpenerDirector.open")
+    def test_csp_report_only_mode_detected(self, mock_open):
+        mock_open.return_value = self._make_response({
+            "Content-Security-Policy-Report-Only": "default-src 'self'",
+        })
+        result = headers_analyzer("example.com")
+        csp = result["headers"]["content-security-policy"]
+        self.assertTrue(csp["present"])
+        self.assertIn("report-only mode", csp["issue"])
+        self.assertEqual(csp["severity"], "medium")
+
+    @patch("tools.headers_tool.urllib.request.OpenerDirector.open")
     def test_x_frame_options_deny_accepted(self, mock_open):
         mock_open.return_value = self._make_response({
             "X-Frame-Options": "DENY",

--- a/tests/test_headers_tool.py
+++ b/tests/test_headers_tool.py
@@ -1,0 +1,146 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import urllib.error
+from tools.headers_tool import headers_analyzer
+
+
+class TestHeadersAnalyzer(unittest.TestCase):
+
+    def _make_response(self, headers: dict, final_url: str = "https://example.com/"):
+        """Helper to build a mock HTTP response."""
+        mock_resp = MagicMock()
+        mock_resp.headers = MagicMock()
+        mock_resp.headers.items.return_value = list(headers.items())
+        mock_resp.url = final_url
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        return mock_resp
+
+    # ------------------------------------------------------------------
+    # Domain validation
+    # ------------------------------------------------------------------
+
+    def test_invalid_domain_rejected(self):
+        result = headers_analyzer("not-a-domain")
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error"], "Invalid domain format")
+
+    def test_ip_address_rejected(self):
+        result = headers_analyzer("192.168.1.1")
+        self.assertFalse(result["success"])
+
+    # ------------------------------------------------------------------
+    # Successful response
+    # ------------------------------------------------------------------
+
+    @patch("tools.headers_tool.urllib.request.OpenerDirector.open")
+    def test_success_returns_correct_structure(self, mock_open):
+        mock_open.return_value = self._make_response({
+            "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+            "X-Frame-Options": "DENY",
+            "X-Content-Type-Options": "nosniff",
+        })
+        result = headers_analyzer("example.com")
+        self.assertTrue(result["success"])
+        self.assertIn("domain", result)
+        self.assertIn("headers", result)
+
+    @patch("tools.headers_tool.urllib.request.OpenerDirector.open")
+    def test_hsts_present_and_valid(self, mock_open):
+        mock_open.return_value = self._make_response({
+            "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        })
+        result = headers_analyzer("example.com")
+        hsts = result["headers"]["strict-transport-security"]
+        self.assertTrue(hsts["present"])
+        self.assertEqual(hsts["issue"], "None")
+        self.assertEqual(hsts["severity"], "low")
+
+    @patch("tools.headers_tool.urllib.request.OpenerDirector.open")
+    def test_hsts_missing_flagged_as_high(self, mock_open):
+        mock_open.return_value = self._make_response({})
+        result = headers_analyzer("example.com")
+        hsts = result["headers"]["strict-transport-security"]
+        self.assertFalse(hsts["present"])
+        self.assertEqual(hsts["severity"], "high")
+
+    @patch("tools.headers_tool.urllib.request.OpenerDirector.open")
+    def test_hsts_low_max_age_flagged(self, mock_open):
+        mock_open.return_value = self._make_response({
+            "Strict-Transport-Security": "max-age=3600",
+        })
+        result = headers_analyzer("example.com")
+        hsts = result["headers"]["strict-transport-security"]
+        self.assertTrue(hsts["present"])
+        self.assertIn("max-age", hsts["issue"])
+        self.assertEqual(hsts["severity"], "medium")
+
+    @patch("tools.headers_tool.urllib.request.OpenerDirector.open")
+    def test_csp_missing_flagged(self, mock_open):
+        mock_open.return_value = self._make_response({})
+        result = headers_analyzer("example.com")
+        csp = result["headers"]["content-security-policy"]
+        self.assertFalse(csp["present"])
+        self.assertEqual(csp["severity"], "high")
+
+    @patch("tools.headers_tool.urllib.request.OpenerDirector.open")
+    def test_csp_unsafe_inline_flagged(self, mock_open):
+        mock_open.return_value = self._make_response({
+            "Content-Security-Policy": "default-src 'self'; script-src 'unsafe-inline'",
+        })
+        result = headers_analyzer("example.com")
+        csp = result["headers"]["content-security-policy"]
+        self.assertTrue(csp["present"])
+        self.assertIn("unsafe-inline", csp["issue"])
+        self.assertEqual(csp["severity"], "high")
+
+    @patch("tools.headers_tool.urllib.request.OpenerDirector.open")
+    def test_x_frame_options_deny_accepted(self, mock_open):
+        mock_open.return_value = self._make_response({
+            "X-Frame-Options": "DENY",
+        })
+        result = headers_analyzer("example.com")
+        xfo = result["headers"]["x-frame-options"]
+        self.assertTrue(xfo["present"])
+        self.assertEqual(xfo["issue"], "None")
+
+    @patch("tools.headers_tool.urllib.request.OpenerDirector.open")
+    def test_x_content_type_options_nosniff_accepted(self, mock_open):
+        mock_open.return_value = self._make_response({
+            "X-Content-Type-Options": "nosniff",
+        })
+        result = headers_analyzer("example.com")
+        xcto = result["headers"]["x-content-type-options"]
+        self.assertTrue(xcto["present"])
+        self.assertEqual(xcto["issue"], "None")
+
+    @patch("tools.headers_tool.urllib.request.OpenerDirector.open")
+    def test_server_header_flagged_as_disclosure(self, mock_open):
+        mock_open.return_value = self._make_response({
+            "Server": "Apache/2.4.41",
+        })
+        result = headers_analyzer("example.com")
+        self.assertIn("server", result["headers"])
+        self.assertIn("exposes technology", result["headers"]["server"]["issue"])
+
+    # ------------------------------------------------------------------
+    # Error handling
+    # ------------------------------------------------------------------
+
+    @patch("tools.headers_tool.urllib.request.OpenerDirector.open",
+           side_effect=urllib.error.URLError("Connection refused"))
+    def test_connection_error_returns_failure(self, _):
+        result = headers_analyzer("example.com")
+        self.assertFalse(result["success"])
+        self.assertIn("Connection failed", result["error"])
+
+    @patch("tools.headers_tool.urllib.request.OpenerDirector.open",
+           side_effect=Exception("Unexpected error"))
+    def test_unexpected_exception_returns_failure(self, _):
+        result = headers_analyzer("example.com")
+        self.assertFalse(result["success"])
+        self.assertIn("error", result)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/fullrecon_tool.py
+++ b/tools/fullrecon_tool.py
@@ -55,7 +55,7 @@ def full_recon(domain: str) -> dict:
             results[name] = {"success": False, "error": str(e)}
 
     # Run all tools in parallel
-    with concurrent.futures.ThreadPoolExecutor(max_workers=7) as ex:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as ex:
         futures = [
             ex.submit(run, "whois",    whois_lookup,       domain),
             ex.submit(run, "dns",      dns_enumeration,    domain),

--- a/tools/fullrecon_tool.py
+++ b/tools/fullrecon_tool.py
@@ -1,3 +1,4 @@
+from tools.headers_tool import headers_analyzer
 from tools.whois_tool import whois_lookup
 from tools.dns_tool import dns_enumeration
 from tools.portscan_tool import port_scan
@@ -54,7 +55,7 @@ def full_recon(domain: str) -> dict:
             results[name] = {"success": False, "error": str(e)}
 
     # Run all tools in parallel
-    with concurrent.futures.ThreadPoolExecutor(max_workers=6) as ex:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=7) as ex:
         futures = [
             ex.submit(run, "whois",    whois_lookup,       domain),
             ex.submit(run, "dns",      dns_enumeration,    domain),
@@ -62,7 +63,8 @@ def full_recon(domain: str) -> dict:
             ex.submit(run, "ssl",      ssl_inspect,        domain),
             ex.submit(run, "techstack",tech_stack_detect,  domain),
             ex.submit(run, "asn" , asn_lookup, domain),
-            ex.submit(run, "ct_logs", ct_summary, domain)
+            ex.submit(run, "ct_logs", ct_summary, domain),
+            ex.submit(run, "headers",  headers_analyzer,   domain),
         ]
         concurrent.futures.wait(futures)
 
@@ -73,7 +75,8 @@ def full_recon(domain: str) -> dict:
         "results": results,
         "instructions": (
             "Generate a 2-3 sentence summary for each tool's output "
-            "(whois_summary, dns_summary, ports_summary, ssl_summary, techstack_summary , asn_summary , ct_logs) "
+            "(whois_summary, dns_summary, ports_summary, ssl_summary, "
+            "techstack_summary, asn_summary, ct_logs, headers_summary) "
             "and a final overall_summary of 4-5 sentences covering the full security posture. "
         )
     }


### PR DESCRIPTION
## Summary

Closes #50

This PR completes the two missing pieces for `headers_analyzer` to be fully production ready:

1. Adds a dedicated test file: `tests/test_headers_tool.py`
2. Integrates `headers_analyzer` into `full_recon` in `tools/fullrecon_tool.py`

---

## Part 1 — Tests (`tests/test_headers_tool.py`)

Added 12 unit tests covering:

- **Domain validation**: invalid domains and IP addresses are rejected before any network call
- **Successful response structure**: verifies the `success`, `domain`, and `headers` keys are always present
- **Per-header analysis**:
  - HSTS present and valid → `severity: low`
  - HSTS missing → flagged as `severity: high`
  - HSTS with low `max-age` → flagged as `severity: medium`
  - CSP missing → flagged as `severity: high`
  - CSP with `unsafe-inline` → flagged as `severity: high`
  - `X-Frame-Options: DENY` → accepted with no issue
  - `X-Content-Type-Options: nosniff` → accepted with no issue
  - `Server` header present → flagged as technology disclosure
- **Error handling**:
  - `urllib.error.URLError` → returns `{"success": False, "error": "Connection failed: ..."}`
  - Unexpected exceptions → returns `{"success": False, "error": ...}`

All mocks target `urllib.request.OpenerDirector.open` to match the actual implementation in `headers_tool.py`.

---

## Part 2 — Integration into `full_recon` (`tools/fullrecon_tool.py`)

- Imported `headers_analyzer` from `tools.headers_tool`
- Added `ex.submit(run, "headers", headers_analyzer, domain)` to the parallel executor
- Bumped `max_workers` from `6` to `7` to account for the new tool
- Updated the `instructions` string to include `headers_summary` in the list of summaries the MCP client should generate
- Updated `tests/test_full_recon.py` to mock `headers_analyzer` in the existing tests so they continue to pass

---

## Testing

```
pytest tests/test_headers_tool.py -v
pytest tests/test_full_recon.py -v
```

All tests pass locally.