### PR TITLE
test(asn): add asn_lookup coverage, fix IP_API_KEY error message, update CI workflow

### DIFF
--- a/.github/workflows/thanks-on-close.yml
+++ b/.github/workflows/thanks-on-close.yml
@@ -15,13 +15,19 @@ jobs:
       - uses: actions/github-script@v8
         with:
           script: |
+            const username = context.payload.issue.user.login;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
               body: [
-                "✅ Thanks for your report! This issue has been closed.",
+                `🎉 This issue has been closed — nice work, @${username}!`,
                 "",
-                "Feel free to open a new one if the problem persists."
+                "Thank you so much for your contribution to AynOps!",
+                "Every contribution helps make this project better for everyone. 🙏",
+                "",
+                "If AynOps has been useful to you, consider giving it a ⭐ star —",
+                "it helps the project grow and reach more people:",
+                "https://github.com/AynOps/AynOps"
               ].join("\n")
             });

--- a/tests/test_asn_lookup.py
+++ b/tests/test_asn_lookup.py
@@ -1,15 +1,18 @@
-from unittest.mock import Mock, MagicMock, patch, call
-import unittest
-import socket
-from tools.asn_tool import asn_lookup
 import os
+import socket
+import unittest
+from unittest.mock import Mock, patch
+
+import requests
+
+from tools.asn_tool import asn_lookup
 
 
 class TestAsnLookup(unittest.TestCase):
 
     def test_missing_api_key_returns_error(self):
         with patch.dict(os.environ, {}, clear=True):
-            result = asn_lookup("example.com")
+            result = asn_lookup("8.8.8.8")
         self.assertFalse(result["success"])
         self.assertIn("IP_API_KEY", result["error"])
 
@@ -52,7 +55,6 @@ class TestAsnLookup(unittest.TestCase):
     @patch.dict(os.environ, {"IP_API_KEY": "test-key"})
     @patch("tools.asn_tool.requests.get")
     def test_api_timeout_returns_error(self, mock_get):
-        import requests
         mock_get.side_effect = requests.exceptions.Timeout()
 
         result = asn_lookup("8.8.8.8")

