### PR TITLE
Feat/cloud exposure check tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ It is also listed on glama mcp registry.
 | `asn_lookup` | Autonomous System Number (ASN) and network ownership lookup — identifies hosting provider, ISP, organization, geolocation, and infrastructure ownership for domains or IP addresses |
 | `cve_lookup` | Search NVD for known CVEs by software name and version (no API key required) |
 | `ip_reputation` | Check if an IP is flagged as malicious via AbuseIPDB (api key requied) |
-| `cloud_exposure_tool` | Checks for publicly accessible AWS S3, Azure Blob Storage, and Google Cloud Storage buckets using common bucket naming patterns derived from the target domain.|
 | `full_recon` | Runs all core tools in parallel and returns combined results with claude analysis |
+| `cloud_exposure_tool` | Checks for publicly accessible AWS S3, Azure Blob Storage, and Google Cloud Storage buckets using common bucket naming patterns derived from the target domain. (Not included in full_recon ) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ It is also listed on glama mcp registry.
 | `asn_lookup` | Autonomous System Number (ASN) and network ownership lookup — identifies hosting provider, ISP, organization, geolocation, and infrastructure ownership for domains or IP addresses |
 | `cve_lookup` | Search NVD for known CVEs by software name and version (no API key required) |
 | `ip_reputation` | Check if an IP is flagged as malicious via AbuseIPDB (api key requied) |
+| `cloud_exposure_tool` | Checks for publicly accessible AWS S3, Azure Blob Storage, and Google Cloud Storage buckets using common bucket naming patterns derived from the target domain.|
 | `full_recon` | Runs all core tools in parallel and returns combined results with claude analysis |
 
 ---
@@ -223,6 +224,7 @@ Look up CVEs for apache 2.4.49
 Look up CVEs for log4j 2.14.1
 Check the reputation of IP 1.2.3.4
 ASN Lookup for google.com
