### PR TITLE
fix: handle None dates in whois_lookup gracefully

### DIFF
--- a/tests/test_whois_lookup.py
+++ b/tests/test_whois_lookup.py
@@ -51,5 +51,16 @@ class TestWhoisLookup(unittest.TestCase):
         self.assertFalse(result["success"])
         self.assertIn("WHOIS server timeout", result["error"])
 
+    @patch("tools.whois_tool.whois.whois")
+    def test_whois_none_dates_return_null(self, mock_whois):
+        m = self._mock_whois_result()
+        m.expiration_date = None
+        m.creation_date = None
+        mock_whois.return_value = m
+        result = whois_lookup("example.com")
+        self.assertTrue(result["success"])
+        self.assertIsNone(result["expiration_date"])
+        self.assertIsNone(result["creation_date"])
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tools/whois_tool.py
+++ b/tools/whois_tool.py
@@ -10,6 +10,8 @@ def whois_lookup(domain: str) -> dict:
         result = whois.whois(domain)
 
         def safe_date(d):
+            if d is None:
+                return None
             return str(d[0] if isinstance(d, list) else d)
 
         return {


### PR DESCRIPTION
Closes #32

## What's Changed
`safe_date()` in `tools/whois_tool.py` did `str(d[0] if isinstance(d, list)
else d)` — when `d` is `None` (some ccTLDs don't publish expiration_date),
`str(None)` returns the string `"None"`, which Claude then surfaces to
the user as if it were a real value ("this domain expires on None").

Fixed by checking for `None` explicitly before stringifying.

## Test
Added `test_whois_none_dates_return_null`, covering creation_date and expiration_date — the fields most likely to be None on ccTLDs.

## Test Results
```
5 passed, 1 warning in 0.34s

tests/test_whois_lookup.py::TestWhoisLookup::test_whois_exception_caught PASSED
tests/test_whois_lookup.py::TestWhoisLookup::test_whois_invalid_domain PASSED
tests/test_whois_lookup.py::TestWhoisLookup::test_whois_list_dates_normalized PASSED
tests/test_whois_lookup.py::TestWhoisLookup::test_whois_none_dates_return_null PASSED
tests/test_whois_lookup.py::TestWhoisLookup::test_whois_success PASSED
```
Note: 1 warning from pytest-asyncio (unrelated to this change),
asyncio.get_event_loop_policy deprecation in Python 3.16.