### PR TITLE
fix: sanitize dns records and use tcp resolver

### DIFF
--- a/tests/test_dns_enumeration.py
+++ b/tests/test_dns_enumeration.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, MagicMock, patch, call
+from unittest.mock import MagicMock, Mock, patch
 import unittest
 from tools.dns_tool import dns_enumeration
 
@@ -13,37 +13,87 @@ class TestDnsEnumeration(unittest.TestCase):
             records.append(r)
         return records
 
+    def _make_txt_answer(self, chunks):
+        record = Mock()
+        record.strings = chunks
+        return [record]
+
+    def _make_soa_answer(self):
+        record = Mock()
+        record.mname = "ns1.example.com."
+        record.rname = "hostmaster.example.com."
+        record.serial = 1
+        record.refresh = 2
+        record.retry = 3
+        record.expire = 4
+        record.minimum = 5
+        return [record]
+
     def test_invalid_domain(self):
         result = dns_enumeration("bad_domain")
         self.assertFalse(result["success"])
 
-    @patch("tools.dns_tool.dns.resolver.resolve")
-    def test_dns_success_returns_records(self, mock_resolve):
-        def side_effect(domain, rtype, lifetime=5):
+    @patch("tools.dns_tool.dns.resolver.Resolver")
+    def test_dns_success_returns_records(self, mock_resolver_class):
+        resolver = Mock()
+        mock_resolver_class.return_value = resolver
+
+        def side_effect(domain, rtype, lifetime=5, tcp=False):
+            import dns.resolver as real_dns
+
+            if domain != "example.com":
+                raise real_dns.NoAnswer
             if rtype == "A":
                 return self._make_resolver_answer(["93.184.216.34"])
+            if rtype == "MX":
+                record = Mock()
+                record.preference = 10
+                record.exchange = "mail.example.com."
+                return [record]
+            if rtype == "NS":
+                return self._make_resolver_answer(["ns1.example.com."])
+            if rtype == "TXT":
+                return self._make_txt_answer((b"v=spf1 ", b"include:example.com"))
+            if rtype == "CNAME":
+                return self._make_resolver_answer(["alias.example.com."])
+            if rtype == "SOA":
+                return self._make_soa_answer()
             raise Exception("no record")
 
-        mock_resolve.side_effect = side_effect
+        resolver.resolve.side_effect = side_effect
         result = dns_enumeration("example.com")
 
         self.assertTrue(result["success"])
         self.assertEqual(result["domain"], "example.com")
-        self.assertIn("records", result)
+        self.assertEqual(result["records"]["MX"][0]["exchange"], "mail.example.com")
+        self.assertEqual(result["records"]["NS"], ["ns1.example.com"])
+        self.assertEqual(result["records"]["TXT"], ["v=spf1 include:example.com"])
+        self.assertEqual(result["records"]["CNAME"], ["alias.example.com"])
+        self.assertEqual(result["records"]["SOA"]["mname"], "ns1.example.com")
+        self.assertEqual(result["records"]["SOA"]["rname"], "hostmaster.example.com")
         self.assertIn("subdomains_found", result)
+        self.assertEqual(resolver.nameservers, ["1.1.1.1", "8.8.8.8"])
+        resolver.resolve.assert_any_call("example.com", "TXT", lifetime=5, tcp=True)
+        resolver.resolve.assert_any_call("www.example.com", "A", lifetime=3, tcp=True)
 
-    @patch("tools.dns_tool.dns.resolver.resolve")
-    def test_dns_nxdomain_returns_failure(self, mock_resolve):
+    @patch("tools.dns_tool.dns.resolver.Resolver")
+    def test_dns_nxdomain_returns_failure(self, mock_resolver_class):
         import dns.resolver as real_dns
-        mock_resolve.side_effect = real_dns.NXDOMAIN
+
+        resolver = Mock()
+        resolver.resolve.side_effect = real_dns.NXDOMAIN
+        mock_resolver_class.return_value = resolver
         result = dns_enumeration("thisdoesnotexistatall12345.com")
         self.assertFalse(result["success"])
         self.assertIn("does not exist", result["error"])
 
