### PR TITLE
fix: header analyzer results differing from browser DevTools (#62)

### DIFF
--- a/tests/test_headers_tool.py
+++ b/tests/test_headers_tool.py
@@ -15,11 +15,12 @@ def _resp(status_code: int, headers: dict):
     that look like a production bug but are actually just an inaccurate
     mock.
 
-    headers is a plain dict on input, curl_cffi (like `requests`)
-    already combines a repeated header into one comma-joined value
-    during its own parsing, so by the time this tool sees resp.headers,
-    a duplicate-header scenario is already a single combined string,
-    not separate entries.
+    headers is a plain dict on input, note this means a genuinely
+    duplicate header name can't be represented this way (a Python dict
+    literal collapses a repeated key before Headers() ever sees it).
+    See test_dict_headers_items_preserves_genuinely_duplicate_headers
+    below for the test that specifically covers that case using a
+    list of tuples instead.
     """
     m = Mock()
     m.status_code = status_code
@@ -91,9 +92,6 @@ class TestHeadersAnalyzer(unittest.TestCase):
 
     @patch("tools.headers_tool.requests.get")
     def test_hsts_max_age_zero_flagged_high(self, mock_get):
-        """Fix: max-age=0 actively disables HSTS (a real rollback
-        technique), so it must be flagged as high severity, not lumped
-        in with merely-short-but-nonzero durations as medium."""
         mock_get.return_value = _resp(200, {
             "Strict-Transport-Security": "max-age=0",
         })
@@ -104,8 +102,6 @@ class TestHeadersAnalyzer(unittest.TestCase):
 
     @patch("tools.headers_tool.requests.get")
     def test_hsts_negative_max_age_flagged_high(self, mock_get):
-        """Fix: a negative max-age is invalid per spec, not just "weak", so it
-        must be flagged distinctly from a low-but-valid value."""
         mock_get.return_value = _resp(200, {
             "Strict-Transport-Security": "max-age=-1",
         })
@@ -116,9 +112,6 @@ class TestHeadersAnalyzer(unittest.TestCase):
 
     @patch("tools.headers_tool.requests.get")
     def test_hsts_malformed_max_age_value_caught(self, mock_get):
-        """A non-numeric max-age (e.g. a malformed or hand-edited header)
-        must be caught by the except clause, not raise an uncaught
-        exception."""
         mock_get.return_value = _resp(200, {
             "Strict-Transport-Security": "max-age=notanumber",
         })
@@ -130,9 +123,6 @@ class TestHeadersAnalyzer(unittest.TestCase):
 
     @patch("tools.headers_tool.requests.get")
     def test_hsts_present_without_max_age_directive(self, mock_get):
-        """HSTS header present but with no max-age= substring at all
-        (e.g. just "includeSubDomains"), distinct from HSTS being
-        completely absent."""
         mock_get.return_value = _resp(200, {
             "Strict-Transport-Security": "includeSubDomains",
         })
@@ -144,10 +134,6 @@ class TestHeadersAnalyzer(unittest.TestCase):
 
     @patch("tools.headers_tool.requests.get")
     def test_hsts_missing_includesubdomains_upgrades_severity(self, mock_get):
-        """A valid, long max-age without includeSubDomains should still
-        be flagged (and the severity upgraded from the default "low"
-        to "medium" for the missing directive), not silently accepted
-        as fully clean."""
         mock_get.return_value = _resp(200, {
             "Strict-Transport-Security": "max-age=31536000",
         })
@@ -198,11 +184,6 @@ class TestHeadersAnalyzer(unittest.TestCase):
 
     @patch("tools.headers_tool.requests.get")
     def test_csp_missing_default_src_flagged_once(self, mock_get):
-        """Regression test for the redundant-check cleanup: a CSP with
-        neither default-src 'self' nor 'none' should be flagged exactly
-        once (the old code had two nested checks for the exact same
-        condition -- this verifies behavior is unchanged after removing
-        the dead duplicate, not just that it doesn't crash)."""
         mock_get.return_value = _resp(200, {
             "Content-Security-Policy": "script-src 'self'",
         })
@@ -229,7 +210,16 @@ class TestHeadersAnalyzer(unittest.TestCase):
         a header that appears more than once in a real response into one
         comma-joined value during parsing, verify the analysis logic
         correctly flags an unsafe directive even when it's not first in
-        an already-combined value."""
+        an already-combined value.
+
+        Note: this test's mock is built from a Python dict, so it can
+        only represent a value that is ALREADY combined into one string.
+        It tests the downstream CSP-parsing logic, not curl_cffi's
+        own merging mechanism. See
+        test_dict_headers_items_preserves_genuinely_duplicate_headers
+        for the test that covers the merging mechanism itself using
+        genuinely separate header entries.
+        """
         mock_get.return_value = _resp(200, {
             "Content-Security-Policy": "default-src 'self', script-src 'unsafe-inline'",
         })
@@ -237,6 +227,39 @@ class TestHeadersAnalyzer(unittest.TestCase):
         csp = result["headers"]["content-security-policy"]
         self.assertIn("default-src 'self'", csp["value"])
         self.assertIn("script-src 'unsafe-inline'", csp["value"])
+        self.assertEqual(csp["severity"], "high")
+
+    @patch("tools.headers_tool.requests.get")
+    def test_dict_headers_items_preserves_genuinely_duplicate_headers(self, mock_get):
+        """Regression test requested in review: the test above
+        (test_combined_duplicate_csp_directives_are_analyzed_correctly)
+        builds Headers() from a Python dict literal, but a dict
+        literal with a duplicate key collapses to a single entry in
+        plain Python before Headers() ever receives it, so that test
+        never actually exercised curl_cffi's own duplicate-merging
+        behavior, only the downstream CSP-parsing logic on a value
+        that was already a single combined string.
+
+        This test instead builds a real curl_cffi Headers object from
+        a list of tuples, which CAN represent two genuinely separate
+        entries for the same header name, unlike a dict, to directly
+        verify that dict(resp.headers.items()) in _walk_redirect_chain
+        does not silently collapse to just one of them, the way the
+        original urllib-based implementation did.
+        """
+        mock_resp = Mock()
+        mock_resp.status_code = 200
+        mock_resp.headers = Headers([
+            ("Content-Security-Policy", "script-src 'unsafe-inline'"),
+            ("Content-Security-Policy", "default-src 'self'"),
+        ])
+        mock_get.return_value = mock_resp
+
+        result = headers_analyzer("example.com")
+
+        csp = result["headers"]["content-security-policy"]
+        self.assertIn("script-src 'unsafe-inline'", csp["value"])
+        self.assertIn("default-src 'self'", csp["value"])
         self.assertEqual(csp["severity"], "high")
 
     @patch("tools.headers_tool.requests.get")
@@ -249,9 +272,6 @@ class TestHeadersAnalyzer(unittest.TestCase):
 
     @patch("tools.headers_tool.requests.get")
     def test_x_frame_options_unrecognized_value_flagged(self, mock_get):
-        """A value that's neither DENY nor SAMEORIGIN (e.g. a malformed
-        or non-standard directive) must be flagged, not silently treated
-        as acceptable just because the header is present."""
         mock_get.return_value = _resp(200, {"X-Frame-Options": "ALLOW-FROM https://example.com"})
         result = headers_analyzer("example.com")
         xfo = result["headers"]["x-frame-options"]
@@ -285,11 +305,6 @@ class TestHeadersAnalyzer(unittest.TestCase):
 
     @patch("tools.headers_tool.requests.get")
     def test_referrer_policy_weak_value_flagged(self, mock_get):
-        """A Referrer-Policy value that's present but not in the
-        recognized "good" list (e.g. "unsafe-url", which leaks the full
-        URL including path and query string cross-origin) must be
-        flagged as leaking more than necessary, not silently accepted
-        just because the header exists."""
         mock_get.return_value = _resp(200, {"Referrer-Policy": "unsafe-url"})
         result = headers_analyzer("example.com")
         rp = result["headers"]["referrer-policy"]
@@ -298,8 +313,7 @@ class TestHeadersAnalyzer(unittest.TestCase):
         self.assertEqual(rp["severity"], "medium")
 
     # ------------------------------------------------------------------
-    # Permissions-Policy content analysis (fix: presence-only -> low was
-    # treated as automatically "fine" regardless of content)
+    # Permissions-Policy content analysis
     # ------------------------------------------------------------------
 
     @patch("tools.headers_tool.requests.get")
@@ -333,10 +347,7 @@ class TestHeadersAnalyzer(unittest.TestCase):
         self.assertEqual(pp["severity"], "low")
 
     # ------------------------------------------------------------------
-    # WAF / bot-challenge detection (#62: "differences between browser
-    # and non-browser requests") -- confirmed via live testing that a
-    # site behind Cloudflare can serve a JS challenge page instead of
-    # the real site to a non-browser-fingerprinted client.
+    # WAF / bot-challenge detection
     # ------------------------------------------------------------------
 
     @patch("tools.headers_tool.requests.get")
@@ -352,10 +363,6 @@ class TestHeadersAnalyzer(unittest.TestCase):
 
     @patch("tools.headers_tool.requests.get")
     def test_normal_cloudflare_site_without_challenge_is_analyzed_normally(self, mock_get):
-        """Server: cloudflare alone must not trigger the challenge
-        rejection, only the explicit cf-mitigated: challenge signal
-        should. Plenty of legitimate sites run behind Cloudflare without
-        ever serving a challenge."""
         mock_get.return_value = _resp(200, {
             "Server": "cloudflare",
             "X-Frame-Options": "DENY",
@@ -366,11 +373,7 @@ class TestHeadersAnalyzer(unittest.TestCase):
         self.assertTrue(result["headers"]["x-frame-options"]["present"])
 
     # ------------------------------------------------------------------
-    # Full redirect-chain recovery (#62: "Redirect handling" / "Response
-    # selection"), each hop is fetched individually (allow_redirects=
-    # False) so its own headers are captured, not just the final
-    # destination's. A header present on an intermediate hop but absent
-    # (or different) on the final destination is now fully visible.
+    # Full redirect-chain recovery
     # ------------------------------------------------------------------
 
     @patch("tools.headers_tool.requests.get")
@@ -384,9 +387,6 @@ class TestHeadersAnalyzer(unittest.TestCase):
 
     @patch("tools.headers_tool.requests.get")
     def test_redirect_captures_each_hops_distinct_headers(self, mock_get):
-        """Root-cause fix: the redirect hop and the final hop
-        have DIFFERENT X-Frame-Options values, and both must be visible
-        in redirect_chain, not just the final one."""
         mock_get.side_effect = [
             _resp(301, {
                 "Location": "https://www.example.com/home",
@@ -408,16 +408,11 @@ class TestHeadersAnalyzer(unittest.TestCase):
         self.assertEqual(
             result["redirect_chain"][1]["headers"]["x-frame-options"], "DENY"
         )
-        # The final analysis must reflect the DESTINATION's header, not
-        # the redirect's.
         self.assertEqual(result["headers"]["x-frame-options"]["value"], "DENY")
         self.assertEqual(result["final_url"], "https://www.example.com/home")
 
     @patch("tools.headers_tool.requests.get")
     def test_relative_location_header_is_resolved(self, mock_get):
-        """A redirect's Location header is often a relative path, not a
-        full URL. It must be resolved against the current URL, not
-        treated as a literal (broken) next destination."""
         mock_get.side_effect = [
             _resp(301, {"Location": "/new-path"}),
             _resp(200, {"X-Frame-Options": "DENY"}),
@@ -427,14 +422,6 @@ class TestHeadersAnalyzer(unittest.TestCase):
 
     @patch("tools.headers_tool.requests.get")
     def test_self_redirecting_url_fails_explicitly(self, mock_get):
-        """Regression test for a bug found during final audit: a server
-        misconfigured to 301-redirect a URL to itself (a real pattern,
-        e.g. broken nginx/Apache redirect rules) would previously be
-        silently analyzed as if its 301 response were the real page,
-        reporting redirected=False (technically true by the old len(hops)
-        > 1 check, since the loop guard stopped the chain at 1 hop) while
-        actually surfacing the REDIRECT's own headers as the site's
-        configuration. Must now fail explicitly instead."""
         mock_get.return_value = _resp(301, {
             "Location": "https://example.com",
             "X-Frame-Options": "SAMEORIGIN",
@@ -442,19 +429,13 @@ class TestHeadersAnalyzer(unittest.TestCase):
         result = headers_analyzer("example.com")
         self.assertFalse(result["success"])
         self.assertIn("error", result)
-        # Must not contain a "headers" analysis key at all, there is no
-        # successful analysis to report.
         self.assertNotIn("headers", result)
 
     @patch("tools.headers_tool.requests.get")
     def test_redirect_loop_does_not_hang(self, mock_get):
-        """A redirect pointing back to an already-visited URL must stop
-        (not loop forever). And since it never resolves to real page
-        content, it must fail explicitly rather than silently analyzing
-        whichever redirect response it stopped on."""
         mock_get.side_effect = [
             _resp(301, {"Location": "https://example.com/b"}),
-            _resp(301, {"Location": "https://example.com"}),  # loops back
+            _resp(301, {"Location": "https://example.com"}),
         ]
         result = headers_analyzer("example.com")
         self.assertFalse(result["success"])
@@ -462,10 +443,6 @@ class TestHeadersAnalyzer(unittest.TestCase):
 
     @patch("tools.headers_tool.requests.get")
     def test_redirect_chain_caps_at_max_hops(self, mock_get):
-        """A long chain of redirects that never resolves to real content
-        must stop at a reasonable cap (bounded request count) and fail
-        explicitly, not silently analyze whichever redirect response
-        it happened to stop on as if it were the real page."""
         def make_redirect(i):
             return _resp(301, {"Location": f"https://example.com/{i}"})
         mock_get.side_effect = [make_redirect(i) for i in range(20)]
@@ -476,10 +453,6 @@ class TestHeadersAnalyzer(unittest.TestCase):
 
     @patch("tools.headers_tool.requests.get")
     def test_redirect_missing_location_header_stops_cleanly(self, mock_get):
-        """A 301/302 with no Location header is malformed and has no
-        real destination to analyze, must stop gracefully (not crash
-        on a None location) and fail explicitly rather than analyzing
-        the broken redirect response itself as if it were the page."""
         mock_get.return_value = _resp(301, {})
         result = headers_analyzer("example.com")
         self.assertFalse(result["success"])
@@ -507,14 +480,6 @@ class TestHeadersAnalyzer(unittest.TestCase):
 
     @patch("tools.headers_tool._walk_redirect_chain", return_value=[])
     def test_empty_hop_list_returns_failure(self, _):
-        """_walk_redirect_chain always appends at least one hop before
-        it can return via the real requests.get() call site (max_hops
-        defaults to 8, and `seen` always starts empty), so this branch
-        is unreachable through the public API today. It's kept as a
-        defensive guard in case _walk_redirect_chain's contract changes
-        later (e.g. max_hops becomes caller-configurable down to 0).
-        Tested here by patching the internal function directly, since
-        there's no way to trigger it through headers_analyzer()."""
         result = headers_analyzer("example.com")
         self.assertFalse(result["success"])
         self.assertIn("error", result)

--- a/tests/test_headers_tool.py
+++ b/tests/test_headers_tool.py
@@ -1,20 +1,33 @@
 import unittest
-from unittest.mock import patch, MagicMock
-import urllib.error
+from unittest.mock import patch, Mock
+from curl_cffi.requests.errors import RequestsError
+from curl_cffi.requests.headers import Headers
 from tools.headers_tool import headers_analyzer
 
 
-class TestHeadersAnalyzer(unittest.TestCase):
+def _resp(status_code: int, headers: dict):
+    """Build a mock curl_cffi response for a single hop.
 
-    def _make_response(self, headers: dict, final_url: str = "https://example.com/"):
-        """Helper to build a mock HTTP response."""
-        mock_resp = MagicMock()
-        mock_resp.headers = MagicMock()
-        mock_resp.headers.items.return_value = list(headers.items())
-        mock_resp.url = final_url
-        mock_resp.__enter__ = lambda s: s
-        mock_resp.__exit__ = MagicMock(return_value=False)
-        return mock_resp
+    Wraps headers in curl_cffi's real Headers class (not a plain dict)
+    -- Headers does case-insensitive lookups (e.g. .get("location")
+    matches a "Location" key), matching real response behavior. A plain
+    dict would silently fail that lookup and give false test failures
+    that look like a production bug but are actually just an inaccurate
+    mock.
+
+    headers is a plain dict on input, curl_cffi (like `requests`)
+    already combines a repeated header into one comma-joined value
+    during its own parsing, so by the time this tool sees resp.headers,
+    a duplicate-header scenario is already a single combined string,
+    not separate entries.
+    """
+    m = Mock()
+    m.status_code = status_code
+    m.headers = Headers(headers)
+    return m
+
+
+class TestHeadersAnalyzer(unittest.TestCase):
 
     # ------------------------------------------------------------------
     # Domain validation
@@ -30,12 +43,12 @@ class TestHeadersAnalyzer(unittest.TestCase):
         self.assertFalse(result["success"])
 
     # ------------------------------------------------------------------
-    # Successful response
+    # Successful response (single hop, no redirect)
     # ------------------------------------------------------------------
 
-    @patch("tools.headers_tool.urllib.request.OpenerDirector.open")
-    def test_success_returns_correct_structure(self, mock_open):
-        mock_open.return_value = self._make_response({
+    @patch("tools.headers_tool.requests.get")
+    def test_success_returns_correct_structure(self, mock_get):
+        mock_get.return_value = _resp(200, {
             "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
             "X-Frame-Options": "DENY",
             "X-Content-Type-Options": "nosniff",
@@ -44,10 +57,11 @@ class TestHeadersAnalyzer(unittest.TestCase):
         self.assertTrue(result["success"])
         self.assertIn("domain", result)
         self.assertIn("headers", result)
+        self.assertIn("redirect_chain", result)
 
-    @patch("tools.headers_tool.urllib.request.OpenerDirector.open")
-    def test_hsts_present_and_valid(self, mock_open):
-        mock_open.return_value = self._make_response({
+    @patch("tools.headers_tool.requests.get")
+    def test_hsts_present_and_valid(self, mock_get):
+        mock_get.return_value = _resp(200, {
             "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         })
         result = headers_analyzer("example.com")
@@ -56,17 +70,17 @@ class TestHeadersAnalyzer(unittest.TestCase):
         self.assertEqual(hsts["issue"], "None")
         self.assertEqual(hsts["severity"], "low")
 
-    @patch("tools.headers_tool.urllib.request.OpenerDirector.open")
-    def test_hsts_missing_flagged_as_high(self, mock_open):
-        mock_open.return_value = self._make_response({})
+    @patch("tools.headers_tool.requests.get")
+    def test_hsts_missing_flagged_as_high(self, mock_get):
+        mock_get.return_value = _resp(200, {})
         result = headers_analyzer("example.com")
         hsts = result["headers"]["strict-transport-security"]
         self.assertFalse(hsts["present"])
         self.assertEqual(hsts["severity"], "high")
 
-    @patch("tools.headers_tool.urllib.request.OpenerDirector.open")
-    def test_hsts_low_max_age_flagged(self, mock_open):
-        mock_open.return_value = self._make_response({
+    @patch("tools.headers_tool.requests.get")
+    def test_hsts_low_max_age_flagged_medium(self, mock_get):
+        mock_get.return_value = _resp(200, {
             "Strict-Transport-Security": "max-age=3600",
         })
         result = headers_analyzer("example.com")
@@ -75,17 +89,85 @@ class TestHeadersAnalyzer(unittest.TestCase):
         self.assertIn("max-age", hsts["issue"])
         self.assertEqual(hsts["severity"], "medium")
 
-    @patch("tools.headers_tool.urllib.request.OpenerDirector.open")
-    def test_csp_missing_flagged(self, mock_open):
-        mock_open.return_value = self._make_response({})
+    @patch("tools.headers_tool.requests.get")
+    def test_hsts_max_age_zero_flagged_high(self, mock_get):
+        """Fix: max-age=0 actively disables HSTS (a real rollback
+        technique), so it must be flagged as high severity, not lumped
+        in with merely-short-but-nonzero durations as medium."""
+        mock_get.return_value = _resp(200, {
+            "Strict-Transport-Security": "max-age=0",
+        })
+        result = headers_analyzer("example.com")
+        hsts = result["headers"]["strict-transport-security"]
+        self.assertEqual(hsts["severity"], "high")
+        self.assertIn("disables", hsts["issue"])
+
+    @patch("tools.headers_tool.requests.get")
+    def test_hsts_negative_max_age_flagged_high(self, mock_get):
+        """Fix: a negative max-age is invalid per spec, not just "weak", so it
+        must be flagged distinctly from a low-but-valid value."""
+        mock_get.return_value = _resp(200, {
+            "Strict-Transport-Security": "max-age=-1",
+        })
+        result = headers_analyzer("example.com")
+        hsts = result["headers"]["strict-transport-security"]
+        self.assertEqual(hsts["severity"], "high")
+        self.assertIn("invalid", hsts["issue"])
+
+    @patch("tools.headers_tool.requests.get")
+    def test_hsts_malformed_max_age_value_caught(self, mock_get):
+        """A non-numeric max-age (e.g. a malformed or hand-edited header)
+        must be caught by the except clause, not raise an uncaught
+        exception."""
+        mock_get.return_value = _resp(200, {
+            "Strict-Transport-Security": "max-age=notanumber",
+        })
+        result = headers_analyzer("example.com")
+        hsts = result["headers"]["strict-transport-security"]
+        self.assertTrue(hsts["present"])
+        self.assertIn("Could not parse", hsts["issue"])
+        self.assertEqual(hsts["severity"], "medium")
+
+    @patch("tools.headers_tool.requests.get")
+    def test_hsts_present_without_max_age_directive(self, mock_get):
+        """HSTS header present but with no max-age= substring at all
+        (e.g. just "includeSubDomains"), distinct from HSTS being
+        completely absent."""
+        mock_get.return_value = _resp(200, {
+            "Strict-Transport-Security": "includeSubDomains",
+        })
+        result = headers_analyzer("example.com")
+        hsts = result["headers"]["strict-transport-security"]
+        self.assertTrue(hsts["present"])
+        self.assertIn("max-age directive is missing", hsts["issue"])
+        self.assertEqual(hsts["severity"], "high")
+
+    @patch("tools.headers_tool.requests.get")
+    def test_hsts_missing_includesubdomains_upgrades_severity(self, mock_get):
+        """A valid, long max-age without includeSubDomains should still
+        be flagged (and the severity upgraded from the default "low"
+        to "medium" for the missing directive), not silently accepted
+        as fully clean."""
+        mock_get.return_value = _resp(200, {
+            "Strict-Transport-Security": "max-age=31536000",
+        })
+        result = headers_analyzer("example.com")
+        hsts = result["headers"]["strict-transport-security"]
+        self.assertTrue(hsts["present"])
+        self.assertIn("includeSubDomains", hsts["issue"])
+        self.assertEqual(hsts["severity"], "medium")
+
+    @patch("tools.headers_tool.requests.get")
+    def test_csp_missing_flagged(self, mock_get):
+        mock_get.return_value = _resp(200, {})
         result = headers_analyzer("example.com")
         csp = result["headers"]["content-security-policy"]
         self.assertFalse(csp["present"])
         self.assertEqual(csp["severity"], "high")
 
-    @patch("tools.headers_tool.urllib.request.OpenerDirector.open")
-    def test_csp_unsafe_inline_flagged(self, mock_open):
-        mock_open.return_value = self._make_response({
+    @patch("tools.headers_tool.requests.get")
+    def test_csp_unsafe_inline_flagged(self, mock_get):
+        mock_get.return_value = _resp(200, {
             "Content-Security-Policy": "default-src 'self'; script-src 'unsafe-inline'",
         })
         result = headers_analyzer("example.com")
@@ -94,9 +176,45 @@ class TestHeadersAnalyzer(unittest.TestCase):
         self.assertIn("unsafe-inline", csp["issue"])
         self.assertEqual(csp["severity"], "high")
 
-    @patch("tools.headers_tool.urllib.request.OpenerDirector.open")
-    def test_csp_report_only_mode_detected(self, mock_open):
-        mock_open.return_value = self._make_response({
+    @patch("tools.headers_tool.requests.get")
+    def test_csp_unsafe_eval_flagged(self, mock_get):
+        mock_get.return_value = _resp(200, {
+            "Content-Security-Policy": "default-src 'self'; script-src 'unsafe-eval'",
+        })
+        result = headers_analyzer("example.com")
+        csp = result["headers"]["content-security-policy"]
+        self.assertIn("unsafe-eval", csp["issue"])
+        self.assertEqual(csp["severity"], "high")
+
+    @patch("tools.headers_tool.requests.get")
+    def test_csp_wildcard_source_flagged(self, mock_get):
+        mock_get.return_value = _resp(200, {
+            "Content-Security-Policy": "default-src *",
+        })
+        result = headers_analyzer("example.com")
+        csp = result["headers"]["content-security-policy"]
+        self.assertIn("Wildcard", csp["issue"])
+        self.assertEqual(csp["severity"], "high")
+
+    @patch("tools.headers_tool.requests.get")
+    def test_csp_missing_default_src_flagged_once(self, mock_get):
+        """Regression test for the redundant-check cleanup: a CSP with
+        neither default-src 'self' nor 'none' should be flagged exactly
+        once (the old code had two nested checks for the exact same
+        condition -- this verifies behavior is unchanged after removing
+        the dead duplicate, not just that it doesn't crash)."""
+        mock_get.return_value = _resp(200, {
+            "Content-Security-Policy": "script-src 'self'",
+        })
+        result = headers_analyzer("example.com")
+        csp = result["headers"]["content-security-policy"]
+        issue_count = csp["issue"].count("No restrictive default-src")
+        self.assertEqual(issue_count, 1)
+        self.assertEqual(csp["severity"], "medium")
+
+    @patch("tools.headers_tool.requests.get")
+    def test_csp_report_only_mode_detected(self, mock_get):
+        mock_get.return_value = _resp(200, {
             "Content-Security-Policy-Report-Only": "default-src 'self'",
         })
         result = headers_analyzer("example.com")
@@ -105,47 +223,303 @@ class TestHeadersAnalyzer(unittest.TestCase):
         self.assertIn("report-only mode", csp["issue"])
         self.assertEqual(csp["severity"], "medium")
 
-    @patch("tools.headers_tool.urllib.request.OpenerDirector.open")
-    def test_x_frame_options_deny_accepted(self, mock_open):
-        mock_open.return_value = self._make_response({
-            "X-Frame-Options": "DENY",
+    @patch("tools.headers_tool.requests.get")
+    def test_combined_duplicate_csp_directives_are_analyzed_correctly(self, mock_get):
+        """curl_cffi (like `requests` and like DevTools) already combines
+        a header that appears more than once in a real response into one
+        comma-joined value during parsing, verify the analysis logic
+        correctly flags an unsafe directive even when it's not first in
+        an already-combined value."""
+        mock_get.return_value = _resp(200, {
+            "Content-Security-Policy": "default-src 'self', script-src 'unsafe-inline'",
         })
+        result = headers_analyzer("example.com")
+        csp = result["headers"]["content-security-policy"]
+        self.assertIn("default-src 'self'", csp["value"])
+        self.assertIn("script-src 'unsafe-inline'", csp["value"])
+        self.assertEqual(csp["severity"], "high")
+
+    @patch("tools.headers_tool.requests.get")
+    def test_x_frame_options_deny_accepted(self, mock_get):
+        mock_get.return_value = _resp(200, {"X-Frame-Options": "DENY"})
         result = headers_analyzer("example.com")
         xfo = result["headers"]["x-frame-options"]
         self.assertTrue(xfo["present"])
         self.assertEqual(xfo["issue"], "None")
 
-    @patch("tools.headers_tool.urllib.request.OpenerDirector.open")
-    def test_x_content_type_options_nosniff_accepted(self, mock_open):
-        mock_open.return_value = self._make_response({
-            "X-Content-Type-Options": "nosniff",
-        })
+    @patch("tools.headers_tool.requests.get")
+    def test_x_frame_options_unrecognized_value_flagged(self, mock_get):
+        """A value that's neither DENY nor SAMEORIGIN (e.g. a malformed
+        or non-standard directive) must be flagged, not silently treated
+        as acceptable just because the header is present."""
+        mock_get.return_value = _resp(200, {"X-Frame-Options": "ALLOW-FROM https://example.com"})
+        result = headers_analyzer("example.com")
+        xfo = result["headers"]["x-frame-options"]
+        self.assertTrue(xfo["present"])
+        self.assertIn("Unexpected value", xfo["issue"])
+        self.assertEqual(xfo["severity"], "medium")
+
+    @patch("tools.headers_tool.requests.get")
+    def test_x_content_type_options_nosniff_accepted(self, mock_get):
+        mock_get.return_value = _resp(200, {"X-Content-Type-Options": "nosniff"})
         result = headers_analyzer("example.com")
         xcto = result["headers"]["x-content-type-options"]
         self.assertTrue(xcto["present"])
         self.assertEqual(xcto["issue"], "None")
 
-    @patch("tools.headers_tool.urllib.request.OpenerDirector.open")
-    def test_server_header_flagged_as_disclosure(self, mock_open):
-        mock_open.return_value = self._make_response({
-            "Server": "Apache/2.4.41",
-        })
+    @patch("tools.headers_tool.requests.get")
+    def test_server_header_flagged_as_disclosure(self, mock_get):
+        mock_get.return_value = _resp(200, {"Server": "Apache/2.4.41"})
         result = headers_analyzer("example.com")
         self.assertIn("server", result["headers"])
         self.assertIn("exposes technology", result["headers"]["server"]["issue"])
+
+    @patch("tools.headers_tool.requests.get")
+    def test_referrer_policy_good_value_accepted(self, mock_get):
+        mock_get.return_value = _resp(200, {"Referrer-Policy": "strict-origin-when-cross-origin"})
+        result = headers_analyzer("example.com")
+        rp = result["headers"]["referrer-policy"]
+        self.assertTrue(rp["present"])
+        self.assertEqual(rp["issue"], "None")
+        self.assertEqual(rp["severity"], "low")
+
+    @patch("tools.headers_tool.requests.get")
+    def test_referrer_policy_weak_value_flagged(self, mock_get):
+        """A Referrer-Policy value that's present but not in the
+        recognized "good" list (e.g. "unsafe-url", which leaks the full
+        URL including path and query string cross-origin) must be
+        flagged as leaking more than necessary, not silently accepted
+        just because the header exists."""
+        mock_get.return_value = _resp(200, {"Referrer-Policy": "unsafe-url"})
+        result = headers_analyzer("example.com")
+        rp = result["headers"]["referrer-policy"]
+        self.assertTrue(rp["present"])
+        self.assertIn("may leak", rp["issue"])
+        self.assertEqual(rp["severity"], "medium")
+
+    # ------------------------------------------------------------------
+    # Permissions-Policy content analysis (fix: presence-only -> low was
+    # treated as automatically "fine" regardless of content)
+    # ------------------------------------------------------------------
+
+    @patch("tools.headers_tool.requests.get")
+    def test_permissions_policy_restrictive_clean(self, mock_get):
+        mock_get.return_value = _resp(200, {
+            "Permissions-Policy": "camera=(), microphone=()",
+        })
+        result = headers_analyzer("example.com")
+        pp = result["headers"]["permissions-policy"]
+        self.assertTrue(pp["present"])
+        self.assertEqual(pp["issue"], "None")
+        self.assertEqual(pp["severity"], "low")
+
+    @patch("tools.headers_tool.requests.get")
+    def test_permissions_policy_wildcard_sensitive_feature_flagged(self, mock_get):
+        mock_get.return_value = _resp(200, {
+            "Permissions-Policy": "camera=*, geolocation=()",
+        })
+        result = headers_analyzer("example.com")
+        pp = result["headers"]["permissions-policy"]
+        self.assertTrue(pp["present"])
+        self.assertIn("camera", pp["issue"])
+        self.assertEqual(pp["severity"], "medium")
+
+    @patch("tools.headers_tool.requests.get")
+    def test_permissions_policy_missing_flagged_low(self, mock_get):
+        mock_get.return_value = _resp(200, {})
+        result = headers_analyzer("example.com")
+        pp = result["headers"]["permissions-policy"]
+        self.assertFalse(pp["present"])
+        self.assertEqual(pp["severity"], "low")
+
+    # ------------------------------------------------------------------
+    # WAF / bot-challenge detection (#62: "differences between browser
+    # and non-browser requests") -- confirmed via live testing that a
+    # site behind Cloudflare can serve a JS challenge page instead of
+    # the real site to a non-browser-fingerprinted client.
+    # ------------------------------------------------------------------
+
+    @patch("tools.headers_tool.requests.get")
+    def test_cloudflare_challenge_page_is_rejected_not_analyzed(self, mock_get):
+        mock_get.return_value = _resp(200, {
+            "Server": "cloudflare",
+            "cf-mitigated": "challenge",
+            "X-Frame-Options": "SAMEORIGIN",
+        })
+        result = headers_analyzer("example.com")
+        self.assertFalse(result["success"])
+        self.assertIn("challenge", result["error"].lower())
+
+    @patch("tools.headers_tool.requests.get")
+    def test_normal_cloudflare_site_without_challenge_is_analyzed_normally(self, mock_get):
+        """Server: cloudflare alone must not trigger the challenge
+        rejection, only the explicit cf-mitigated: challenge signal
+        should. Plenty of legitimate sites run behind Cloudflare without
+        ever serving a challenge."""
+        mock_get.return_value = _resp(200, {
+            "Server": "cloudflare",
+            "X-Frame-Options": "DENY",
+            "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        })
+        result = headers_analyzer("example.com")
+        self.assertTrue(result["success"])
+        self.assertTrue(result["headers"]["x-frame-options"]["present"])
+
+    # ------------------------------------------------------------------
+    # Full redirect-chain recovery (#62: "Redirect handling" / "Response
+    # selection"), each hop is fetched individually (allow_redirects=
+    # False) so its own headers are captured, not just the final
+    # destination's. A header present on an intermediate hop but absent
+    # (or different) on the final destination is now fully visible.
+    # ------------------------------------------------------------------
+
+    @patch("tools.headers_tool.requests.get")
+    def test_no_redirect_single_hop_chain(self, mock_get):
+        mock_get.return_value = _resp(200, {"X-Frame-Options": "DENY"})
+        result = headers_analyzer("example.com")
+        self.assertFalse(result["redirected"])
+        self.assertEqual(len(result["redirect_chain"]), 1)
+        self.assertEqual(result["final_url"], "https://example.com")
+        self.assertEqual(result["requested_url"], "https://example.com")
+
+    @patch("tools.headers_tool.requests.get")
+    def test_redirect_captures_each_hops_distinct_headers(self, mock_get):
+        """Root-cause fix: the redirect hop and the final hop
+        have DIFFERENT X-Frame-Options values, and both must be visible
+        in redirect_chain, not just the final one."""
+        mock_get.side_effect = [
+            _resp(301, {
+                "Location": "https://www.example.com/home",
+                "X-Frame-Options": "SAMEORIGIN",
+            }),
+            _resp(200, {
+                "X-Frame-Options": "DENY",
+            }),
+        ]
+        result = headers_analyzer("example.com")
+
+        self.assertTrue(result["redirected"])
+        self.assertEqual(len(result["redirect_chain"]), 2)
+        self.assertEqual(result["redirect_chain"][0]["status_code"], 301)
+        self.assertEqual(
+            result["redirect_chain"][0]["headers"]["x-frame-options"], "SAMEORIGIN"
+        )
+        self.assertEqual(result["redirect_chain"][1]["status_code"], 200)
+        self.assertEqual(
+            result["redirect_chain"][1]["headers"]["x-frame-options"], "DENY"
+        )
+        # The final analysis must reflect the DESTINATION's header, not
+        # the redirect's.
+        self.assertEqual(result["headers"]["x-frame-options"]["value"], "DENY")
+        self.assertEqual(result["final_url"], "https://www.example.com/home")
+
+    @patch("tools.headers_tool.requests.get")
+    def test_relative_location_header_is_resolved(self, mock_get):
+        """A redirect's Location header is often a relative path, not a
+        full URL. It must be resolved against the current URL, not
+        treated as a literal (broken) next destination."""
+        mock_get.side_effect = [
+            _resp(301, {"Location": "/new-path"}),
+            _resp(200, {"X-Frame-Options": "DENY"}),
+        ]
+        result = headers_analyzer("example.com")
+        self.assertEqual(result["final_url"], "https://example.com/new-path")
+
+    @patch("tools.headers_tool.requests.get")
+    def test_self_redirecting_url_fails_explicitly(self, mock_get):
+        """Regression test for a bug found during final audit: a server
+        misconfigured to 301-redirect a URL to itself (a real pattern,
+        e.g. broken nginx/Apache redirect rules) would previously be
+        silently analyzed as if its 301 response were the real page,
+        reporting redirected=False (technically true by the old len(hops)
+        > 1 check, since the loop guard stopped the chain at 1 hop) while
+        actually surfacing the REDIRECT's own headers as the site's
+        configuration. Must now fail explicitly instead."""
+        mock_get.return_value = _resp(301, {
+            "Location": "https://example.com",
+            "X-Frame-Options": "SAMEORIGIN",
+        })
+        result = headers_analyzer("example.com")
+        self.assertFalse(result["success"])
+        self.assertIn("error", result)
+        # Must not contain a "headers" analysis key at all, there is no
+        # successful analysis to report.
+        self.assertNotIn("headers", result)
+
+    @patch("tools.headers_tool.requests.get")
+    def test_redirect_loop_does_not_hang(self, mock_get):
+        """A redirect pointing back to an already-visited URL must stop
+        (not loop forever). And since it never resolves to real page
+        content, it must fail explicitly rather than silently analyzing
+        whichever redirect response it stopped on."""
+        mock_get.side_effect = [
+            _resp(301, {"Location": "https://example.com/b"}),
+            _resp(301, {"Location": "https://example.com"}),  # loops back
+        ]
+        result = headers_analyzer("example.com")
+        self.assertFalse(result["success"])
+        self.assertIn("loop", result["error"].lower())
+
+    @patch("tools.headers_tool.requests.get")
+    def test_redirect_chain_caps_at_max_hops(self, mock_get):
+        """A long chain of redirects that never resolves to real content
+        must stop at a reasonable cap (bounded request count) and fail
+        explicitly, not silently analyze whichever redirect response
+        it happened to stop on as if it were the real page."""
+        def make_redirect(i):
+            return _resp(301, {"Location": f"https://example.com/{i}"})
+        mock_get.side_effect = [make_redirect(i) for i in range(20)]
+        result = headers_analyzer("example.com")
+        self.assertFalse(result["success"])
+        self.assertLessEqual(mock_get.call_count, 8)
+        self.assertIn("hop", result["error"].lower())
+
+    @patch("tools.headers_tool.requests.get")
+    def test_redirect_missing_location_header_stops_cleanly(self, mock_get):
+        """A 301/302 with no Location header is malformed and has no
+        real destination to analyze, must stop gracefully (not crash
+        on a None location) and fail explicitly rather than analyzing
+        the broken redirect response itself as if it were the page."""
+        mock_get.return_value = _resp(301, {})
+        result = headers_analyzer("example.com")
+        self.assertFalse(result["success"])
+        self.assertIn("error", result)
+
+    @patch("tools.headers_tool.requests.get")
+    def test_domain_in_result_reflects_final_destination(self, mock_get):
+        mock_get.side_effect = [
+            _resp(301, {"Location": "https://www.example.com/"}),
+            _resp(200, {}),
+        ]
+        result = headers_analyzer("example.com")
+        self.assertEqual(result["domain"], "www.example.com")
 
     # ------------------------------------------------------------------
     # Error handling
     # ------------------------------------------------------------------
 
-    @patch("tools.headers_tool.urllib.request.OpenerDirector.open",
-           side_effect=urllib.error.URLError("Connection refused"))
+    @patch("tools.headers_tool.requests.get",
+           side_effect=RequestsError("Failed to connect"))
     def test_connection_error_returns_failure(self, _):
         result = headers_analyzer("example.com")
         self.assertFalse(result["success"])
         self.assertIn("Connection failed", result["error"])
 
-    @patch("tools.headers_tool.urllib.request.OpenerDirector.open",
+    @patch("tools.headers_tool._walk_redirect_chain", return_value=[])
+    def test_empty_hop_list_returns_failure(self, _):
+        """_walk_redirect_chain always appends at least one hop before
+        it can return via the real requests.get() call site (max_hops
+        defaults to 8, and `seen` always starts empty), so this branch
+        is unreachable through the public API today. It's kept as a
+        defensive guard in case _walk_redirect_chain's contract changes
+        later (e.g. max_hops becomes caller-configurable down to 0).
+        Tested here by patching the internal function directly, since
+        there's no way to trigger it through headers_analyzer()."""
+        result = headers_analyzer("example.com")
+        self.assertFalse(result["success"])
+        self.assertIn("error", result)
+
+    @patch("tools.headers_tool.requests.get",
            side_effect=Exception("Unexpected error"))
     def test_unexpected_exception_returns_failure(self, _):
         result = headers_analyzer("example.com")

--- a/tools/headers_tool.py
+++ b/tools/headers_tool.py
@@ -5,12 +5,65 @@ misconfigurations with severity ratings.
 """
 from __future__ import annotations
 
-import urllib.request
-import urllib.error
-import ssl
-from typing import Any
+from urllib.parse import urljoin
+from curl_cffi import requests
+from curl_cffi.requests.errors import RequestsError
+from typing import Any, List, Dict
 
 from utils.helpers import is_valid_domain
+
+_REDIRECT_STATUSES = (301, 302, 303, 307, 308)
+_MAX_REDIRECT_HOPS = 8
+
+# Sensitive Permissions-Policy features worth flagging when wildcarded
+# to all origins. Not exhaustive, these are the ones with the most
+# direct privacy/security impact if left unrestricted.
+_SENSITIVE_PERMISSIONS_FEATURES = (
+    "camera", "microphone", "geolocation", "payment", "usb",
+)
+
+
+def _walk_redirect_chain(url: str, max_hops: int = _MAX_REDIRECT_HOPS) -> List[Dict[str, Any]]:
+    """Manually follow redirects one hop at a time, capturing each
+    response's status and headers along the way.
+
+    curl_cffi's built-in allow_redirects=True (like every other HTTP
+    client's auto-follow) only ever surfaces the FINAL response. If an
+    intermediate hop, the redirect response itself carries
+    different security headers than the destination ( many sites apply
+    a baseline header set at a load-balancer/WAF layer that issues
+    the redirect, then different page-specific headers on the destination),
+    that's invisible with auto-follow. This was a confirmed, real source
+    of "differs from DevTools" reports, since DevTools shows every hop
+    in the chain as a separate entry.
+    """
+    hops: List[Dict[str, Any]] = []
+    current_url = url
+    seen = set()
+
+    while len(hops) < max_hops:
+        if current_url in seen:
+            break  # redirect loop guard
+        seen.add(current_url)
+
+        resp = requests.get(
+            current_url, timeout=10, impersonate="chrome", allow_redirects=False
+        )
+        hops.append({
+            "url": current_url,
+            "status_code": resp.status_code,
+            "headers": dict(resp.headers.items()),
+        })
+
+        if resp.status_code in _REDIRECT_STATUSES:
+            location = resp.headers.get("location")
+            if not location:
+                break
+            current_url = urljoin(current_url, location)
+            continue
+        break
+
+    return hops
 
 
 def headers_analyzer(domain: str) -> dict:
@@ -33,25 +86,81 @@ def headers_analyzer(domain: str) -> dict:
     if not is_valid_domain(domain):
         return {"success": False, "error": "Invalid domain format"}
 
-    url = f"https://{domain}"
+    requested_url = f"https://{domain}"
 
     try:
-        ctx = ssl.create_default_context()
-        ctx.check_hostname = False
-        ctx.verify_mode = ssl.CERT_NONE
-        req = urllib.request.Request(url, headers={"User-Agent": "AynOps-HeadersAnalyzer/1.0"})
-        # Build an opener that follows redirects (HTTPRedirectHandler is default,
-        # but we explicitly ensure it's included) and captures the FINAL response
-        opener = urllib.request.build_opener(
-            urllib.request.HTTPSHandler(context=ctx),
-            urllib.request.HTTPRedirectHandler(),
-        )
-        with opener.open(req, timeout=10) as resp:
-            # resp.url gives us the final URL after redirects
-            domain = resp.url.split("/")[2]
-            # Normalize all header keys to lowercase for consistent lookup
-            raw_headers = {k.lower(): v for k, v in resp.headers.items()}
-    except urllib.error.URLError as e:
+        # impersonate="chrome" matches a real Chrome TLS fingerprint and
+        # negotiates modern HTTP (h2/h3) instead of a bare-Python TLS
+        # signature over HTTP/1.1. Many sites behind a WAF (Cloudflare
+        # especially) serve a JS bot-challenge page instead of the real
+        # site to clients that don't look like a real browser at the
+        # TLS/protocol level, confirmed against a real production site:
+        # a plain non-impersonated client got Cloudflare's challenge page
+        # (cf-mitigated: challenge) with its own unrelated security
+        # headers, while impersonate="chrome" reached the real site. Same
+        # library/pattern already used in crt_sh_tool.py for this reason.
+        hops = _walk_redirect_chain(requested_url)
+
+        if not hops:
+            return {"success": False, "error": "No response received"}
+
+        final_hop = hops[-1]
+
+        # If the chain ends ON a redirect status, we never actually reached
+        # real page content, this happens when a redirect loop is
+        # detected (e.g. a misconfigured server that 301s to itself) or
+        # when the hop cap is hit mid-chain. Confirmed via testing: without
+        # this check, the tool would silently analyze the REDIRECT
+        # response's own headers (often minimal/unrelated to the page) as
+        # if they were the site's real security configuration, and report
+        # redirected=False even though a redirect demonstrably occurred.
+        if final_hop["status_code"] in _REDIRECT_STATUSES:
+            return {
+                "success": False,
+                "error": (
+                    f"Could not reach final page content -- redirect chain "
+                    f"did not resolve (stopped after {len(hops)} hop(s) at "
+                    f"a {final_hop['status_code']} response, either due to "
+                    f"a redirect loop or exceeding the {_MAX_REDIRECT_HOPS}-hop "
+                    f"limit). The headers on that response are not the "
+                    f"site's actual configuration."
+                ),
+            }
+
+        final_url = final_hop["url"]
+        domain = final_url.split("/")[2]
+        redirected = len(hops) > 1
+
+        # curl_cffi (like the `requests` library it mirrors) already
+        # combines a header that appears more than once in a response into
+        # one comma-joined value while parsing, matching what DevTools
+        # displays. This matters because a header appearing more than once
+        # (e.g. two Content-Security-Policy directives layered from
+        # different sources, a CDN and the origin server) must not be
+        # silently collapsed down to just one of them; every combined
+        # directive has to be visible for the analysis below to be
+        # accurate.
+        raw_headers = {k.lower(): v for k, v in final_hop["headers"].items()}
+
+        # Defensive check: if a WAF challenge still gets through despite
+        # impersonation (e.g. a stricter Cloudflare policy, or a different
+        # provider), its headers belong to the challenge page, not the
+        # site. Analyzing them as if they were the site's real security
+        # posture would be actively misleading. cf-mitigated is Cloudflare's
+        # own signal for this; confirmed present on a real challenge response
+        # observed during investigation.
+        if raw_headers.get("cf-mitigated") == "challenge":
+            return {
+                "success": False,
+                "error": (
+                    "Received a bot-detection challenge page instead of the "
+                    "real site (Cloudflare challenge detected). Headers from "
+                    "a challenge page do not reflect the site's actual "
+                    "configuration, so no analysis was performed."
+                ),
+            }
+
+    except RequestsError as e:
         return {"success": False, "error": f"Connection failed: {str(e)}"}
     except Exception as e:
         return {"success": False, "error": str(e)}
@@ -67,7 +176,13 @@ def headers_analyzer(domain: str) -> dict:
         if "max-age=" in hsts_lower:
             try:
                 max_age = int(hsts_lower.split("max-age=")[1].split(";")[0].strip())
-                if max_age < 31536000:
+                if max_age < 0:
+                    issues.append(f"max-age is {max_age}, which is invalid (must be non-negative)")
+                    severity = "high"
+                elif max_age == 0:
+                    issues.append("max-age is 0 — this actively disables HSTS, removing protection")
+                    severity = "high"
+                elif max_age < 31536000:
                     issues.append(f"max-age is {max_age}, recommend 31536000 (1 year)")
                     severity = "medium"
             except (ValueError, IndexError):
@@ -78,7 +193,8 @@ def headers_analyzer(domain: str) -> dict:
             severity = "high"
         if "includesubdomains" not in hsts_lower:
             issues.append("includeSubDomains directive is missing")
-            severity = "medium"
+            if severity == "low":
+                severity = "medium"
         headers["strict-transport-security"] = {
             "present": True,
             "value": hsts,
@@ -114,11 +230,13 @@ def headers_analyzer(domain: str) -> dict:
         if "default-src *" in csp_lower or "script-src *" in csp_lower:
             issues.append("Wildcard (*) source defeats the purpose of CSP")
             severity = "high"
+        # A CSP without a restrictive default-src (neither 'self' nor
+        # 'none') leaves an implicit fallback that's effectively
+        # unrestricted for any directive not explicitly listed.
         if "default-src 'none'" not in csp_lower and "default-src 'self'" not in csp_lower:
-            if not any(d in csp_lower for d in ["default-src 'self'", "default-src 'none'"]):
-                issues.append("No restrictive default-src directive found")
-                if severity == "low":
-                    severity = "medium"
+            issues.append("No restrictive default-src directive found")
+            if severity == "low":
+                severity = "medium"
         if report_only:
             issues.insert(0, "CSP is report-only mode — violations are reported but not enforced")
             if severity == "low":
@@ -210,11 +328,23 @@ def headers_analyzer(domain: str) -> dict:
     # --- Permissions-Policy ---
     pp = raw_headers.get("permissions-policy", "")
     if pp:
+        pp_lower = pp.lower()
+        issues = []
+        severity = "low"
+        # Previously: presence alone was treated as "issue: None, severity:
+        # low", regardless of content. Unlike every other header in this
+        # file, which evaluates actual values, not just presence. A policy
+        # wildcarding a sensitive feature to all origins (e.g. "camera=*")
+        # provides essentially no restriction despite being "present".
+        for feature in _SENSITIVE_PERMISSIONS_FEATURES:
+            if f"{feature}=*" in pp_lower:
+                issues.append(f"'{feature}' is granted to all origins (wildcard) — consider restricting")
+                severity = "medium"
         headers["permissions-policy"] = {
             "present": True,
             "value": pp[:100] + ("..." if len(pp) > 100 else ""),
-            "issue": "None",
-            "severity": "low",
+            "issue": "; ".join(issues) if issues else "None",
+            "severity": severity,
         }
     else:
         headers["permissions-policy"] = {
@@ -235,4 +365,19 @@ def headers_analyzer(domain: str) -> dict:
                 "severity": "low",
             }
 
-    return {"success": True, "domain": domain, "headers": headers}
+    return {
+        "success": True,
+        "domain": domain,
+        "requested_url": requested_url,
+        "final_url": final_url,
+        "redirected": redirected,
+        "redirect_chain": [
+            {
+                "url": h["url"],
+                "status_code": h["status_code"],
+                "headers": {k.lower(): v for k, v in h["headers"].items()},
+            }
+            for h in hops
+        ],
+        "headers": headers,
+    }


### PR DESCRIPTION
Related to #62 (partial fix — see "Does not resolve" below)

## Investigation summary

Issue named 6 candidate causes. Investigated each with live testing against real sites:

| Candidate cause | Status |
|---|---|
| Header normalization/parsing | ✅ Fixed |
| Browser vs non-browser requests | 🟡 Partially fixed — Cloudflare confirmed, other WAF providers untested |
| Redirect handling | ✅ Fixed (full per-hop capture) |
| Response selection | ✅ Fixed (same change as above) |
| Header collection | ✅ Fixed (fetch layer replaced) |
| Analysis logic | 🟡 Partially fixed — 3 bugs audited/fixed, but scoring still only runs on the final hop |

## Root causes confirmed

**1. Duplicate-header overwrite.**
`resp.headers.items()` over raw urllib/http.client yields one tuple per occurrence of a repeated header, the old dict comprehension silently kept only the last one. Validated via a real socket-level response with two CSP headers, and cross-checked against the `requests` library (which auto-combines), confirming this diverges from what both `requests` and DevTools show.

**2. WAF/bot-challenge blocking.**
Confirmed against npmjs.com, which is Cloudflare-fronted: a plain client gets served Cloudflare's "Just a moment..." challenge page (`cf-mitigated: challenge`) with its own unrelated headers (`x-frame-options: SAMEORIGIN`), while a Chrome-impersonated client (`curl_cffi`, already used in `crt_sh_tool.py`) reaches the real page (`x-frame-options: DENY`). These are genuinely different security postures, not a subtle difference.

**3. Redirect chain invisibility.**
The analyzer only ever saw the final response after auto-following redirects. Now follows hops manually, exposing each one's status/headers via `redirect_chain`. Also fixes an edge case found during audit: a self-redirecting or looping chain that never reaches real content now fails explicitly instead of silently analyzing a redirect response as if it were the page.

**4. Three analysis-logic bugs.** 
Found via audit (see commit message for detail): a dead/redundant CSP check, HSTS max-age=0 treated the same as a merely-short duration, and Permissions-Policy never evaluating its actual content.

## Does NOT resolve

- WAF providers other than Cloudflare (no equivalent signal checked)
- Full severity analysis per redirect hop (only the final hop gets scored, intermediate hops expose raw headers only)

## Scope

Only `tools/headers_tool.py` and `tests/test_headers_tool.py` touched, per the issue's own "Files to change." Verified no other consumer (`fullrecon_tool.py`, `server.py`) breaks. Both pass the result dict through untouched, and all new fields are additive. No new dependency (`curl_cffi` already pinned for `crt_sh_tool.py`).

## Test Results

```
pytest tests/test_headers_tool.py -v
40 passed
```