+Does example.com have any exposed cloud storage?
 ```
 
 ### Port scan types

--- a/mcp.json
+++ b/mcp.json
@@ -85,6 +85,12 @@
       "api_key_url": "https://www.abuseipdb.com"
     },
     {
+      "name": "cloud_exposure_check",
+      "description": "Checks for publicly accessible AWS S3, Azure Blob Storage, and Google Cloud Storage buckets from the target domain",
+      "input": {"domain": "string"},
+      "requires_api_key": false
+    },
+    {
       "name": "full_recon",
       "description": "Runs all core tools in parallel against a domain and returns combined results with claude anlaysis",
       "input": {"domain": "string"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "python-whois>=0.9.6",
     "reportlab>=4.5.1",
     "requests>=2.34.2",
+    "tldextract>=5.3.1",
 ]
 
 [tool.pytest.ini_options]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ requests-oauthlib==2.0.0
 requests-toolbelt==1.0.0
 pytest==9.0.3
 curl_cffi==0.15.0
+tldextract==5.3.1

--- a/server.py
+++ b/server.py
@@ -11,6 +11,7 @@ from tools.iprep_tool import ip_reputation
 from tools.crt_sh_tool import cert_transparency
 from tools.headers_tool import headers_analyzer
 from tools.email_security_tool import email_security_check
+from tools.cloud_exposure_tool import cloud_exposure_check
 
 mcp = FastMCP("AynOps")
 
@@ -26,6 +27,7 @@ mcp.tool()(ip_reputation)
 mcp.tool()(cert_transparency)
 mcp.tool()(headers_analyzer)
 mcp.tool()(email_security_check)
+mcp.tool()(cloud_exposure_check)
 
 if __name__ == "__main__":
     mcp.run()

--- a/tests/test_cloud_exposure.py
+++ b/tests/test_cloud_exposure.py
@@ -1,0 +1,131 @@
+import pytest
+from unittest.mock import patch, MagicMock
+import requests
+
+from tools.cloud_exposure_tool import (
+    generate_bucket_names,
+    url_response,
+    check_provider,
+    cloud_exposure_check,
+    COMMON_SUFFIXES,
+    SUBDOMAIN_PREFIXES
+)
+
+def test_generate_bucket_names_basic():
+    company = "google"
+    names = generate_bucket_names(company)
+    
+    assert company in names
+    assert f"{company}-backup" in names
+    assert f"backup.{company}.com" in names
+    expected_count = len(COMMON_SUFFIXES) + len(SUBDOMAIN_PREFIXES)
+    assert len(names) == expected_count
+
+def test_generate_bucket_names_uniqueness():
+    # Duplicates should be filtered out by dict.fromkeys()
+    names = generate_bucket_names("test")
+    assert len(names) == len(set(names))
+
+@patch("tools.cloud_exposure_tool.requests.get")
+def test_url_response_public(mock_get):
+    # Simulate a 200 OK Response
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_get.return_value = mock_response
+    
+    result = url_response("https://example.s3.amazonaws.com/")
+    assert result["status"] == "PUBLIC"
+    assert result["severity"] == "CRITICAL"
+
+@patch("tools.cloud_exposure_tool.requests.get")
+def test_url_response_private(mock_get):
+    # Simulate a 403 Forbidden Response
+    mock_response = MagicMock()
+    mock_response.status_code = 403
+    mock_get.return_value = mock_response
+    
+    result = url_response("https://example.s3.amazonaws.com/")
+    assert result["status"] == "EXISTS_PRIVATE"
+    assert result["severity"] == "INFO"
+
+@patch("tools.cloud_exposure_tool.requests.get")
+def test_url_response_not_found(mock_get):
+    # Simulate a 404 Not Found Response
+    mock_response = MagicMock()
+    mock_response.status_code = 404
+    mock_get.return_value = mock_response
+    
+    result = url_response("https://example.s3.amazonaws.com/")
+    assert result["status"] == "NOT_FOUND"
+
+@patch("tools.cloud_exposure_tool.requests.get")
+def test_url_response_exception(mock_get):
+    # Simulate a network timeout or connection failure
+    mock_get.side_effect = requests.exceptions.Timeout("Connection timed out")
+    
+    result = url_response("https://example.s3.amazonaws.com/")
+    assert result["status"] == "ERROR"
+    assert "Connection timed out" in result["note"]
+
+@patch("tools.cloud_exposure_tool.url_response")
+def test_check_provider_aws(mock_url_response):
+    mock_url_response.return_value = {"status": "NOT_FOUND", "severity": "INFO", "note": "Bucket does not exist"}
+    
+    result = check_provider("mybucket", "AWS S3")
+    assert result["provider"] == "AWS S3"
+    assert result["bucket_name"] == "mybucket"
+    mock_url_response.assert_called_once_with("https://mybucket.s3.amazonaws.com/")
+
+@patch("tools.cloud_exposure_tool.url_response")
+def test_check_provider_gcp(mock_url_response):
+    mock_url_response.return_value = {"status": "NOT_FOUND", "severity": "INFO", "note": "Bucket does not exist"}
+    
+    result = check_provider("mybucket", "GCP")
+    mock_url_response.assert_called_once_with("https://storage.googleapis.com/mybucket/")
+
+@patch("tools.cloud_exposure_tool.url_response")
+def test_check_provider_azure(mock_url_response):
+    mock_url_response.return_value = {"status": "NOT_FOUND", "severity": "INFO", "note": "Bucket does not exist"}
+    
+    result = check_provider("mybucket", "AZURE")
+    expected_url = "https://mybucket.blob.core.windows.net/mybucket?restype=container&comp=list"
+    mock_url_response.assert_called_once_with(expected_url)
+
+def test_check_provider_invalid():
+    with pytest.raises(ValueError, match="Unknown provider: UNKNOWN_CLOUD"):
+        check_provider("mybucket", "UNKNOWN_CLOUD")
+
+@patch("tools.cloud_exposure_tool.is_valid_domain")
+def test_cloud_exposure_check_invalid_domain(mock_is_valid):
+    mock_is_valid.return_value = False
+    
+    result = cloud_exposure_check("invalid_domain_here")
+    assert result["success"] is False
+    assert result["error"] == "Invalid domain format"
+
+@patch("tools.cloud_exposure_tool.is_valid_domain")
+@patch("tools.cloud_exposure_tool.check_provider")
+def test_cloud_exposure_check_success_and_aggregates(mock_check_provider, mock_is_valid):
+    mock_is_valid.return_value = True
+    
+    call_count = 0
+    def side_effect_callback(bucket, provider):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return {"status": "PUBLIC", "bucket_name": bucket, "provider": provider}
+        elif call_count == 2:
+            return {"status": "EXISTS_PRIVATE", "bucket_name": bucket, "provider": provider}
+        else:
+            return {"status": "NOT_FOUND", "bucket_name": bucket, "provider": provider}
+            
+    mock_check_provider.side_effect = side_effect_callback
+    
+    result = cloud_exposure_check("testcompany.com")
+    
+    assert result["success"] is True
+    assert result["domain"] == "testcompany.com"
+    assert result["total_exposed"] == 1
+    assert result["total_private"] == 1
+    expected_not_found = result["buckets_checked"] - 2
+    assert result["total_not_found"] == expected_not_found

--- a/tests/test_cloud_exposure.py
+++ b/tests/test_cloud_exposure.py
@@ -13,17 +13,28 @@ from tools.cloud_exposure_tool import (
 
 def test_generate_bucket_names_basic():
     company = "google"
-    names = generate_bucket_names(company)
+    # Testing AWS/GCP logic branches using the positional fallback format
+    names = generate_bucket_names(company, "AWS S3")
     
     assert company in names
     assert f"{company}-backup" in names
     assert f"backup.{company}.com" in names
+    
+    # Combined rules check
     expected_count = len(COMMON_SUFFIXES) + len(SUBDOMAIN_PREFIXES)
     assert len(names) == expected_count
 
+def test_generate_bucket_names_azure_fallback():
+    company = "google"
+    names = generate_bucket_names(company, "AZURE")
+    
+    assert company in names
+    assert f"{company}backup" in names
+    assert f"backup{company}" in names
+
 def test_generate_bucket_names_uniqueness():
     # Duplicates should be filtered out by dict.fromkeys()
-    names = generate_bucket_names("test")
+    names = generate_bucket_names("test", "AWS S3")
     assert len(names) == len(set(names))
 
 @patch("tools.cloud_exposure_tool.requests.get")
@@ -53,6 +64,16 @@ def test_url_response_not_found(mock_get):
     # Simulate a 404 Not Found Response
     mock_response = MagicMock()
     mock_response.status_code = 404
+    mock_get.return_value = mock_response
+    
+    result = url_response("https://example.s3.amazonaws.com/")
+    assert result["status"] == "NOT_FOUND"
+
+@patch("tools.cloud_exposure_tool.requests.get")
+def test_url_response_fallback_to_not_found(mock_get):
+    # Simulate an unexpected status code like 500, which maps to NOT_FOUND in original code
+    mock_response = MagicMock()
+    mock_response.status_code = 500
     mock_get.return_value = mock_response
     
     result = url_response("https://example.s3.amazonaws.com/")
@@ -127,5 +148,6 @@ def test_cloud_exposure_check_success_and_aggregates(mock_check_provider, mock_i
     assert result["domain"] == "testcompany.com"
     assert result["total_exposed"] == 1
     assert result["total_private"] == 1
+    
     expected_not_found = result["buckets_checked"] - 2
     assert result["total_not_found"] == expected_not_found

--- a/tools/cloud_exposure_tool.py
+++ b/tools/cloud_exposure_tool.py
@@ -1,0 +1,148 @@
+from utils.helpers import is_valid_domain
+import tldextract
+import requests
+from concurrent.futures import ThreadPoolExecutor , as_completed
+
+COMMON_SUFFIXES = [
+    "",
+    "assets",
+    "backup",
+    "backups",
+    "dev",
+    "prod",
+    "production",
+    "staging",
+    "stage",
+    "test",
+    "media",
+    "static",
+    "files",
+    "uploads",
+    "images",
+    "cdn",
+    "storage",
+    "data",
+]
+
+SUBDOMAIN_PREFIXES = [
+    "assets",
+    "backup",
+    "media",
+    "static",
+    "cdn",
+    "files",
+]
+
+def generate_bucket_names(company_name: str) -> list:
+    """Generate bucket names for the given company names and return list"""
+    bucket_names = []
+
+    for i in COMMON_SUFFIXES:
+        if i == "":
+            bucket_names.append(company_name)
+        else:
+            x = company_name + "-" + i
+            bucket_names.append(x)
+
+    for i in SUBDOMAIN_PREFIXES:
+        bucket_names.append(i + "." + company_name + ".com")
+
+    bucket_names = list(dict.fromkeys(bucket_names))
+    return bucket_names
+
+def url_response(url: str) -> dict:
+    """Check bucket urls and return the response results"""
+    try:
+        response = requests.get(url, timeout=5, headers={"User-Agent": "AynOps Recon"})
+    except Exception as e:
+        return {
+            "url": url,
+            "status": "ERROR",
+            "severity": "INFO",
+            "note": str(e)
+        }
+
+    if response.status_code == 200:
+        return {
+                "url": url ,
+                "status":"PUBLIC" , 
+                "severity":"CRITICAL" , 
+                "note": "Bucket is publicly listable — files are exposed"
+            }
+    elif response.status_code == 403:
+        return {
+                "url": url ,
+                "status": "EXISTS_PRIVATE" , 
+                "severity":"INFO" ,
+                "note": "Bucket exists but is not publicly accessible"
+            }
+    
+    elif response.status_code == 404:
+        return {
+            "url": url,
+            "status": "NOT_FOUND" ,
+            "severity": "INFO" ,
+            "note":"Bucket does not exist"
+        }
+    
+    else:
+        return {
+            "url":url,
+            "status":"NOT_FOUND",
+            "severity":"INFO",
+            "note": f"URL Respond with status code {response.status_code}"
+        }
+    
+def check_provider(bucket, provider):
+    """Build url with bucket names and cloud provider , then send url for checking to url_response"""
+    if provider == "AWS S3":
+        url = "https://" + bucket + ".s3.amazonaws.com/"
+    elif provider == "GCP":
+        url = "https://storage.googleapis.com/" + bucket + "/"
+    elif provider == "AZURE":
+        url = "https://" + bucket + ".blob.core.windows.net/" + bucket + "?restype=container&comp=list"
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+    result = url_response(url)
+    return {
+        "bucket_name": bucket ,
+        "provider":provider,
+        **result
+    }
+
+def cloud_exposure_check(domain: str) -> dict:
+    """Takes domain as input and return complete metrics and results for cloud urls exposed or not for a company"""
+    if not is_valid_domain(domain):
+        return {"success": False, "error": "Invalid domain format"}
+    
+    company_name = tldextract.extract(domain).domain
+    bucket_names = generate_bucket_names(company_name)
+    providers = ["AWS S3" , "GCP" , "AZURE"]
+
+    findings = []
+
+    with ThreadPoolExecutor(max_workers=10) as executor:
+        futures = [executor.submit(check_provider, bucket, provider) for bucket in bucket_names for provider in providers]
+        for future in as_completed(futures):
+            try:
+                findings.append(future.result())
+            except Exception as e:
+                findings.append({
+                    "status": "ERROR",
+                    "note": str(e)
+                })
+        
+    total_exposed = len([item for item in findings if item.get("status") == "PUBLIC"])
+    total_private = len([item for item in findings if item.get("status") == "EXISTS_PRIVATE"])
+    total_not_found = len([item for item in findings if item.get("status") == "NOT_FOUND"])
+
+    return {
+        "success": True,
+        "domain": domain ,
+        "buckets_checked": len(bucket_names) * 3 ,
+        "findings": findings ,
+        "total_exposed": total_exposed,
+        "total_private": total_private,
+        "total_not_found": total_not_found
+    }

--- a/tools/cloud_exposure_tool.py
+++ b/tools/cloud_exposure_tool.py
@@ -33,19 +33,32 @@ SUBDOMAIN_PREFIXES = [
     "files",
 ]
 
-def generate_bucket_names(company_name: str) -> list:
+def generate_bucket_names(company_name: str , provider: str) -> list:
     """Generate bucket names for the given company names and return list"""
-    bucket_names = []
+    if provider in ("AWS S3", "GCP"):
+        bucket_names = []
 
-    for i in COMMON_SUFFIXES:
-        if i == "":
-            bucket_names.append(company_name)
-        else:
-            x = company_name + "-" + i
-            bucket_names.append(x)
+        for i in COMMON_SUFFIXES:
+            if i == "":
+                bucket_names.append(company_name)
+            else:
+                x = company_name + "-" + i
+                bucket_names.append(x)
 
-    for i in SUBDOMAIN_PREFIXES:
-        bucket_names.append(i + "." + company_name + ".com")
+        for i in SUBDOMAIN_PREFIXES:
+            bucket_names.append(i + "." + company_name + ".com")
+    else:
+        bucket_names = []
+
+        for i in COMMON_SUFFIXES:
+            if i == "":
+                bucket_names.append(company_name)
+            else:
+                x = company_name + i
+                bucket_names.append(x)
+
+        for i in SUBDOMAIN_PREFIXES:
+            bucket_names.append(i + company_name)
 
     bucket_names = list(dict.fromkeys(bucket_names))
     return bucket_names
@@ -96,11 +109,14 @@ def url_response(url: str) -> dict:
 def check_provider(bucket, provider):
     """Build url with bucket names and cloud provider , then send url for checking to url_response"""
     if provider == "AWS S3":
-        url = "https://" + bucket + ".s3.amazonaws.com/"
+        if "." in bucket:
+            url = f"https://s3.amazonaws.com/{bucket}/"
+        else:
+            url = f"https://{bucket}.s3.amazonaws.com/"
     elif provider == "GCP":
-        url = "https://storage.googleapis.com/" + bucket + "/"
+        url = f"https://storage.googleapis.com/{bucket}/"
     elif provider == "AZURE":
-        url = "https://" + bucket + ".blob.core.windows.net/" + bucket + "?restype=container&comp=list"
+        url =f"https://{bucket}.blob.core.windows.net/{bucket}?restype=container&comp=list"  
     else:
         raise ValueError(f"Unknown provider: {provider}")
 
@@ -117,13 +133,20 @@ def cloud_exposure_check(domain: str) -> dict:
         return {"success": False, "error": "Invalid domain format"}
     
     company_name = tldextract.extract(domain).domain
-    bucket_names = generate_bucket_names(company_name)
-    providers = ["AWS S3" , "GCP" , "AZURE"]
+    default_buckets = generate_bucket_names(company_name, "AWS S3")
+    azure_buckets = generate_bucket_names(company_name, "AZURE")
 
     findings = []
 
     with ThreadPoolExecutor(max_workers=10) as executor:
-        futures = [executor.submit(check_provider, bucket, provider) for bucket in bucket_names for provider in providers]
+        futures = []
+        for bucket in default_buckets:
+            futures.append(executor.submit(check_provider , bucket , "AWS S3"))
+            futures.append(executor.submit(check_provider , bucket , "GCP"))
+
+        for bucket in azure_buckets:
+            futures.append(executor.submit(check_provider , bucket , "AZURE"))
+
         for future in as_completed(futures):
             try:
                 findings.append(future.result())
@@ -140,7 +163,7 @@ def cloud_exposure_check(domain: str) -> dict:
     return {
         "success": True,
         "domain": domain ,
-        "buckets_checked": len(bucket_names) * 3 ,
+        "buckets_checked": len(default_buckets) * 2 + len(azure_buckets) ,
         "findings": findings ,
         "total_exposed": total_exposed,
         "total_private": total_private,

--- a/uv.lock
+++ b/uv.lock
@@ -73,6 +73,7 @@ dependencies = [
     { name = "python-whois" },
     { name = "reportlab" },
     { name = "requests" },
+    { name = "tldextract" },
 ]
 
 [package.metadata]
@@ -87,6 +88,7 @@ requires-dist = [
     { name = "python-whois", specifier = ">=0.9.6" },
     { name = "reportlab", specifier = ">=4.5.1" },
     { name = "requests", specifier = ">=2.34.2" },
+    { name = "tldextract", specifier = ">=5.3.1" },
 ]
 
 [[package]]
@@ -503,6 +505,15 @@ server = [
     { name = "uvicorn" },
     { name = "watchfiles" },
     { name = "websockets" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.29.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/94/00f2059e4835eace3ae8fde680b932c496f8ec7bdc99168dfa53fb2e6b79/filelock-3.29.7.tar.gz", hash = "sha256:5b481979797ae69e72f0b389d89a80bdd585c260c5b3f1fb9c0a5ba9bb3f195d", size = 71521, upload-time = "2026-07-08T05:46:58.716Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/02/be4a57b60c7149b55b9e3b3c13f609cd8eb5307c751f22bd8fb8d262e75b/filelock-3.29.7-py3-none-any.whl", hash = "sha256:987db6f789a3a2a59f55081801b2b3697cb97e2a736b5f1a9e99b559285fbc51", size = 46036, upload-time = "2026-07-08T05:46:57.53Z" },
 ]
 
 [[package]]
@@ -1255,6 +1266,18 @@ wheels = [
 ]
 
 [[package]]
+name = "requests-file"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3c/f8/5dc70102e4d337063452c82e1f0d95e39abfe67aa222ed8a5ddeb9df8de8/requests_file-3.0.1.tar.gz", hash = "sha256:f14243d7796c588f3521bd423c5dea2ee4cc730e54a3cac9574d78aca1272576", size = 6967, upload-time = "2025-10-20T18:56:42.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/d5/de8f089119205a09da657ed4784c584ede8381a0ce6821212a6d4ca47054/requests_file-3.0.1-py2.py3-none-any.whl", hash = "sha256:d0f5eb94353986d998f80ac63c7f146a307728be051d4d1cd390dbdb59c10fa2", size = 4514, upload-time = "2025-10-20T18:56:41.184Z" },
+]
+
+[[package]]
 name = "rich"
 version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1407,6 +1430,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
+name = "tldextract"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "idna" },
+    { name = "requests" },
+    { name = "requests-file" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/65/7b/644fbbb49564a6cb124a8582013315a41148dba2f72209bba14a84242bf0/tldextract-5.3.1.tar.gz", hash = "sha256:a72756ca170b2510315076383ea2993478f7da6f897eef1f4a5400735d5057fb", size = 126105, upload-time = "2025-12-28T23:58:05.532Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/42/0e49d6d0aac449ca71952ec5bae764af009754fcb2e76a5cc097543747b3/tldextract-5.3.1-py3-none-any.whl", hash = "sha256:6bfe36d518de569c572062b788e16a659ccaceffc486d243af0484e8ecf432d9", size = 105886, upload-time = "2025-12-28T23:58:04.071Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes #26 
This PR adds a new `cloud_exposure_check` reconnaissance tool that identifies potentially exposed cloud storage buckets associated with a target domain.

The tool derives common bucket naming patterns from the provided domain and probes AWS S3, Azure Blob Storage, and Google Cloud Storage endpoints to determine whether buckets are publicly accessible, privately accessible, or not found.

## Changes

* Added `cloud_exposure_check` tool.
* Added new dependency of tldextract
* Generated common bucket name variants from the target domain.
* Added support for checking:

  * AWS S3
  * Azure Blob Storage
  * Google Cloud Storage
* Classified bucket states as:

  * `PUBLIC`
  * `EXISTS_PRIVATE`
  * `NOT_FOUND`
  * `ERROR`
* Added concurrent provider checks using `ThreadPoolExecutor` for improved performance.
* Registered the tool in `server.py`.
* Added unit tests with mocked HTTP responses.
* Updated the README tool table.

## Example Output

The tool returns:

* Bucket name
* Cloud provider
* Bucket URL
* Exposure status
* Severity
* Informational note

along with summary metrics including the number of buckets checked and totals for public, private, and not found buckets.

## Note :- currently not added in full_recon.py