### PR TITLE
fix: cert_transparency silently drops root-domain wildcards

### DIFF
--- a/tests/test_crtsh_tool.py
+++ b/tests/test_crtsh_tool.py
@@ -161,5 +161,24 @@ def test_unrelated_wildcard_is_filtered_out(mock_get):
     assert result["wildcards_found"] == []
     assert result["unique_subdomains"] == []
 
+@patch("tools.crt_sh_tool.requests.get")
+def test_wildcard_suffix_collision_is_filtered_out(mock_get):
+    """*.example.com should NOT appear when querying ample.com"""
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = [
+        {
+            "name_value": "*.example.com",
+            "issuer_name": "Let's Encrypt",
+            "not_before": "2026-01-01T00:00:00",
+            "not_after": "2026-04-01T00:00:00",
+        }
+    ]
+    mock_get.return_value = mock_response
+
+    result = cert_transparency("ample.com")
+
+    assert result["wildcards_found"] == []
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_crtsh_tool.py
+++ b/tests/test_crtsh_tool.py
@@ -99,8 +99,67 @@ def test_wildcard_subdomain(mock_get):
 
     result = cert_transparency("example.com")
 
+    assert ".api.example.com" in result["wildcards_found"]
+    assert result["unique_subdomains"] == []
+
+
+@patch("tools.crt_sh_tool.requests.get")
+def test_wildcard_on_root_domain_is_captured(mock_get):
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = [
+        {
+            "name_value": "*.example.com",
+            "issuer_name": "Let's Encrypt",
+            "not_before": "2026-01-01T00:00:00",
+            "not_after": "2026-04-01T00:00:00",
+        }
+    ]
+    mock_get.return_value = mock_response
+
+    result = cert_transparency("example.com")
+
+    assert ".example.com" in result["wildcards_found"]
+    assert result["unique_subdomains"] == []
+    assert result["total_unique_subdomains"] == 0
+
+@patch("tools.crt_sh_tool.requests.get")
+def test_mixed_wildcard_and_concrete_subdomain(mock_get):
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = [
+        {
+            "name_value": "*.example.com\napi.example.com",
+            "issuer_name": "Let's Encrypt",
+            "not_before": "2026-01-01T00:00:00",
+            "not_after": "2026-04-01T00:00:00",
+        }
+    ]
+    mock_get.return_value = mock_response
+
+    result = cert_transparency("example.com")
+
+    assert ".example.com" in result["wildcards_found"]
     assert "api.example.com" in result["unique_subdomains"]
 
+@patch("tools.crt_sh_tool.requests.get")
+def test_unrelated_wildcard_is_filtered_out(mock_get):
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = [
+        {
+            "name_value": "*.unrelated-domain.net",
+            "issuer_name": "Let's Encrypt",
+            "not_before": "2026-01-01T00:00:00",
+            "not_after": "2026-04-01T00:00:00",
+        }
+    ]
+    mock_get.return_value = mock_response
+
+    result = cert_transparency("example.com")
+    
+    assert result["wildcards_found"] == []
+    assert result["unique_subdomains"] == []
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tools/crt_sh_tool.py
+++ b/tools/crt_sh_tool.py
@@ -52,6 +52,7 @@ def cert_transparency(domain: str) -> Dict[str, Any]:
         data = response.json()
 
         unique_subdomains = set()
+        wildcards = set()
         certificates = []
         seen = set()
 
@@ -63,9 +64,16 @@ def cert_transparency(domain: str) -> Dict[str, Any]:
 
             for name in names:
                 name = name.strip().lower()
-                if not name or name.startswith("*."):
-                    name = name[2:] if name.startswith("*.") else name
-                    
+
+                if not name:
+                    continue
+
+                if name.startswith("*."):
+                    wildcard_pattern = name[1:]  # "*.example.com" -> ".example.com"
+                    if wildcard_pattern.endswith(domain):
+                        wildcards.add(wildcard_pattern)
+                    continue
+
                 if not name.endswith(domain) or name == domain:
                     continue
 
@@ -90,6 +98,7 @@ def cert_transparency(domain: str) -> Dict[str, Any]:
             "total_certificates": len(certificates),
             "total_unique_subdomains": len(unique_subdomains),
             "unique_subdomains": sorted(unique_subdomains),
+            "wildcards_found": sorted(wildcards),
             "returned_certificates": min(50, len(certificates)),
             "truncated": len(certificates) > 50,
             "certificates": certificates[:50]
@@ -107,6 +116,7 @@ def cert_transparency(domain: str) -> Dict[str, Any]:
                 "total_certificates": 0,
                 "total_unique_subdomains": len(fallback_subdomains),
                 "unique_subdomains": sorted(list(fallback_subdomains)),
+                "wildcards_found": [],
                 "returned_certificates": 0,
                 "truncated": False,
                 "certificates": [],

--- a/tools/crt_sh_tool.py
+++ b/tools/crt_sh_tool.py
@@ -70,7 +70,7 @@ def cert_transparency(domain: str) -> Dict[str, Any]:
 
                 if name.startswith("*."):
                     wildcard_pattern = name[1:]  # "*.example.com" -> ".example.com"
-                    if wildcard_pattern.endswith(domain):
+                    if wildcard_pattern.endswith("." + domain) or wildcard_pattern == "." + domain:
                         wildcards.add(wildcard_pattern)
                     continue
 


### PR DESCRIPTION
Closes #29

## What's Changed

### tools/crt_sh_tool.py
Wildcard detection moved into the existing per-`name` loop instead of
checking `entry.get("name_value", "").startswith("*.")` at the entry
level. A single CT log entry can list multiple SANs separated by `\n`
in any order. Checking only the first character of the raw string
misses wildcards that aren't listed first, or incorrectly swallows a
concrete subdomain into the wildcard string when it is.

Each name is now classified individually:
- empty → skipped
- starts with `*.` → recorded in the new `wildcards_found` field
  (stripped to `.example.com` form), filtered to patterns that
  actually belong to the queried domain
- otherwise → existing concrete-subdomain logic, unchanged

This fixes the root cause from #29: `*.example.com` no longer gets
stripped down to `example.com`, compared against the root domain,
and silently dropped.

### tests/test_crtsh_tool.py
- Updated `test_wildcard_subdomain` per the issue — now asserts the
  wildcard lands in `wildcards_found`, not `unique_subdomains`
- Added `test_wildcard_on_root_domain_is_captured` — direct regression
  test for the bug in the issue title
- Added `test_mixed_wildcard_and_concrete_subdomain` — verifies
  per-name detection handles SANs regardless of order
- Added `test_unrelated_wildcard_is_filtered_out` — verifies wildcards
  not belonging to the queried domain don't pollute the field

## Test Results
```
pytest tests/test_crtsh_tool.py -v

9 passed, 316 warnings in 1.21s
```
Warnings are from pytest-asyncio (Python 3.14 deprecation), unrelated to this change.