### PR TITLE
Enhanced the full recon tool to get better analysis with claude

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ It is also listed on glama mcp registry.
 | `tech_stack_detect` | Web server, CMS, JS frameworks, CDN, analytics, and security header scoring |
 | `cert_transparency` | Subdomain discovery via crt.sh Certificate Transparency logs with an automatic fallback to HackerTarget passive DNS on timeouts |
 | `asn_lookup` | Autonomous System Number (ASN) and network ownership lookup — identifies hosting provider, ISP, organization, geolocation, and infrastructure ownership for domains or IP addresses |
-| `full_recon` | Runs all core tools in parallel and returns combined results for Claude to analyze |
 | `cve_lookup` | Search NVD for known CVEs by software name and version (no API key required) |
 | `ip_reputation` | Check if an IP is flagged as malicious via AbuseIPDB (api key requied) |
+| `full_recon` | Runs all core tools in parallel and returns combined results with claude analysis |
+
 ---
 
 ## 📸 Demo
@@ -74,7 +75,7 @@ Claude: Found 2 critical CVEs for Apache 2.4.49:
 ```
 You: Do a complete security recon on reddit.com
 
-Claude: [calls full_recon → runs 6 tools in parallel → delivers full analysis]
+Claude: [calls full_recon → runs all core tools in parallel → delivers full analysis]
 ```
 
 <div align="center">
@@ -284,6 +285,7 @@ Intended for:
 ├── requirements.txt      # Python dependencies
 ├── mcp.json              # MCP server metadata
 ├── glama.json            # Glama MCP metadata
+├── server.json           # MCP all tools metadata
 ├── Dockerfile            # Docker image definition
 ├── SECURITY.md           # Security policy
 ├── CONTRIBUTING.md       # Contribution guidelines