-    @patch("tools.dns_tool.dns.resolver.resolve")
-    def test_dns_no_answer_returns_empty_list(self, mock_resolve):
+    @patch("tools.dns_tool.dns.resolver.Resolver")
+    def test_dns_no_answer_returns_empty_list(self, mock_resolver_class):
         import dns.resolver as real_dns
-        mock_resolve.side_effect = real_dns.NoAnswer
+
+        resolver = Mock()
+        resolver.resolve.side_effect = real_dns.NoAnswer
+        mock_resolver_class.return_value = resolver
         result = dns_enumeration("example.com")
         # NoAnswer means success but empty records
         self.assertTrue(result["success"])

--- a/tools/dns_tool.py
+++ b/tools/dns_tool.py
@@ -1,6 +1,29 @@
 import dns.resolver
 from utils.helpers import is_valid_domain
 
+PUBLIC_RESOLVERS = ["1.1.1.1", "8.8.8.8"]
+
+
+def _clean_name(value) -> str:
+    return str(value).rstrip(".")
+
+
+def _format_txt_record(record) -> str:
+    chunks = getattr(record, "strings", None)
+    if chunks:
+        return "".join(
+            chunk.decode("utf-8") if isinstance(chunk, bytes) else str(chunk)
+            for chunk in chunks
+        )
+    return str(record)
+
+
+def _make_resolver() -> dns.resolver.Resolver:
+    resolver = dns.resolver.Resolver(configure=False)
+    resolver.nameservers = PUBLIC_RESOLVERS
+    return resolver
+
+
 def dns_enumeration(domain: str) -> dict:
     """
     Enumerate DNS records for a domain.
@@ -11,26 +34,31 @@ def dns_enumeration(domain: str) -> dict:
 
     record_types = ["A", "AAAA", "MX", "NS", "TXT", "CNAME", "SOA"]
     records = {}
+    resolver = _make_resolver()
 
     for rtype in record_types:
         try:
-            answers = dns.resolver.resolve(domain, rtype, lifetime=5)
+            answers = resolver.resolve(domain, rtype, lifetime=5, tcp=True)
             if rtype == "MX":
                 records[rtype] = [
-                    {"preference": r.preference, "exchange": str(r.exchange)}
+                    {"preference": r.preference, "exchange": _clean_name(r.exchange)}
                     for r in answers
                 ]
             elif rtype == "SOA":
                 r = answers[0]
                 records[rtype] = {
-                    "mname": str(r.mname),
-                    "rname": str(r.rname),
+                    "mname": _clean_name(r.mname),
+                    "rname": _clean_name(r.rname),
                     "serial": r.serial,
                     "refresh": r.refresh,
                     "retry": r.retry,
                     "expire": r.expire,
                     "minimum": r.minimum
                 }
+            elif rtype == "TXT":
+                records[rtype] = [_format_txt_record(r) for r in answers]
+            elif rtype in {"NS", "CNAME"}:
+                records[rtype] = [_clean_name(r) for r in answers]
             else:
                 records[rtype] = [str(r) for r in answers]
         except dns.resolver.NoAnswer:
@@ -47,7 +75,7 @@ def dns_enumeration(domain: str) -> dict:
     for sub in common_subdomains:
         try:
             full = f"{sub}.{domain}"
-            dns.resolver.resolve(full, "A", lifetime=3)
+            resolver.resolve(full, "A", lifetime=3, tcp=True)
             found_subdomains.append(full)
         except Exception:
             pass


### PR DESCRIPTION
## Summary
- use a dedicated DNS resolver configured with public resolvers for DNS enumeration
- query DNS records over TCP to avoid truncating large TXT responses
- sanitize trailing root dots from MX, NS, CNAME, and SOA names and merge chunked TXT payloads
- update DNS tests with mocked resolver coverage for TCP queries and formatted records

Fixes #59

## Tests
- uv run pytest tests/test_dns_enumeration.py -q
- uv run pytest -q
- python -m compileall tools/dns_tool.py tests/test_dns_enumeration.py