### PR TITLE
Fixed the bug #64

### DIFF
--- a/tools/email_security_tool.py
+++ b/tools/email_security_tool.py
@@ -119,6 +119,7 @@ def _check_dmarc(domain: str, recommendations: List[str]) -> Dict[str, Any]:
     txt_records, failed = _query_txt(f"_dmarc.{domain}")
 
     if failed:
+        recommendations.append("Could not verify DMARC — DNS lookup timed out.")
         return {"found": False, "record": None, "policy": None, "score": 0}
 
     dmarc_records = [r for r in txt_records if r.lower().startswith("v=dmarc1")]
@@ -203,9 +204,6 @@ def email_security_check(domain: str) -> dict:
         dkim = _check_dkim(domain, recommendations)
 
         raw_score = spf.pop("score") + dmarc.pop("score") + dkim.pop("score")
-        
-        if recommendations and raw_score == 100:
-            raw_score = 90
 
         if raw_score >= 90:
             rating = "Excellent"


### PR DESCRIPTION
Fixes: #64 

Changes:
1. DMARC timeout now surfaces in recommendations

_check_dmarc was silently returning found: false on DNS timeout with no message, unlike _check_spf which correctly warns the user. Added the missing recommendations.append() on the failed branch.

2. Removed dead anti-100% normalization guard

The condition if recommendations and raw_score == 100 could never trigger — hitting 100 requires perfect scores on all three checks (SPF=30 + DMARC=35 + DKIM=35), which means recommendations is always empty at that point. Removed the dead code entirely.
Testing:

Verified against google.com, github.com, and openai.com. openai.com now correctly returns 100% with empty recommendations.