--- a/tests/test_asn_lookup.py
+++ b/tests/test_asn_lookup.py
@@ -1,0 +1,65 @@
+from unittest.mock import Mock, MagicMock, patch, call
+import unittest
+import socket
+from tools.asn_tool import asn_lookup
+import os
+
+
+class TestAsnLookup(unittest.TestCase):
+
+    def test_missing_api_key_returns_error(self):
+        with patch.dict(os.environ, {}, clear=True):
+            result = asn_lookup("example.com")
+        self.assertFalse(result["success"])
+        self.assertIn("IP_API_KEY", result["error"])
+
+    @patch.dict(os.environ, {"IP_API_KEY": "test-key"})
+    @patch("tools.asn_tool.requests.get")
+    def test_valid_ip_returns_asn_data(self, mock_get):
+        response = Mock()
+        response.status_code = 200
+        response.json.return_value = {
+            "ip": "8.8.8.8",
+            "country_name": "United States",
+            "region_name": "California",
+            "city": "Mountain View",
+            "connection": {
+                "asn": 15169,
+                "org": "Google LLC",
+                "isp": "Google LLC",
+            },
+        }
+        mock_get.return_value = response
+
+        result = asn_lookup("8.8.8.8")
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["asn"], "AS15169")
+        self.assertEqual(result["org"], "Google LLC")
+        self.assertEqual(result["country"], "United States")
+        mock_get.assert_called_once()
+
+    @patch.dict(os.environ, {"IP_API_KEY": "test-key"})
+    @patch("tools.asn_tool.socket.getaddrinfo")
+    def test_unresolvable_domain_returns_error(self, mock_getaddrinfo):
+        mock_getaddrinfo.side_effect = socket.gaierror("Name or service not known")
+
+        result = asn_lookup("thisdomaindoesnotexist.invalid")
+
+        self.assertFalse(result["success"])
+        self.assertIn("resolve", result["error"])
+
+    @patch.dict(os.environ, {"IP_API_KEY": "test-key"})
+    @patch("tools.asn_tool.requests.get")
+    def test_api_timeout_returns_error(self, mock_get):
+        import requests
+        mock_get.side_effect = requests.exceptions.Timeout()
+
+        result = asn_lookup("8.8.8.8")
+
+        self.assertFalse(result["success"])
+        self.assertIn("timed out", result["error"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/asn_tool.py
+++ b/tools/asn_tool.py
@@ -25,7 +25,11 @@ def asn_lookup(target: str) -> dict:
         if not api_key:
             return {
                 "success": False,
-                "error": "Environment variable 'IP_API_KEY' is missing or not set."
+                "error": (
+                    "IP_API_KEY environment variable is not set. "
+                    "Get a free key at https://ipapi.com and add it to "
+                    "your Claude Desktop config under 'IP_API_KEY'."
+                )
             }
 
         if "://" in target:


### PR DESCRIPTION
Closes #43
Closes #34
Closes #49

## What's Changed

### `tests/test_asn_lookup.py`

Adds the only missing test file in the project. Follows the same
structure and conventions as `tests/test_ip_reputation.py` as
suggested in #43.

**4 test cases:**

**1. `test_missing_api_key_returns_error`**
Patches `os.environ` with `clear=True` to fully simulate a missing
`IP_API_KEY`. Asserts `success=False` and that the error message
contains `"IP_API_KEY"` so the user knows exactly which variable
to set. Uses `"8.8.8.8"` so the function exits before touching
`socket.getaddrinfo`.

**2. `test_valid_ip_returns_asn_data`**
Mocks `requests.get` to return a realistic ipapi.com response shape.
Uses `"8.8.8.8"` directly so `socket.getaddrinfo` is bypassed — only
one thing to mock. Asserts `success=True` and that `asn`, `org`, and
`country` fields are correctly mapped. Notably verifies that raw
integer ASN `15169` from the API is correctly formatted to `"AS15169"`.

**3. `test_unresolvable_domain_returns_error`**
Patches `tools.asn_tool.socket.getaddrinfo` to raise `socket.gaierror`,
simulating a DNS failure for an invalid domain. Asserts `success=False`
and that the error message contains `"resolve"` matching the exact
return value in `asn_tool.py`.

**4. `test_api_timeout_returns_error`**
Patches `tools.asn_tool.requests.get` to raise
`requests.exceptions.Timeout`. Asserts `success=False` and that the
error message contains `"timed out"`.

---

### `tools/asn_tool.py`

Improves the `IP_API_KEY` missing error message. Previously returned
a vague `"Environment variable 'IP_API_KEY' is missing or not set."`
with no guidance. Now includes the signup URL and config location so
the user can immediately act on it.

**Before:**
`Environment variable 'IP_API_KEY' is missing or not set.`

**After:**
```
IP_API_KEY environment variable is not set. Get a free key at
https://ipapi.com/ and add it to your Claude Desktop config
under 'IP_API_KEY'.
```


---

### `.github/workflows/thanks-on-close.yml`

Replaces the generic issue-close bot message with a warmer,
contributor-friendly response. The new message mentions the reporter
by username using `context.payload.issue.user.login` (idiomatic for
`github-script`, avoids `${{ }}` expressions inside JS) and encourages
starring the repo.

**Before:**
```
✅ Thanks for your report! This issue has been closed.
Feel free to open a new one if the problem persists.
```

**After:**
```
🎉 This issue has been closed — nice work, @{username}!

Thank you so much for your contribution to AynOps!
Every contribution helps make this project better for everyone. 🙏

If AynOps has been useful to you, consider giving it a ⭐ star —
it helps the project grow and reach more people:
https://github.com/AynOps/AynOps
```

---

## Test Results
```
pytest tests/test_asn_lookup.py -v
4 passed, 1 warning in 1.52s
```

Warning is from `pytest-asyncio` (Python 3.14 deprecation),
unrelated to this change.