--- a/mcp.json
+++ b/mcp.json
@@ -71,12 +71,6 @@
       "api_key_url": "https://ipapi.com/"
     },
     {
-      "name": "full_recon",
-      "description": "Runs core tools in parallel against a domain and returns combined results",
-      "input": {"domain": "string"},
-      "requires_api_key": false
-    },
-    {
       "name": "cve_lookup",
       "description": "Search NVD database for known CVEs by software name and version",
       "input": {"software": "string", "version": "string"},
@@ -89,6 +83,12 @@
       "requires_api_key": true,
       "api_key_env": "ABUSEIPDB_API_KEY",
       "api_key_url": "https://www.abuseipdb.com"
+    },
+    {
+      "name": "full_recon",
+      "description": "Runs all core tools in parallel against a domain and returns combined results with claude anlaysis",
+      "input": {"domain": "string"},
+      "requires_api_key": false
     }
   ],
   "environment_variables": [

--- a/tests/test_full_recon.py
+++ b/tests/test_full_recon.py
@@ -1,83 +1,1062 @@
-from unittest.mock import patch
-import unittest
-from tools.fullrecon_tool import full_recon
+import pytest
+from datetime import datetime, timezone, timedelta
+from unittest.mock import patch, MagicMock
 
-class TestFullRecon(unittest.TestCase):
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-    def test_invalid_domain_rejected(self):
-        result = full_recon("not-a-domain")
-        self.assertFalse(result["success"])
-        self.assertIn("error", result)
+from tools.fullrecon_tool import (
+    safe_parse_datetime,
+    _format_signals_block,
+    extract_signals,
+    ct_summary,
+    _extract_ip,
+    _extract_software,
+    full_recon,
+    THREAT_ANALYSIS_PROMPT,
+)
 
-    @patch("tools.fullrecon_tool.headers_analyzer", return_value={"success": True, "domain": "example.com", "headers": {}})
-    @patch("tools.fullrecon_tool.whois_lookup", return_value={"success": True, "domain": "example.com"})
-    @patch("tools.fullrecon_tool.dns_enumeration", return_value={"success": True, "records": {}})
-    @patch("tools.fullrecon_tool.port_scan", return_value={"success": True, "results": []})
-    @patch("tools.fullrecon_tool.ssl_inspect", return_value={"success": True, "certificate": {}})
-    @patch("tools.fullrecon_tool.tech_stack_detect", return_value={"success": True, "technologies": {}})
-    @patch("tools.fullrecon_tool.asn_lookup", return_value={"success": True, "asn": "AS12345"})
-    @patch("tools.fullrecon_tool.ct_summary", return_value={"success": True, "total_unique_subdomains": 10, "sample_subdomains": ["api.example.com"]})
-    def test_full_recon_calls_all_tools(self, mock_ct, mock_asn, mock_tech, mock_ssl, mock_ports, mock_dns, mock_whois, mock_headers):
-        result = full_recon("example.com")
+# ===========================================================================
+# Fixtures & helpers
+# ===========================================================================
 
-        self.assertTrue(result["success"])
-        self.assertEqual(result["domain"], "example.com")
-        self.assertIn("scanned_at", result)
-        self.assertIn("results", result)
-
-        # All 5 subtool results present
-        self.assertIn("whois", result["results"])
-        self.assertIn("dns", result["results"])
-        self.assertIn("ports", result["results"])
-        self.assertIn("ssl", result["results"])
-        self.assertIn("techstack", result["results"])
-        self.assertIn("asn", result["results"])
-        self.assertIn("ct_logs", result["results"])
-        self.assertIn("headers", result["results"])
-        mock_whois.assert_called_once_with("example.com")
-        mock_dns.assert_called_once_with("example.com")
-        mock_ssl.assert_called_once_with("example.com")
-        mock_tech.assert_called_once_with("example.com")
-        mock_ports.assert_called_once_with("example.com", "service")
-        mock_asn.assert_called_once_with("example.com")
-        mock_ct.assert_called_once_with("example.com")
-        mock_headers.assert_called_once_with("example.com")
-
-    @patch("tools.fullrecon_tool.whois_lookup", side_effect=Exception("WHOIS exploded"))
-    @patch("tools.fullrecon_tool.dns_enumeration", return_value={"success": True})
-    @patch("tools.fullrecon_tool.port_scan", return_value={"success": True})
-    @patch("tools.fullrecon_tool.ssl_inspect", return_value={"success": True})
-    @patch("tools.fullrecon_tool.tech_stack_detect", return_value={"success": True})
-    @patch("tools.fullrecon_tool.asn_lookup", return_value={"success": True})
-    @patch("tools.fullrecon_tool.ct_summary", return_value={"success": True})
-    @patch("tools.fullrecon_tool.headers_analyzer", return_value={"success": True})
-    def test_full_recon_tool_failure_isolated(self, mock_headers, mock_ct, mock_asn, mock_tech, mock_ssl, mock_ports, mock_dns, mock_whois):
-        """One tool crashing must not crash the whole recon."""
-        result = full_recon("example.com")
-
-        self.assertTrue(result["success"])
-        # The failing tool should have an error, others should be fine
-        self.assertFalse(result["results"]["whois"]["success"])
-        self.assertTrue(result["results"]["dns"]["success"])
-        self.assertTrue(result["results"]["asn"]["success"])
-        self.assertTrue(result["results"]["ct_logs"]["success"])
-
-    @patch("tools.fullrecon_tool.whois_lookup", return_value={"success": True})
-    @patch("tools.fullrecon_tool.dns_enumeration", return_value={"success": True})
-    @patch("tools.fullrecon_tool.port_scan", return_value={"success": True})
-    @patch("tools.fullrecon_tool.ssl_inspect", return_value={"success": True})
-    @patch("tools.fullrecon_tool.tech_stack_detect", return_value={"success": True})
-    @patch("tools.fullrecon_tool.asn_lookup", return_value={"success": True})
-    @patch("tools.fullrecon_tool.ct_summary", return_value={"success": True})
-    @patch("tools.fullrecon_tool.headers_analyzer", return_value={"success": True})
-    def test_full_recon_scanned_at_is_iso_format(self, mock_headers, mock_ct, mock_asn, mock_tech, mock_ssl, mock_ports, mock_dns, mock_whois):
-        from datetime import datetime
-        result = full_recon("example.com")
-        # Should be parseable ISO timestamp ending in Z
-        ts = result["scanned_at"]
-        self.assertTrue(ts.endswith("Z"))
-        datetime.fromisoformat(ts.rstrip("Z"))  # raises if invalid
+def _future_iso(days: int) -> str:
+    """Return an ISO-8601 UTC string <days> from now."""
+    dt = datetime.now(timezone.utc) + timedelta(days=days)
+    return dt.isoformat()
 
 
-if __name__ == "__main__":
-    unittest.main(verbosity=2)
+def _past_iso(days: int) -> str:
+    """Return an ISO-8601 UTC string <days> ago."""
+    dt = datetime.now(timezone.utc) - timedelta(days=days)
+    return dt.isoformat()
+
+
+def _minimal_signals() -> dict:
+    """Return the baseline signals structure with all safe defaults."""
+    return {
+        "domain_expiry_days":       None,
+        "dns_missing_records":      [],
+        "open_ports":               [],
+        "ssl_days_remaining":       None,
+        "software_detected":        [],
+        "ip_abuse_score":           0,
+        "subdomain_count":          0,
+        "missing_security_headers": [],
+        "headers_tool_state":       "success",
+        "email_security":           {},
+        "cves_found":               [],
+        "ip_reputation_flagged":    False,
+        "auto_warnings":            [],
+    }
+
+
+# ===========================================================================
+# 1.  safe_parse_datetime
+# ===========================================================================
+
+class TestSafeParseDatetime:
+
+    def test_none_input_returns_none(self):
+        assert safe_parse_datetime(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert safe_parse_datetime("") is None
+
+    def test_datetime_object_passthrough(self):
+        dt = datetime(2030, 1, 1, tzinfo=timezone.utc)
+        assert safe_parse_datetime(dt) is dt
+
+    def test_iso_with_z_suffix(self):
+        result = safe_parse_datetime("2030-06-15T12:00:00Z")
+        assert result is not None
+        assert result.year == 2030
+        assert result.month == 6
+
+    def test_iso_with_plus_offset(self):
+        result = safe_parse_datetime("2030-06-15T12:00:00+05:30")
+        assert result is not None
+        assert result.year == 2030
+
+    def test_date_only_string(self):
+        result = safe_parse_datetime("2030-12-31")
+        assert result is not None
+        assert result.year == 2030
+        assert result.day == 31
+
+    def test_space_separated_with_offset(self):
+        result = safe_parse_datetime("2030-06-15 12:00:00+00:00")
+        assert result is not None
+
+    def test_space_separated_no_timezone(self):
+        result = safe_parse_datetime("2030-06-15 12:00:00")
+        assert result is not None
+
+    def test_completely_garbage_string_returns_none(self):
+        assert safe_parse_datetime("not-a-date-at-all!!") is None
+
+    def test_numeric_input_converted_to_string(self):
+        # Should not crash; may return None
+        result = safe_parse_datetime(20301231)
+        # Just ensure no exception
+        assert result is None or isinstance(result, datetime)
+
+    def test_naive_datetime_object_passthrough(self):
+        dt = datetime(2030, 1, 1)  # no tzinfo
+        assert safe_parse_datetime(dt) is dt
+
+
+# ===========================================================================
+# 2.  _format_signals_block
+# ===========================================================================
+
+class TestFormatSignalsBlock:
+
+    def test_no_warnings_no_email_no_cves(self):
+        signals = _minimal_signals()
+        signals["open_ports"] = ["80/tcp (http)"]
+        signals["software_detected"] = ["nginx"]
+        signals["subdomain_count"] = 5
+        text = _format_signals_block(signals)
+        assert "Open ports" in text
+        assert "80/tcp (http)" in text
+        assert "nginx" in text
+        assert "CVEs found" in text
+        assert "none" in text.lower()
+
+    def test_auto_warnings_appear_at_top(self):
+        signals = _minimal_signals()
+        signals["auto_warnings"] = ["Domain EXPIRED 3 days ago", "SSL cert EXPIRED 1 days ago"]
+        text = _format_signals_block(signals)
+        lines = text.splitlines()
+        # warnings block must appear before domain expiry line
+        warn_idx  = next(i for i, l in enumerate(lines) if "AUTO-WARNINGS" in l)
+        expiry_idx = next(i for i, l in enumerate(lines) if "Domain expiry" in l)
+        assert warn_idx < expiry_idx
+
+    def test_cves_capped_at_five_with_overflow_message(self):
+        signals = _minimal_signals()
+        signals["cves_found"] = [
+            {"id": f"CVE-2024-{n:04d}", "cvss": 9.0, "summary": "desc"} for n in range(8)
+        ]
+        text = _format_signals_block(signals)
+        assert "… and 3 more" in text
+
+    def test_exactly_five_cves_no_overflow(self):
+        signals = _minimal_signals()
+        signals["cves_found"] = [
+            {"id": f"CVE-2024-{n:04d}", "cvss": 7.5, "summary": "desc"} for n in range(5)
+        ]
+        text = _format_signals_block(signals)
+        assert "more" not in text
+
+    def test_email_security_block_rendered(self):
+        signals = _minimal_signals()
+        signals["email_security"] = {
+            "security_score": "80%",
+            "rating":         "Good",
+            "spf_found":      True,
+            "spf_policy":     "-all",
+            "dkim_found":     False,
+            "dmarc_found":    True,
+            "dmarc_policy":   "reject",
+        }
+        text = _format_signals_block(signals)
+        assert "SPF" in text
+        assert "DKIM" in text
+        assert "DMARC" in text
+        assert "✓ found" in text
+        assert "✗ missing" in text
+
+    def test_missing_headers_count_displayed(self):
+        signals = _minimal_signals()
+        signals["missing_security_headers"] = ["CSP", "X-FRAME-OPTIONS", "HSTS"]
+        text = _format_signals_block(signals)
+        assert "3" in text
+        assert "CSP" in text
+
+
+# ===========================================================================
+# 3.  extract_signals
+# ===========================================================================
+
+class TestExtractSignals:
+
+    # ── 3.1 WHOIS ──────────────────────────────────────────────────────────
+
+    def test_whois_domain_expiry_future(self):
+        results = {"whois": {"success": True, "expiration_date": _future_iso(60)}}
+        sig = extract_signals(results)
+        assert sig["domain_expiry_days"] is not None
+        assert sig["domain_expiry_days"] > 0
+
+    def test_whois_critical_warning_under_14_days(self):
+        results = {"whois": {"success": True, "expiration_date": _future_iso(7)}}
+        sig = extract_signals(results)
+        warnings = " ".join(sig["auto_warnings"])
+        assert "CRITICAL" in warnings or "expires in" in warnings
+
+    def test_whois_high_warning_under_30_days(self):
+        results = {"whois": {"success": True, "expiration_date": _future_iso(20)}}
+        sig = extract_signals(results)
+        warnings = " ".join(sig["auto_warnings"])
+        assert "expires in" in warnings
+
+    def test_whois_expired_domain_warning(self):
+        results = {"whois": {"success": True, "expiration_date": _past_iso(3)}}
+        sig = extract_signals(results)
+        warnings = " ".join(sig["auto_warnings"])
+        assert "EXPIRED" in warnings
+
+    def test_whois_failure_no_crash(self):
+        sig = extract_signals({"whois": {"success": False}})
+        assert sig["domain_expiry_days"] is None
+
+    def test_whois_nested_data_key(self):
+        results = {"whois": {"success": True, "data": {"expiration_date": _future_iso(100)}}}
+        sig = extract_signals(results)
+        assert sig["domain_expiry_days"] is not None
+
+    # ── 3.2 DNS ────────────────────────────────────────────────────────────
+
+    def test_dns_missing_a_aaaa_adds_warning(self):
+        results = {"dns": {"success": True, "records": {}}}
+        sig = extract_signals(results)
+        assert "A/AAAA" in sig["dns_missing_records"]
+        assert any("A or AAAA" in w for w in sig["auto_warnings"])
+
+    def test_dns_missing_mx_adds_warning(self):
+        results = {"dns": {"success": True, "records": {"A": ["1.2.3.4"]}}}
+        sig = extract_signals(results)
+        assert "MX" in sig["dns_missing_records"]
+
+    def test_dns_all_records_present_no_warnings(self):
+        results = {
+            "dns": {
+                "success": True,
+                "records": {"A": ["1.2.3.4"], "MX": ["mail.example.com"]},
+            }
+        }
+        sig = extract_signals(results)
+        assert sig["dns_missing_records"] == []
+        assert not any("A or AAAA" in w or "MX" in w for w in sig["auto_warnings"])
+
+    def test_dns_failure_no_crash(self):
+        sig = extract_signals({"dns": {"success": False}})
+        assert sig["dns_missing_records"] == []
+
+    # ── 3.3 PORTS ──────────────────────────────────────────────────────────
+
+    def _ports_result(self, port_num: int, service: str) -> dict:
+        return {
+            "success": True,
+            "results": [
+                {
+                    "protocols": {
+                        "tcp": [
+                            {"port": port_num, "state": "open", "service": service}
+                        ]
+                    }
+                }
+            ],
+        }
+
+    def test_open_port_added_to_signals(self):
+        results = {"ports": self._ports_result(80, "http")}
+        sig = extract_signals(results)
+        assert any("80" in p for p in sig["open_ports"])
+
+    def test_dangerous_port_ftp_triggers_warning(self):
+        results = {"ports": self._ports_result(21, "ftp")}
+        sig = extract_signals(results)
+        assert any("21" in w and "FTP" in w for w in sig["auto_warnings"])
+
+    def test_dangerous_port_rdp_triggers_warning(self):
+        results = {"ports": self._ports_result(3389, "rdp")}
+        sig = extract_signals(results)
+        assert any("3389" in w and "RDP" in w for w in sig["auto_warnings"])
+
+    def test_safe_port_no_warning(self):
+        results = {"ports": self._ports_result(443, "https")}
+        sig = extract_signals(results)
+        # 443 is not in the dangerous set
+        dangerous_warnings = [w for w in sig["auto_warnings"] if "443" in w]
+        assert not dangerous_warnings
+
+    def test_closed_port_ignored(self):
+        results = {
+            "ports": {
+                "success": True,
+                "results": [
+                    {"protocols": {"tcp": [{"port": 21, "state": "closed", "service": "ftp"}]}}
+                ],
+            }
+        }
+        sig = extract_signals(results)
+        assert sig["open_ports"] == []
+
+    def test_ports_failure_no_crash(self):
+        sig = extract_signals({"ports": {"success": False}})
+        assert sig["open_ports"] == []
+
+    # ── 3.4 SSL ────────────────────────────────────────────────────────────
+
+    def test_ssl_days_remaining_calculated(self):
+        results = {"ssl": {"success": True, "expires": _future_iso(45)}}
+        sig = extract_signals(results)
+        assert sig["ssl_days_remaining"] is not None
+        assert sig["ssl_days_remaining"] > 0
+
+    def test_ssl_expired_warning(self):
+        results = {"ssl": {"success": True, "expires": _past_iso(5)}}
+        sig = extract_signals(results)
+        assert any("SSL cert EXPIRED" in w for w in sig["auto_warnings"])
+
+    def test_ssl_critical_under_14_days(self):
+        results = {"ssl": {"success": True, "expires": _future_iso(10)}}
+        sig = extract_signals(results)
+        assert any("CRITICAL" in w for w in sig["auto_warnings"])
+
+    def test_ssl_high_under_30_days(self):
+        results = {"ssl": {"success": True, "expires": _future_iso(25)}}
+        sig = extract_signals(results)
+        assert any("HIGH" in w for w in sig["auto_warnings"])
+
+    def test_ssl_failure_no_crash(self):
+        sig = extract_signals({"ssl": {"success": False}})
+        assert sig["ssl_days_remaining"] is None
+
+    # ── 3.5 TECHSTACK ──────────────────────────────────────────────────────
+
+    def test_techstack_server_detected(self):
+        results = {"techstack": {"success": True, "server": "nginx", "cms": "WordPress"}}
+        sig = extract_signals(results)
+        assert "nginx" in sig["software_detected"]
+        assert "WordPress" in sig["software_detected"]
+
+    def test_techstack_unknown_values_excluded(self):
+        results = {
+            "techstack": {
+                "success": True,
+                "server":    "Unknown",
+                "cms":       "None",
+                "framework": "",
+            }
+        }
+        sig = extract_signals(results)
+        assert sig["software_detected"] == []
+
+    def test_techstack_failure_no_crash(self):
+        sig = extract_signals({"techstack": {"success": False}})
+        assert sig["software_detected"] == []
+
+    # ── 3.6 ASN ────────────────────────────────────────────────────────────
+
+    def test_asn_abuse_score_stored(self):
+        results = {"asn": {"success": True, "abuse_score": 35}}
+        sig = extract_signals(results)
+        assert sig["ip_abuse_score"] == 35
+
+    def test_asn_score_over_50_critical_warning(self):
+        results = {"asn": {"success": True, "abuse_score": 75}}
+        sig = extract_signals(results)
+        assert any("HIGH malicious" in w for w in sig["auto_warnings"])
+
+    def test_asn_score_over_20_elevated_warning(self):
+        results = {"asn": {"success": True, "abuse_score": 30}}
+        sig = extract_signals(results)
+        assert any("elevated" in w for w in sig["auto_warnings"])
+
+    def test_asn_score_zero_no_warning(self):
+        results = {"asn": {"success": True, "abuse_score": 0}}
+        sig = extract_signals(results)
+        asn_warnings = [w for w in sig["auto_warnings"] if "ASN" in w]
+        assert not asn_warnings
+
+    def test_asn_non_numeric_score_defaults_to_zero(self):
+        results = {"asn": {"success": True, "abuse_score": "N/A"}}
+        sig = extract_signals(results)
+        assert sig["ip_abuse_score"] == 0
+
+    # ── 3.7 CT LOGS ────────────────────────────────────────────────────────
+
+    def test_ct_logs_subdomain_count_stored(self):
+        results = {"ct_logs": {"success": True, "total_unique_subdomains": 10}}
+        sig = extract_signals(results)
+        assert sig["subdomain_count"] == 10
+
+    def test_ct_logs_over_50_very_large_warning(self):
+        results = {"ct_logs": {"success": True, "total_unique_subdomains": 60}}
+        sig = extract_signals(results)
+        assert any("Very large" in w for w in sig["auto_warnings"])
+
+    def test_ct_logs_over_20_expanded_warning(self):
+        results = {"ct_logs": {"success": True, "total_unique_subdomains": 25}}
+        sig = extract_signals(results)
+        assert any("Expanded" in w for w in sig["auto_warnings"])
+
+    def test_ct_logs_failure_no_crash(self):
+        sig = extract_signals({"ct_logs": {"success": False}})
+        assert sig["subdomain_count"] == 0
+
+    # ── 3.8 HEADERS ────────────────────────────────────────────────────────
+
+    def test_headers_missing_headers_collected(self):
+        results = {
+            "headers": {
+                "success": True,
+                "status_code": 200,
+                "headers": {
+                    "Content-Security-Policy": {"present": False},
+                    "X-Frame-Options":          {"present": False},
+                    "Strict-Transport-Security": {"present": True},
+                },
+            }
+        }
+        sig = extract_signals(results)
+        assert "CONTENT-SECURITY-POLICY" in sig["missing_security_headers"]
+        assert "X-FRAME-OPTIONS" in sig["missing_security_headers"]
+        assert "STRICT-TRANSPORT-SECURITY" not in sig["missing_security_headers"]
+
+    def test_headers_4xx_clears_missing_list(self):
+        results = {
+            "headers": {
+                "success": True,
+                "status_code": 403,
+                "headers": {"Content-Security-Policy": {"present": False}},
+            }
+        }
+        sig = extract_signals(results)
+        assert sig["missing_security_headers"] == []
+        assert "blocked" in sig["headers_tool_state"]
+
+    def test_headers_4_or_more_missing_triggers_warning(self):
+        headers_data = {
+            f"Header-{i}": {"present": False} for i in range(4)
+        }
+        results = {
+            "headers": {"success": True, "status_code": 200, "headers": headers_data}
+        }
+        sig = extract_signals(results)
+        assert any("hardening gap" in w for w in sig["auto_warnings"])
+
+    def test_headers_tool_failure_sets_state(self):
+        results = {"headers": {"success": False}}
+        sig = extract_signals(results)
+        assert sig["headers_tool_state"] == "tool_failed"
+
+    # ── 3.9 EMAIL SECURITY ─────────────────────────────────────────────────
+
+    def _email_result(self, spf=True, dkim=True, dmarc=True,
+                      spf_policy="-all", dmarc_policy="reject") -> dict:
+        return {
+            "success":        True,
+            "security_score": "100%",
+            "rating":         "Excellent",
+            "spf":   {"found": spf,   "policy": spf_policy},
+            "dkim":  {"found": dkim},
+            "dmarc": {"found": dmarc, "policy": dmarc_policy},
+        }
+
+    def test_email_all_present_no_warnings(self):
+        results = {"email_security": self._email_result()}
+        sig = extract_signals(results)
+        email_warnings = [w for w in sig["auto_warnings"] if "SPF" in w or "DKIM" in w or "DMARC" in w]
+        assert not email_warnings
+
+    def test_email_no_spf_no_dmarc_critical_warning(self):
+        results = {"email_security": self._email_result(spf=False, dmarc=False)}
+        sig = extract_signals(results)
+        assert any("trivial email spoofing" in w for w in sig["auto_warnings"])
+
+    def test_email_missing_spf_only(self):
+        results = {"email_security": self._email_result(spf=False)}
+        sig = extract_signals(results)
+        assert any("SPF missing" in w for w in sig["auto_warnings"])
+
+    def test_email_weak_spf_policy_plusall(self):
+        results = {"email_security": self._email_result(spf_policy="+all")}
+        sig = extract_signals(results)
+        assert any("+all" in w for w in sig["auto_warnings"])
+
+    def test_email_missing_dkim_warning(self):
+        results = {"email_security": self._email_result(dkim=False)}
+        sig = extract_signals(results)
+        assert any("DKIM" in w for w in sig["auto_warnings"])
+
+    def test_email_dmarc_none_policy_warning(self):
+        results = {"email_security": self._email_result(dmarc_policy="none")}
+        sig = extract_signals(results)
+        assert any("'none'" in w for w in sig["auto_warnings"])
+
+    def test_email_missing_dmarc_warning(self):
+        results = {"email_security": self._email_result(dmarc=False)}
+        sig = extract_signals(results)
+        assert any("DMARC missing" in w for w in sig["auto_warnings"])
+
+    def test_email_failure_no_crash(self):
+        sig = extract_signals({"email_security": {"success": False}})
+        assert sig["email_security"] == {}
+
+    # ── 3.10 CVE ───────────────────────────────────────────────────────────
+
+    def _cve_result(self, cves: list) -> dict:
+        return {"success": True, "cves": cves}
+
+    def test_cve_critical_score_triggers_warning(self):
+        results = {"cve": self._cve_result([{"id": "CVE-2024-0001", "cvss": 9.5, "summary": "RCE"}])}
+        sig = extract_signals(results)
+        assert any("CRITICAL CVEs" in w for w in sig["auto_warnings"])
+
+    def test_cve_high_score_triggers_warning(self):
+        results = {"cve": self._cve_result([{"id": "CVE-2024-0002", "cvss": 7.8, "summary": "Privesc"}])}
+        sig = extract_signals(results)
+        assert any("High-severity" in w for w in sig["auto_warnings"])
+
+    def test_cve_low_score_no_warning(self):
+        results = {"cve": self._cve_result([{"id": "CVE-2024-0003", "cvss": 3.5, "summary": "Info"}])}
+        sig = extract_signals(results)
+        cve_warnings = [w for w in sig["auto_warnings"] if "CVE" in w]
+        assert not cve_warnings
+
+    def test_cve_alternate_key_names(self):
+        results = {"cve": {"success": True, "cves": [{"cve_id": "CVE-2024-0004", "cvss_score": 9.1, "description": "RCE"}]}}
+        sig = extract_signals(results)
+        # cve_id / cvss_score / description are alternate keys
+        assert len(sig["cves_found"]) == 1
+
+    def test_cve_failure_no_crash(self):
+        sig = extract_signals({"cve": {"success": False}})
+        assert sig["cves_found"] == []
+
+    # ── 3.11 IP REPUTATION ─────────────────────────────────────────────────
+
+    def test_ip_reputation_flagged_stores_true(self):
+        results = {"ip_reputation": {"success": True, "is_malicious": True, "score": 90, "categories": ["malware"]}}
+        sig = extract_signals(results)
+        assert sig["ip_reputation_flagged"] is True
+        assert any("MALICIOUS" in w for w in sig["auto_warnings"])
+
+    def test_ip_reputation_elevated_score_warning(self):
+        results = {"ip_reputation": {"success": True, "is_malicious": False, "score": 40, "categories": []}}
+        sig = extract_signals(results)
+        assert any("elevated risk" in w for w in sig["auto_warnings"])
+
+    def test_ip_reputation_low_score_no_warning(self):
+        results = {"ip_reputation": {"success": True, "is_malicious": False, "score": 5, "categories": []}}
+        sig = extract_signals(results)
+        ip_warnings = [w for w in sig["auto_warnings"] if "IP" in w or "reputation" in w.lower()]
+        assert not ip_warnings
+
+    def test_ip_reputation_non_numeric_score_no_crash(self):
+        results = {"ip_reputation": {"success": True, "is_malicious": False, "score": "N/A", "categories": []}}
+        sig = extract_signals(results)
+        assert sig["ip_reputation_flagged"] is False
+
+    def test_ip_reputation_failure_no_crash(self):
+        sig = extract_signals({"ip_reputation": {"success": False}})
+        assert sig["ip_reputation_flagged"] is False
+
+
+# ===========================================================================
+# 4.  ct_summary
+# ===========================================================================
+
+class TestCtSummary:
+
+    @patch("tools.fullrecon_tool.cert_transparency")
+    def test_returns_failure_on_cert_transparency_fail(self, mock_ct):
+        mock_ct.return_value = {"success": False, "error": "timeout"}
+        result = ct_summary("example.com")
+        assert result["success"] is False
+
+    @patch("tools.fullrecon_tool.cert_transparency")
+    def test_caps_sample_subdomains_at_50(self, mock_ct):
+        subdomains = [f"sub{i}.example.com" for i in range(200)]
+        mock_ct.return_value = {
+            "success":           True,
+            "unique_subdomains": subdomains,
+        }
+        result = ct_summary("example.com")
+        assert result["success"] is True
+        assert len(result["sample_subdomains"]) == 50
+
+    @patch("tools.fullrecon_tool.cert_transparency")
+    def test_uses_total_unique_subdomains_field_if_present(self, mock_ct):
+        mock_ct.return_value = {
+            "success":                True,
+            "total_unique_subdomains": 123,
+            "unique_subdomains":       ["a.com"] * 10,
+        }
+        result = ct_summary("example.com")
+        assert result["total_unique_subdomains"] == 123
+
+    @patch("tools.fullrecon_tool.cert_transparency")
+    def test_counts_from_list_when_total_missing(self, mock_ct):
+        mock_ct.return_value = {
+            "success":         True,
+            "unique_subdomains": ["a.com", "b.com", "c.com"],
+        }
+        result = ct_summary("example.com")
+        assert result["total_unique_subdomains"] == 3
+
+
+# ===========================================================================
+# 5.  _extract_ip
+# ===========================================================================
+
+class TestExtractIp:
+
+    def test_prefers_asn_ip(self):
+        results = {
+            "asn": {"success": True, "ip": "1.2.3.4"},
+            "dns": {"success": True, "records": {"A": ["9.9.9.9"]}},
+        }
+        assert _extract_ip(results, "example.com") == "1.2.3.4"
+
+    def test_falls_back_to_dns_a_record(self):
+        results = {
+            "asn": {"success": False},
+            "dns": {"success": True, "records": {"A": ["8.8.8.8"]}},
+        }
+        assert _extract_ip(results, "example.com") == "8.8.8.8"
+
+    def test_returns_none_when_no_ip_available(self):
+        results = {
+            "asn": {"success": False},
+            "dns": {"success": True, "records": {}},
+        }
+        assert _extract_ip(results, "example.com") is None
+
+    def test_asn_nested_data_key(self):
+        results = {
+            "asn": {"success": True, "data": {"ip": "5.5.5.5"}},
+        }
+        assert _extract_ip(results, "example.com") == "5.5.5.5"
+
+    def test_strips_whitespace_from_ip(self):
+        results = {"asn": {"success": True, "ip": "  2.2.2.2  "}}
+        assert _extract_ip(results, "example.com") == "2.2.2.2"
+
+    def test_empty_results_returns_none(self):
+        assert _extract_ip({}, "example.com") is None
+
+
+# ===========================================================================
+# 6.  _extract_software
+# ===========================================================================
+
+class TestExtractSoftware:
+
+    def test_returns_server_from_techstack(self):
+        results = {"techstack": {"success": True, "server": "Apache", "server_version": "2.4.51"}}
+        sw, ver = _extract_software(results)
+        assert sw == "Apache"
+        assert ver == "2.4.51"
+
+    def test_ignores_unknown_server(self):
+        results = {
+            "techstack": {"success": True, "server": "Unknown"},
+            "ports":     {
+                "success": True,
+                "results": [
+                    {"protocols": {"tcp": [{"port": 22, "state": "open", "service": "ssh", "version": "OpenSSH_8"}]}}
+                ],
+            },
+        }
+        sw, ver = _extract_software(results)
+        assert sw == "ssh"
+        assert ver == "OpenSSH_8"
+
+    def test_falls_back_to_ports_when_techstack_fails(self):
+        results = {
+            "techstack": {"success": False},
+            "ports": {
+                "success": True,
+                "results": [
+                    {"protocols": {"tcp": [{"port": 3306, "state": "open", "service": "mysql", "version": "5.7"}]}}
+                ],
+            },
+        }
+        sw, ver = _extract_software(results)
+        assert sw == "mysql"
+
+    def test_skips_closed_ports(self):
+        results = {
+            "techstack": {"success": False},
+            "ports": {
+                "success": True,
+                "results": [
+                    {"protocols": {"tcp": [{"port": 3306, "state": "closed", "service": "mysql", "version": ""}]}}
+                ],
+            },
+        }
+        sw, ver = _extract_software(results)
+        assert sw == ""
+
+    def test_skips_http_https_unknown_services_in_ports(self):
+        results = {
+            "techstack": {"success": False},
+            "ports": {
+                "success": True,
+                "results": [
+                    {"protocols": {"tcp": [
+                        {"port": 80,  "state": "open", "service": "http",    "version": ""},
+                        {"port": 443, "state": "open", "service": "https",   "version": ""},
+                        {"port": 8080,"state": "open", "service": "unknown", "version": ""},
+                    ]}}
+                ],
+            },
+        }
+        sw, ver = _extract_software(results)
+        assert sw == ""
+
+    def test_empty_results_returns_empty_strings(self):
+        assert _extract_software({}) == ("", "")
+
+
+# ===========================================================================
+# 7.  full_recon (orchestration)
+# ===========================================================================
+
+TOOL_MODULES = {
+    "whois_lookup":         "tools.fullrecon_tool.whois_lookup",
+    "dns_enumeration":      "tools.fullrecon_tool.dns_enumeration",
+    "port_scan":            "tools.fullrecon_tool.port_scan",
+    "ssl_inspect":          "tools.fullrecon_tool.ssl_inspect",
+    "tech_stack_detect":    "tools.fullrecon_tool.tech_stack_detect",
+    "asn_lookup":           "tools.fullrecon_tool.asn_lookup",
+    "cert_transparency":    "tools.fullrecon_tool.cert_transparency",
+    "headers_analyzer":     "tools.fullrecon_tool.headers_analyzer",
+    "email_security_check": "tools.fullrecon_tool.email_security_check",
+    "cve_lookup":           "tools.fullrecon_tool.cve_lookup",
+    "ip_reputation":        "tools.fullrecon_tool.ip_reputation",
+    "is_valid_domain":      "tools.fullrecon_tool.is_valid_domain",
+}
+
+def _patch_all_tools(valid_domain=True, software="nginx", software_version="1.20", ip="1.2.3.4"):
+    """
+    Returns a list of mock patch objects that stub out ALL external tool calls
+    so full_recon can run without any real network activity.
+    """
+    patches = {}
+
+    patches["is_valid_domain"] = patch(
+        TOOL_MODULES["is_valid_domain"], return_value=valid_domain
+    )
+    patches["whois_lookup"] = patch(
+        TOOL_MODULES["whois_lookup"],
+        return_value={"success": True, "expiration_date": _future_iso(365)},
+    )
+    patches["dns_enumeration"] = patch(
+        TOOL_MODULES["dns_enumeration"],
+        return_value={"success": True, "records": {"A": [ip], "MX": ["mail.example.com"]}},
+    )
+    patches["port_scan"] = patch(
+        TOOL_MODULES["port_scan"],
+        return_value={"success": True, "results": []},
+    )
+    patches["ssl_inspect"] = patch(
+        TOOL_MODULES["ssl_inspect"],
+        return_value={"success": True, "expires": _future_iso(90)},
+    )
+    patches["tech_stack_detect"] = patch(
+        TOOL_MODULES["tech_stack_detect"],
+        return_value={"success": True, "server": software, "server_version": software_version},
+    )
+    patches["asn_lookup"] = patch(
+        TOOL_MODULES["asn_lookup"],
+        return_value={"success": True, "ip": ip, "abuse_score": 0},
+    )
+    patches["cert_transparency"] = patch(
+        TOOL_MODULES["cert_transparency"],
+        return_value={"success": True, "unique_subdomains": ["a.example.com"], "total_unique_subdomains": 1},
+    )
+    patches["headers_analyzer"] = patch(
+        TOOL_MODULES["headers_analyzer"],
+        return_value={"success": True, "status_code": 200, "headers": {}},
+    )
+    patches["email_security_check"] = patch(
+        TOOL_MODULES["email_security_check"],
+        return_value={
+            "success": True, "security_score": "100%", "rating": "Excellent",
+            "spf":   {"found": True,  "policy": "-all"},
+            "dkim":  {"found": True},
+            "dmarc": {"found": True,  "policy": "reject"},
+        },
+    )
+    patches["cve_lookup"] = patch(
+        TOOL_MODULES["cve_lookup"],
+        return_value={"success": True, "cves": []},
+    )
+    patches["ip_reputation"] = patch(
+        TOOL_MODULES["ip_reputation"],
+        return_value={"success": True, "is_malicious": False, "score": 0, "categories": []},
+    )
+    return patches
+
+
+class TestFullRecon:
+
+    def test_invalid_domain_returns_error(self):
+        with patch(TOOL_MODULES["is_valid_domain"], return_value=False):
+            result = full_recon("not-valid!!domain")
+        assert result["success"] is False
+        assert "Invalid domain" in result["error"]
+
+    def test_valid_domain_returns_success(self):
+        patches = _patch_all_tools()
+        with (
+            patches["is_valid_domain"],
+            patches["whois_lookup"],
+            patches["dns_enumeration"],
+            patches["port_scan"],
+            patches["ssl_inspect"],
+            patches["tech_stack_detect"],
+            patches["asn_lookup"],
+            patches["cert_transparency"],
+            patches["headers_analyzer"],
+            patches["email_security_check"],
+            patches["cve_lookup"],
+            patches["ip_reputation"],
+        ):
+            result = full_recon("example.com")
+
+        assert result["success"] is True
+        assert result["domain"] == "example.com"
+
+    def test_result_contains_all_expected_keys(self):
+        patches = _patch_all_tools()
+        with (
+            patches["is_valid_domain"],
+            patches["whois_lookup"],
+            patches["dns_enumeration"],
+            patches["port_scan"],
+            patches["ssl_inspect"],
+            patches["tech_stack_detect"],
+            patches["asn_lookup"],
+            patches["cert_transparency"],
+            patches["headers_analyzer"],
+            patches["email_security_check"],
+            patches["cve_lookup"],
+            patches["ip_reputation"],
+        ):
+            result = full_recon("example.com")
+
+        for key in ["domain", "scanned_at", "mode", "tool_coverage", "tools_summary",
+                    "raw_results", "pre_extracted_signals", "instructions"]:
+            assert key in result, f"Missing key: {key}"
+
+    def test_tool_coverage_audit_all_11_tools_present(self):
+        patches = _patch_all_tools()
+        with (
+            patches["is_valid_domain"],
+            patches["whois_lookup"],
+            patches["dns_enumeration"],
+            patches["port_scan"],
+            patches["ssl_inspect"],
+            patches["tech_stack_detect"],
+            patches["asn_lookup"],
+            patches["cert_transparency"],
+            patches["headers_analyzer"],
+            patches["email_security_check"],
+            patches["cve_lookup"],
+            patches["ip_reputation"],
+        ):
+            result = full_recon("example.com")
+
+        coverage = result["tool_coverage"]
+        expected_tools = {"whois", "dns", "ports", "ssl", "techstack",
+                          "asn", "ct_logs", "headers", "email_security", "cve", "ip_reputation"}
+        assert expected_tools == set(coverage.keys())
+
+    def test_tools_summary_counts_correct(self):
+        patches = _patch_all_tools()
+        with (
+            patches["is_valid_domain"],
+            patches["whois_lookup"],
+            patches["dns_enumeration"],
+            patches["port_scan"],
+            patches["ssl_inspect"],
+            patches["tech_stack_detect"],
+            patches["asn_lookup"],
+            patches["cert_transparency"],
+            patches["headers_analyzer"],
+            patches["email_security_check"],
+            patches["cve_lookup"],
+            patches["ip_reputation"],
+        ):
+            result = full_recon("example.com")
+
+        summary = result["tools_summary"]
+        assert summary["total"] == 11
+        assert summary["succeeded"] + summary["skipped"] + summary["failed"] <= 11
+
+    def test_cve_skipped_when_no_software_detected(self):
+        """When techstack returns no recognisable software, CVE lookup must be skipped."""
+        patches = _patch_all_tools(software="Unknown", software_version="")
+        # Override techstack to return an unusable server name
+        patches["tech_stack_detect"] = patch(
+            TOOL_MODULES["tech_stack_detect"],
+            return_value={"success": True, "server": "Unknown"},
+        )
+        with (
+            patches["is_valid_domain"],
+            patches["whois_lookup"],
+            patches["dns_enumeration"],
+            patches["port_scan"],
+            patches["ssl_inspect"],
+            patches["tech_stack_detect"],
+            patches["asn_lookup"],
+            patches["cert_transparency"],
+            patches["headers_analyzer"],
+            patches["email_security_check"],
+            patches["cve_lookup"],
+            patches["ip_reputation"],
+        ):
+            result = full_recon("example.com")
+
+        cve_status = result["tool_coverage"].get("cve", "")
+        assert "skipped" in cve_status
+
+    def test_ip_reputation_skipped_when_no_ip(self):
+        """When neither ASN nor DNS returns an IP, ip_reputation must be skipped."""
+        patches = _patch_all_tools()
+        patches["asn_lookup"] = patch(
+            TOOL_MODULES["asn_lookup"],
+            return_value={"success": False},
+        )
+        patches["dns_enumeration"] = patch(
+            TOOL_MODULES["dns_enumeration"],
+            return_value={"success": True, "records": {}},  # no A record
+        )
+        with (
+            patches["is_valid_domain"],
+            patches["whois_lookup"],
+            patches["dns_enumeration"],
+            patches["port_scan"],
+            patches["ssl_inspect"],
+            patches["tech_stack_detect"],
+            patches["asn_lookup"],
+            patches["cert_transparency"],
+            patches["headers_analyzer"],
+            patches["email_security_check"],
+            patches["cve_lookup"],
+            patches["ip_reputation"],
+        ):
+            result = full_recon("example.com")
+
+        ip_status = result["tool_coverage"].get("ip_reputation", "")
+        assert "skipped" in ip_status
+
+    def test_tool_exception_captured_as_failed(self):
+        """If a tool raises an exception it must appear as 'failed' in coverage."""
+        patches = _patch_all_tools()
+        patches["whois_lookup"] = patch(
+            TOOL_MODULES["whois_lookup"],
+            side_effect=RuntimeError("network timeout"),
+        )
+        with (
+            patches["is_valid_domain"],
+            patches["whois_lookup"],
+            patches["dns_enumeration"],
+            patches["port_scan"],
+            patches["ssl_inspect"],
+            patches["tech_stack_detect"],
+            patches["asn_lookup"],
+            patches["cert_transparency"],
+            patches["headers_analyzer"],
+            patches["email_security_check"],
+            patches["cve_lookup"],
+            patches["ip_reputation"],
+        ):
+            result = full_recon("example.com")
+
+        assert result["success"] is True  # overall recon still succeeds
+        assert result["tool_coverage"]["whois"].startswith("failed")
+
+    def test_instructions_contain_domain(self):
+        patches = _patch_all_tools()
+        with (
+            patches["is_valid_domain"],
+            patches["whois_lookup"],
+            patches["dns_enumeration"],
+            patches["port_scan"],
+            patches["ssl_inspect"],
+            patches["tech_stack_detect"],
+            patches["asn_lookup"],
+            patches["cert_transparency"],
+            patches["headers_analyzer"],
+            patches["email_security_check"],
+            patches["cve_lookup"],
+            patches["ip_reputation"],
+        ):
+            result = full_recon("example.com")
+
+        assert "example.com" in result["instructions"]
+
+    def test_scanned_at_is_utc_iso_format(self):
+        patches = _patch_all_tools()
+        with (
+            patches["is_valid_domain"],
+            patches["whois_lookup"],
+            patches["dns_enumeration"],
+            patches["port_scan"],
+            patches["ssl_inspect"],
+            patches["tech_stack_detect"],
+            patches["asn_lookup"],
+            patches["cert_transparency"],
+            patches["headers_analyzer"],
+            patches["email_security_check"],
+            patches["cve_lookup"],
+            patches["ip_reputation"],
+        ):
+            result = full_recon("example.com")
+
+        scanned_at = result["scanned_at"]
+        assert scanned_at.endswith("Z"), f"Expected UTC 'Z' suffix, got: {scanned_at}"
+
+    def test_mode_is_threat_analysis(self):
+        patches = _patch_all_tools()
+        with (
+            patches["is_valid_domain"],
+            patches["whois_lookup"],
+            patches["dns_enumeration"],
+            patches["port_scan"],
+            patches["ssl_inspect"],
+            patches["tech_stack_detect"],
+            patches["asn_lookup"],
+            patches["cert_transparency"],
+            patches["headers_analyzer"],
+            patches["email_security_check"],
+            patches["cve_lookup"],
+            patches["ip_reputation"],
+        ):
+            result = full_recon("example.com")
+
+        assert result["mode"] == "threat_analysis"
+
+
+# ===========================================================================
+# 8.  THREAT_ANALYSIS_PROMPT (smoke test)
+# ===========================================================================
+
+class TestThreatAnalysisPrompt:
+
+    def test_prompt_contains_placeholder_domain(self):
+        assert "{domain}" in THREAT_ANALYSIS_PROMPT
+
+    def test_prompt_contains_placeholder_scanned_at(self):
+        assert "{scanned_at}" in THREAT_ANALYSIS_PROMPT
+
+    def test_prompt_contains_placeholder_signals_block(self):
+        assert "{signals_block}" in THREAT_ANALYSIS_PROMPT
+
+    def test_prompt_formats_cleanly(self):
+        filled = THREAT_ANALYSIS_PROMPT.format(
+            domain="test.com",
+            scanned_at="2026-01-01T00:00:00Z",
+            signals_block="test signal",
+        )
+        assert "test.com" in filled
+        assert "test signal" in filled

--- a/tools/fullrecon_tool.py
+++ b/tools/fullrecon_tool.py
@@ -1,47 +1,530 @@
-from tools.headers_tool import headers_analyzer
 from tools.whois_tool import whois_lookup
 from tools.dns_tool import dns_enumeration
 from tools.portscan_tool import port_scan
 from tools.ssl_tool import ssl_inspect
 from tools.techstack_tool import tech_stack_detect
 from tools.asn_tool import asn_lookup
+from tools.crt_sh_tool import cert_transparency
+from tools.headers_tool import headers_analyzer
+from tools.cve_tool import cve_lookup
+from tools.iprep_tool import ip_reputation
+from tools.email_security_tool import email_security_check
 from utils.helpers import is_valid_domain
 import concurrent.futures
-from datetime import datetime , timezone
-from tools.crt_sh_tool import cert_transparency
+from datetime import datetime, timezone
 
-## Instead of full crt log we will give less details in full_recon
-## If you want complete info run crt_sh_tool separately
+THREAT_ANALYSIS_PROMPT = """\
+You are a senior penetration tester reviewing raw reconnaissance data collected
+from 11 automated tools about the target domain below.
+
+YOUR JOB IS CORRELATION, NOT ENUMERATION.
+Do NOT summarise each tool individually.
+Instead, weave findings across tools into a single coherent threat picture.
+Look especially for combinations that amplify risk — examples:
+  • Outdated CMS (techstack) + missing X-Frame-Options (headers) = clickjacking on a CMS
+    with known exploits
+  • Open port 443 (ports) + SSL cert expiring in < 30 days (ssl) = imminent HTTPS outage
+  • Missing DMARC/SPF/DKIM (email_security) + public-facing mail server = trivial spoofing
+  • High ASN abuse score (asn) + IP flagged by reputation (ip_reputation) = hosting provider
+    actively used for attacks; consider moving infra
+  • Many CT-log subdomains (ct_logs) + weak headers on root domain (headers) = broad surface
+    with inadequate baseline hardening
+
+Follow this exact output structure — no prose outside it:
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+🛡️  AynOps Threat Intelligence Report
+Target : {domain}
+Scanned: {scanned_at}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+## Executive Summary
+[Exactly 3 sentences:
+  1. Overall security posture (one word rating + brief reason)
+  2. The single most dangerous finding and what an attacker gains from it
+  3. The one action the domain owner must take TODAY]
+
+## 🔴 Critical Findings
+[Only issues that are directly exploitable RIGHT NOW or expose sensitive data.
+ Use this format for every item:
+
+   **[SHORT TITLE]**
+   Risk   : <what an attacker can do — be specific, no vague language>
+   Source : <which tool(s) surfaced this>
+   Correlated with: <other signal(s) that make this worse, or "None">
+
+ Write "None identified." if nothing qualifies.]
+
+## 🟡 Notable Findings
+[Medium/high risk that are not immediately exploitable but increase attack surface.
+ Same format as Critical Findings above.
+ Include: outdated software, missing security headers, weak TLS, large subdomain
+ surface, email spoofing gaps, permissive ASN neighbourhood, and similar.]
+
+## 🟢 What Is Configured Correctly
+[3 bullet points MAX. Only include things that are genuinely well configured.
+ Skip the section entirely if nothing stands out — do not pad.]
+
+## Risk Score
+| Category                        | Score  | Reason (one line)            |
+|---------------------------------|--------|------------------------------|
+| Open ports exposure             |  X/20  | (0 = No Risk, 20 = Max Risk) |
+| Software CVEs                   |  X/25  | (0 = No Risk, 25 = Max Risk) |
+| SSL / TLS posture               |  X/20  | (0 = No Risk, 20 = Max Risk) |
+| Security headers                |  X/15  | (0 = No Risk, 15 = Max Risk) |
+| Email security (SPF/DKIM/DMARC) |  X/10  | (0 = No Risk, 10 = Max Risk) |
+| IP / ASN reputation             |  X/5   | (0 = No Risk, 5 = Max Risk)  |
+| DNS / subdomain surface         |  X/5   | (0 = No Risk, 5 = Max Risk)  |
+| **TOTAL**                       | **X/100** |                         |
+
+Risk Level: CRITICAL (80–100) / HIGH (60–79) / MEDIUM (40–59) / LOW (0–39)
+(higher score = more risk)
+
+## Remediation Roadmap
+**Immediate — do today (before close of business):**
+  1. ...
+
+**This week:**
+  1. ...
+
+**This month:**
+  1. ...
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+PRE-EXTRACTED SIGNALS (use these; do not re-derive from raw JSON):
+{signals_block}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+EVIDENCE QUALITY RULES — follow these strictly:
+• Never report a vulnerability solely because data is missing from a tool.
+• IF the Headers tool returned an HTTP status of 4xx or 5xx, or if the scan returned an empty payload, you MUST classify security headers as "Insufficient data" rather than "Missing". Do not penalize the domain for a blocked or failed request.
+• Use this language:
+    - "Confirmed" — tool returned explicit evidence
+    - "Likely" — strong indirect evidence from correlated tools
+    - "Insufficient data" — tool failed, was blocked, or returned no result
+• CVSS ≥ 9.0 → always Critical regardless of other context
+• CVSS 7.0–8.9 → Notable unless correlated with open port or CMS → then Critical
+• ASN or IP reputation abuse score > 50 → always at least Notable
+• SSL or domain expiry < 14 days → always Critical
+• Missing SPF + missing DMARC → always Critical (trivial spoofing)
+• If a tool was skipped or failed, say so in the relevant finding instead of omitting it
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+"""
+
+
+def _format_signals_block(signals: dict) -> str:
+    """Render the pre-extracted signals dict as a readable block for the prompt."""
+    lines = []
+
+    if signals.get("auto_warnings"):
+        lines.append("⚠️  AUTO-WARNINGS (highest priority):")
+        for w in signals["auto_warnings"]:
+            lines.append(f"  • {w}")
+        lines.append("")
+
+    lines.append(f"Domain expiry      : {signals.get('domain_expiry_days', 'unknown')} days")
+    lines.append(f"SSL days remaining : {signals.get('ssl_days_remaining', 'unknown')} days")
+    lines.append(f"Open ports         : {', '.join(signals['open_ports']) or 'none detected'}")
+    lines.append(f"Software detected  : {', '.join(signals['software_detected']) or 'none'}")
+    lines.append(f"Subdomains (CT)    : {signals.get('subdomain_count', 0)}")
+    lines.append(f"IP abuse score     : {signals.get('ip_abuse_score', 0)}/100")
+    lines.append(f"IP flagged malicious: {signals.get('ip_reputation_flagged', False)}")
+
+    missing_hdrs = signals.get("missing_security_headers", [])
+    lines.append(f"Missing sec headers: {len(missing_hdrs)} — {', '.join(missing_hdrs) or 'none'}")
+    lines.append(f"Headers tool state : {signals.get('headers_tool_state', 'unknown')}")
+
+    missing_dns = signals.get("dns_missing_records", [])
+    lines.append(f"Missing DNS records : {', '.join(missing_dns) or 'none'}")
+
+    email_sec = signals.get("email_security", {})
+    if email_sec:
+        lines.append(f"Email security score: {email_sec.get('security_score', 'n/a')} ({email_sec.get('rating', 'n/a')})")
+        lines.append(f"  SPF  : {'✓ found' if email_sec.get('spf_found') else '✗ missing'} — policy: {email_sec.get('spf_policy', 'n/a')}")
+        lines.append(f"  DKIM : {'✓ found' if email_sec.get('dkim_found') else '✗ missing'}")
+        lines.append(f"  DMARC: {'✓ found' if email_sec.get('dmarc_found') else '✗ missing'} — policy: {email_sec.get('dmarc_policy', 'n/a')}")
+
+    cves = signals.get("cves_found", [])
+    if cves:
+        lines.append(f"CVEs found ({len(cves)}):")
+        for c in cves[:5]:
+            lines.append(f"  • {c['id']} (CVSS {c['cvss']}) — {c['summary']}")
+        if len(cves) > 5:
+            lines.append(f"  … and {len(cves) - 5} more")
+    else:
+        lines.append("CVEs found         : none")
+
+    return "\n".join(lines)
+
+def safe_parse_datetime(date_input) -> datetime | None:
+    """Helper to catch and resolve structural variances in string dates."""
+    if not date_input:
+        return None
+    
+    # If the input is already a datetime object (some tools return structured objects)
+    if isinstance(date_input, datetime):
+        return date_input
+        
+    clean_str = str(date_input).strip().replace("Z", "+00:00")
+    
+    # Try common formats sequentially
+    for fmt in ("%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%d %H:%M:%S%z", "%Y-%m-%d %H:%M:%S", "%Y-%m-%d"):
+        try:
+            return datetime.strptime(clean_str, fmt)
+        except (ValueError, TypeError):
+            continue
+            
+    # Fallback onto standard ISO parsing
+    try:
+        return datetime.fromisoformat(clean_str)
+    except (ValueError, TypeError):
+        return None
+
+def extract_signals(results: dict) -> dict:
+    """
+    Pull key security signals out of ALL 11 tool results.
+    This guides Claude's attention to what matters most
+    so nothing gets buried in a wall of JSON.
+
+    Tools covered:
+      whois, dns, ports, ssl, techstack, asn, ct_logs, headers,
+      email_security, cve, ip_reputation
+    """
+    signals = {
+        # ── per-tool signals ──────────────────────────────────
+        "domain_expiry_days":       None,   # whois
+        "dns_missing_records":      [],     # dns  (SPF / DMARC / DKIM)
+        "open_ports":               [],     # ports
+        "ssl_days_remaining":       None,   # ssl
+        "software_detected":        [],     # techstack
+        "ip_abuse_score":           0,      # asn
+        "subdomain_count":          0,      # ct_logs
+        "missing_security_headers": [],     # headers
+        "email_security":           {},     # email_security_tool
+        "cves_found":               [],     # cve  — list of {id, cvss, summary}
+        "ip_reputation_flagged":    False,  # ip_reputation
+        # ── pre-flagged warnings for Claude ──────────────────
+        "auto_warnings":            [],
+    }
+
+    # ── 1. WHOIS: domain expiry ───────────────────────────────
+    whois = results.get("whois", {})
+    if whois.get("success"):
+        expiry = whois.get("expiration_date") or whois.get("data", {}).get("expiration_date")
+        exp_dt = safe_parse_datetime(expiry)
+        if exp_dt:
+            if exp_dt.tzinfo is None:
+                exp_dt = exp_dt.replace(tzinfo=timezone.utc)
+            days = (exp_dt - datetime.now(timezone.utc)).days
+            signals["domain_expiry_days"] = days
+            if days < 0:
+                signals["auto_warnings"].append(f"Domain EXPIRED {abs(days)} days ago — domain may be hijackable")
+            elif days < 14:
+                signals["auto_warnings"].append(f"Domain expires in {days} days — CRITICAL renewal required")
+            elif days < 30:
+                signals["auto_warnings"].append(f"Domain expires in {days} days — HIGH priority renewal")
+
+    # ── 2. DNS: Check structural connectivity and baseline records ────────────
+    dns = results.get("dns", {})
+    if dns.get("success"):
+        records = dns.get("records", {})
+        missing_dns = []
+
+        # Check for core operational routing records
+        if not records.get("A") and not records.get("AAAA"):
+            missing_dns.append("A/AAAA")
+            signals["auto_warnings"].append(
+                "No A or AAAA records found — domain may not resolve to an active web server."
+            )
+
+        # Check if the domain is missing mail routing capabilities entirely
+        if not records.get("MX"):
+            missing_dns.append("MX")
+            signals["auto_warnings"].append(
+                "Missing MX records — this domain cannot natively receive email traffic safely."
+            )
+
+        # Log tracked structural gaps (excluding email security features handled by wave 1/3)
+        signals["dns_missing_records"] = missing_dns
+
+    # ── 3. PORTS: open port list ──────────────────────────────
+    ports_data = results.get("ports", {})
+    if ports_data.get("success"):
+        open_port_nums = []
+        for host in ports_data.get("results", []):
+            for proto, port_list in host.get("protocols", {}).items():
+                for p in port_list:
+                    if p.get("state") == "open":
+                        signals["open_ports"].append(
+                            f"{p['port']}/tcp ({p.get('service', '?')})"
+                        )
+                        open_port_nums.append(p.get("port"))
+
+        dangerous = {21: "FTP", 23: "Telnet", 3389: "RDP", 445: "SMB",
+                     3306: "MySQL", 5432: "PostgreSQL", 6379: "Redis", 27017: "MongoDB"}
+        for port_num, service in dangerous.items():
+            if port_num in open_port_nums:
+                signals["auto_warnings"].append(
+                    f"Dangerous port open: {port_num} ({service}) — high-value attack target"
+                )
+
+    # ── 4. SSL: days until expiry ─────────────────────────────
+    ssl = results.get("ssl", {})
+    if ssl.get("success"):
+        expiry = ssl.get("expires") or ssl.get("data", {}).get("expires")
+        exp_dt = safe_parse_datetime(expiry)
+        if exp_dt:
+            if exp_dt.tzinfo is None:
+                exp_dt = exp_dt.replace(tzinfo=timezone.utc)
+            days = (exp_dt - datetime.now(timezone.utc)).days
+            signals["ssl_days_remaining"] = days
+            if days < 0:
+                signals["auto_warnings"].append(f"SSL cert EXPIRED {abs(days)} days ago — all HTTPS traffic at risk")
+            elif days < 14:
+                signals["auto_warnings"].append(f"SSL cert expires in {days} days — CRITICAL, renew immediately")
+            elif days < 30:
+                signals["auto_warnings"].append(f"SSL cert expires in {days} days — HIGH priority renewal")
+
+    # ── 5. TECHSTACK: software versions ──────────────────────
+    ts = results.get("techstack", {})
+    if ts.get("success"):
+        for key in ["server", "cms", "framework", "language", "cdn"]:
+            val = ts.get(key) or ts.get("data", {}).get(key)
+            if val and str(val).strip() not in ("Unknown", "None", ""):
+                signals["software_detected"].append(str(val).strip())
+
+    # ── 6. ASN: IP abuse score ────────────────────────────────
+    asn = results.get("asn", {})
+    if asn.get("success"):
+        score = asn.get("abuse_score") or asn.get("data", {}).get("abuse_score", 0)
+        try:
+            score = int(score)
+        except (TypeError, ValueError):
+            score = 0
+        signals["ip_abuse_score"] = score
+        if score > 50:
+            signals["auto_warnings"].append(
+                f"ASN abuse score {score}/100 — HIGH malicious activity reported on this IP range"
+            )
+        elif score > 20:
+            signals["auto_warnings"].append(
+                f"ASN abuse score {score}/100 — elevated, investigate hosting provider"
+            )
+
+    # ── 7. CT LOGS: subdomain attack surface ─────────────────
+    ct = results.get("ct_logs", {})
+    if ct.get("success"):
+        count = ct.get("total_unique_subdomains", 0)
+        signals["subdomain_count"] = count
+        if count > 50:
+            signals["auto_warnings"].append(
+                f"Very large attack surface: {count} subdomains in CT logs"
+            )
+        elif count > 20:
+            signals["auto_warnings"].append(
+                f"Expanded attack surface: {count} subdomains found in CT logs"
+            )
+
+    # ── 8. HEADERS: missing security headers ─────────────────
+    hdrs = results.get("headers", {})
+    signals["headers_tool_state"] = "success"  # Default fallback
+    
+    if hdrs.get("success"):
+        # Track HTTP status if your analyzer provides it (e.g., 403 Forbidden)
+        status_code = hdrs.get("status_code", 200)
+        headers_data = hdrs.get("headers", {})
+        
+        if status_code >= 400 or not headers_data:
+            signals["headers_tool_state"] = f"failed_or_blocked (HTTP {status_code})"
+            signals["missing_security_headers"] = [] # Clear out false missing flags
+        else:
+            missing = []
+            for header_name, header_info in headers_data.items():
+                if isinstance(header_info, dict) and not header_info.get("present", True):
+                    missing.append(header_name.upper())
+            signals["missing_security_headers"] = missing
+            
+            if len(missing) >= 4:
+                signals["auto_warnings"].append(
+                    f"{len(missing)} security headers missing ({', '.join(missing)}) — significant hardening gap"
+                )
+            elif len(missing) >= 2:
+                signals["auto_warnings"].append(
+                    f"{len(missing)} security headers missing: {', '.join(missing)}"
+                )
+    else:
+        signals["headers_tool_state"] = "tool_failed"
+        
+    # ── 9. EMAIL SECURITY: SPF / DKIM / DMARC deep analysis ──
+    # email_security_tool returns full SPF/DKIM/DMARC breakdown with policies and scores
+    email_sec = results.get("email_security", {})
+    if email_sec.get("success"):
+        spf   = email_sec.get("spf",   {})
+        dkim  = email_sec.get("dkim",  {})
+        dmarc = email_sec.get("dmarc", {})
+
+        spf_found   = spf.get("found", False)
+        dkim_found  = dkim.get("found", False)
+        dmarc_found = dmarc.get("found", False)
+        spf_policy  = spf.get("policy", "none")
+        dmarc_policy = dmarc.get("policy", "none")
+
+        signals["email_security"] = {
+            "security_score": email_sec.get("security_score", "0%"),
+            "rating":         email_sec.get("rating", "Unknown"),
+            "spf_found":      spf_found,
+            "spf_policy":     spf_policy,
+            "dkim_found":     dkim_found,
+            "dmarc_found":    dmarc_found,
+            "dmarc_policy":   dmarc_policy,
+            "recommendations": email_sec.get("recommendations", []),
+        }
+
+        if not spf_found and not dmarc_found:
+            signals["auto_warnings"].append(
+                "No SPF and no DMARC configured — trivial email spoofing, any attacker can "
+                "send mail appearing to come from this domain"
+            )
+        elif not spf_found:
+            signals["auto_warnings"].append(
+                "SPF missing — senders cannot be validated, enables phishing from this domain"
+            )
+        elif spf_policy in ("neutral", "pass", "+all"):
+            signals["auto_warnings"].append(
+                f"SPF policy is '{spf_policy}' — provides no real protection; use '-all'"
+            )
+
+        if not dkim_found:
+            signals["auto_warnings"].append(
+                "DKIM not detected on any common selector — email integrity cannot be verified"
+            )
+
+        if not dmarc_found:
+            signals["auto_warnings"].append(
+                "DMARC missing — receiving mail servers have no policy for handling spoofed mail"
+            )
+        elif dmarc_policy == "none":
+            signals["auto_warnings"].append(
+                "DMARC policy is 'none' — monitoring only, spoofed mail is still delivered"
+            )
+
+    # ── 10. CVE: known vulnerabilities ────────────────────────
+    cve = results.get("cve", {})
+    if cve.get("success"):
+        cve_list = cve.get("cves") or cve.get("data", {}).get("cves", [])
+        for entry in cve_list:
+            cve_id   = entry.get("id") or entry.get("cve_id", "")
+            cvss     = entry.get("cvss") or entry.get("cvss_score", 0)
+            summary  = entry.get("summary") or entry.get("description", "")
+            if cve_id:
+                signals["cves_found"].append({
+                    "id":      cve_id,
+                    "cvss":    cvss,
+                    "summary": str(summary)[:120],
+                })
+
+        critical_cves = [c for c in signals["cves_found"] if float(c.get("cvss") or 0) >= 9.0]
+        high_cves     = [c for c in signals["cves_found"] if 7.0 <= float(c.get("cvss") or 0) < 9.0]
+        if critical_cves:
+            ids = ", ".join(c["id"] for c in critical_cves[:3])
+            signals["auto_warnings"].append(
+                f"CRITICAL CVEs detected: {ids} (CVSS ≥ 9.0) — immediately exploitable"
+            )
+        elif high_cves:
+            ids = ", ".join(c["id"] for c in high_cves[:3])
+            signals["auto_warnings"].append(
+                f"High-severity CVEs detected: {ids} (CVSS 7–9) — patch urgently"
+            )
+
+    # ── 11. IP REPUTATION: malicious flag ────────────────────
+    iprep = results.get("ip_reputation", {})
+    if iprep.get("success"):
+        flagged    = iprep.get("is_malicious") or iprep.get("data", {}).get("is_malicious", False)
+        rep_score  = iprep.get("score") or iprep.get("data", {}).get("score", 0)
+        categories = iprep.get("categories") or iprep.get("data", {}).get("categories", [])
+        signals["ip_reputation_flagged"] = bool(flagged)
+        try:
+            rep_score = int(rep_score)
+        except (TypeError, ValueError):
+            rep_score = 0
+        if flagged:
+            cat_str = f" ({', '.join(categories[:3])})" if categories else ""
+            signals["auto_warnings"].append(
+                f"IP flagged as MALICIOUS by reputation service{cat_str} "
+                f"— hosting may be blacklisted by mail servers and firewalls"
+            )
+        elif rep_score > 20:
+            signals["auto_warnings"].append(
+                f"IP reputation score {rep_score}/100 — elevated risk, monitor closely"
+            )
+
+    return signals
+
+
 def ct_summary(domain: str) -> dict:
-    """
-    Lightweight CT log summary for full recon.
-    Avoids returning hundreds/thousands of certificates.
-    """
+    """Lightweight CT log summary — avoids returning thousands of certs."""
     result = cert_transparency(domain)
-
     if not result.get("success"):
         return result
-
     return {
         "success": True,
         "total_unique_subdomains": result.get(
             "total_unique_subdomains",
             len(result.get("unique_subdomains", []))
         ),
-        "sample_subdomains": result.get(
-            "unique_subdomains",
-            []
-        )[:50]
+        "sample_subdomains": result.get("unique_subdomains", [])[:50],
     }
+
+
+def _extract_ip(results: dict, domain: str) -> str | None:
+    """
+    Extract IP address from results using multiple fallbacks.
+    Priority: ASN result → DNS A record → None
+    """
+    asn = results.get("asn", {})
+    if asn.get("success"):
+        ip = asn.get("ip") or asn.get("data", {}).get("ip")
+        if ip:
+            return str(ip).strip()
+
+    dns = results.get("dns", {})
+    if dns.get("success"):
+        a_records = dns.get("records", {}).get("A", [])
+        if a_records:
+            return str(a_records[0]).strip()
+
+    return None
+
+
+def _extract_software(results: dict) -> tuple[str, str]:
+    """
+    Extract software name and version from techstack or ports.
+    Returns (software, version) tuple.
+    """
+    ts = results.get("techstack", {})
+    if ts.get("success"):
+        server  = ts.get("server")  or ts.get("data", {}).get("server",  "")
+        version = ts.get("server_version") or ts.get("data", {}).get("server_version", "")
+        if server and server.lower() not in ("unknown", "none", ""):
+            return str(server).strip(), str(version).strip()
+
+    ports = results.get("ports", {})
+    if ports.get("success"):
+        for host in ports.get("results", []):
+            for proto, port_list in host.get("protocols", {}).items():
+                for p in port_list:
+                    if p.get("state") == "open":
+                        service = p.get("service", "")
+                        version = p.get("version", "")
+                        if service and service not in ("http", "https", "unknown"):
+                            return service, version
+
+    return "", ""
+
 
 def full_recon(domain: str) -> dict:
     """
-    Run all recon tools on a domain in parallel:
-    WHOIS, DNS enumeration, port scan, SSL inspection,
-    technology stack detection , asn lookup and certificate transparency search.
-
-    Returns combined raw results. The MCP client (Claude)
-    should generate summaries for each section.
+    Run ALL 11 recon tools on a domain in three waves to prevent network rate-limiting.
     """
     if not is_valid_domain(domain):
         return {"success": False, "error": "Invalid domain format"}
@@ -54,29 +537,98 @@ def full_recon(domain: str) -> dict:
         except Exception as e:
             results[name] = {"success": False, "error": str(e)}
 
-    # Run all tools in parallel
-    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as ex:
+    # ── Wave 1: Lightweight API & Infrastructure Records ─────────────────────
+    with concurrent.futures.ThreadPoolExecutor(max_workers=6) as ex:
         futures = [
-            ex.submit(run, "whois",    whois_lookup,       domain),
-            ex.submit(run, "dns",      dns_enumeration,    domain),
-            ex.submit(run, "ports",    port_scan,          domain, "service"),
-            ex.submit(run, "ssl",      ssl_inspect,        domain),
-            ex.submit(run, "techstack",tech_stack_detect,  domain),
-            ex.submit(run, "asn" , asn_lookup, domain),
-            ex.submit(run, "ct_logs", ct_summary, domain),
-            ex.submit(run, "headers",  headers_analyzer,   domain),
+            ex.submit(run, "whois",          whois_lookup,        domain),
+            ex.submit(run, "dns",            dns_enumeration,     domain),
+            ex.submit(run, "ssl",            ssl_inspect,         domain),
+            ex.submit(run, "headers",        headers_analyzer,    domain),
+            ex.submit(run, "email_security", email_security_check, domain),
+            ex.submit(run, "asn" , asn_lookup , domain)
         ]
         concurrent.futures.wait(futures)
 
+    # ── Wave 2: Aggressive Port/Tech Scans & Throttled Log Aggregators ───────
+    with concurrent.futures.ThreadPoolExecutor(max_workers=3) as ex:
+        futures = [
+            ex.submit(run, "ports",          port_scan,           domain, "service"),
+            ex.submit(run, "techstack",      tech_stack_detect,   domain),
+            ex.submit(run, "ct_logs",        ct_summary,          domain),  # Separated to avoid rate-limiting
+        ]
+        concurrent.futures.wait(futures)
+
+    # ── Wave 3: Threat Feeds & Enrichment Data (Depends on Wave 1 & 2) ───────
+    software, version = _extract_software(results)
+    ip = _extract_ip(results, domain)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as ex:
+        futures = []
+
+        if software:
+            futures.append(ex.submit(run, "cve", cve_lookup, software, version))
+        else:
+            results["cve"] = {
+                "success": False,
+                "skipped": True,
+                "reason": "No software detected in techstack or port scan — CVE lookup skipped",
+            }
+
+        if ip:
+            futures.append(ex.submit(run, "ip_reputation", ip_reputation, ip))
+        else:
+            results["ip_reputation"] = {
+                "success": False,
+                "skipped": True,
+                "reason": "No IP address found — ip_reputation skipped",
+            }
+
+        if futures:
+            concurrent.futures.wait(futures)
+
+    scanned_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+    # ── Tool coverage audit ────────────────────────────────────
+    all_tools = [
+    "whois", "dns", "ports", "ssl", "techstack",
+    "asn", "ct_logs", "headers", "email_security", "cve", "ip_reputation",
+    ]
+
+    tool_coverage = {}
+    for tool in all_tools:
+        r = results.get(tool, {})
+        if r.get("success"):
+            tool_coverage[tool] = "success"
+        elif r.get("skipped"):
+            tool_coverage[tool] = f"skipped — {r.get('reason', '')}"
+        elif "error" in r:
+            tool_coverage[tool] = f"failed — {r.get('error', '')}"
+        else:
+            tool_coverage[tool] = "no result"
+
+    tools_succeeded = sum(1 for v in tool_coverage.values() if v == "success")
+    tools_skipped   = sum(1 for v in tool_coverage.values() if v.startswith("skipped"))
+    tools_failed    = sum(1 for v in tool_coverage.values() if v.startswith("failed"))
+
+    signals = extract_signals(results)
+
     return {
-        "success": True,
-        "domain": domain,
-        "scanned_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
-        "results": results,
-        "instructions": (
-            "Generate a 2-3 sentence summary for each tool's output "
-            "(whois_summary, dns_summary, ports_summary, ssl_summary, "
-            "techstack_summary, asn_summary, ct_logs, headers_summary) "
-            "and a final overall_summary of 4-5 sentences covering the full security posture. "
-        )
+        "success":               True,
+        "domain":                domain,
+        "scanned_at":            scanned_at,
+        "mode":                  "threat_analysis",
+        "tool_coverage":         tool_coverage,
+        "tools_summary":         {
+            "total":     len(all_tools),
+            "succeeded": tools_succeeded,
+            "skipped":   tools_skipped,
+            "failed":    tools_failed,
+        },
+        "raw_results":           results,
+        "pre_extracted_signals": signals,
+        "instructions":          THREAT_ANALYSIS_PROMPT.format(
+                                     domain=domain,
+                                     scanned_at=scanned_at,
+                                     signals_block=_format_signals_block(signals),
+                                 ),
     }


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>Enhance <code>full_recon</code> with Structured Threat Intelligence Output Fix #58 </h1>
<h2>Problem</h2>
<p>The previous <code>full_recon</code> returned a flat, per-tool summary driven by a single-line instruction:</p>
<blockquote>
<p>"Generate a 2-3 sentence summary for each tool's output... End with an overall_summary of 4-5 sentences."</p>
</blockquote>
<p>This approach had two core weaknesses:</p>
<ol>
<li>
<p><strong>No cross-tool correlation.</strong> Critical compound risks — an expiring SSL cert on an open HTTPS port, a detected CMS combined with missing security headers — were never surfaced. Each tool's output was treated in isolation.</p>
</li>
<li>
<p><strong>Two tools were unused.</strong> <code>email_security_tool</code> and <code>headers_tool</code>, both already present in the repo, were not being called by <code>full_recon</code> due to mismatched input fields. Their data never reached Claude.</p>
</li>
</ol>
<hr>
<h2>What Changed</h2>
<h3>1. <code>THREAT_ANALYSIS_PROMPT</code> constant</h3>
<p>Replaced the plain instruction string with a structured prompt that explicitly instructs Claude to <strong>correlate findings across tools</strong> rather than enumerate them one by one.</p>
<p>The prompt enforces a fixed output structure:</p>
<ul>
<li><strong>Executive Summary</strong> — 3-sentence posture assessment</li>
<li><strong>🔴 Critical Findings</strong> — directly exploitable issues with <code>Risk</code>, <code>Source</code>, and <code>Correlated with</code> fields</li>
<li><strong>🟡 Notable Findings</strong> — medium/high risk findings using the same format</li>
<li><strong>🟢 What Is Configured Correctly</strong> — max 3 bullets, only genuine positives</li>
<li><strong>Risk Score table</strong> — scored across 7 categories (Open Ports / CVEs / SSL / Headers / Email / IP Reputation / DNS), total out of 100</li>
<li><strong>Remediation Roadmap</strong> — tiered as Immediate / This week / This month</li>
</ul>
<p>The prompt also includes <strong>evidence quality rules</strong> to prevent Claude from penalising a domain for blocked or failed tool responses (e.g. a 403 on the headers tool is classified as <code>Insufficient data</code>, not <code>Missing headers</code>).</p>
<h3>2. <code>safe_parse_datetime()</code> helper</h3>
<p>Added a robust datetime parser that handles the structural variance across tool outputs:</p>
<ul>
<li>Accepts existing <code>datetime</code> objects (passthrough)</li>
<li>Handles <code>Z</code>-suffix, <code>+00:00</code> offset, space-separated, and date-only ISO strings</li>
<li>Falls back to <code>datetime.fromisoformat()</code> before returning <code>None</code> — never raises</li>
</ul>
<h3>3. <code>extract_signals()</code> helper</h3>
<p>Pre-extracts the most security-relevant signals from all 11 tool results before passing anything to Claude. This keeps Claude focused on what matters and prevents critical findings from being buried in raw JSON.</p>
<p>Signals extracted per tool:</p>

Tool | Signal
-- | --
whois | Domain expiry in days; auto-warning if < 30 days or already expired
dns | Missing A/AAAA and MX records
ports | Open port list; auto-warning for dangerous ports (FTP, Telnet, RDP, SMB, DB ports)
ssl | Days until cert expiry; auto-warning if < 30 days or expired
techstack | Detected server, CMS, framework, language, CDN
asn | IP abuse score; auto-warning if > 20
ct_logs | Subdomain count; auto-warning if > 20
headers | Missing security header names; respects HTTP 4xx/5xx as Insufficient data
email_security | SPF/DKIM/DMARC presence and policies; auto-warning for critical gaps (e.g. no SPF + no DMARC)
cve | CVE list with CVSS scores; auto-warning for CVSS ≥ 9.0 or ≥ 7.0
ip_reputation | Malicious flag and abuse score; auto-warning if flagged or score > 20


<p>All external I/O is fully mocked — no real network calls required.</p>
<hr></body></html><!--EndFragment-->
</body>
</html>