### PR TITLE
Fix mcp.json key to match README (cybersecurity -> AynOps)

### DIFF
--- a/mcp.json
+++ b/mcp.json
@@ -114,7 +114,7 @@
   },
   "claude_desktop_config": {
   "mcpServers": {
-    "AnyOps": {
+    "AynOps": {
       "command": "C:\\full\\path\\to\\AynOps\\.venv\\Scripts\\python.exe",
       "args": ["C:\\full\\path\\to\\AynOps\\server.py"],
       "env": {

--- a/mcp.json
+++ b/mcp.json
@@ -114,7 +114,7 @@
   },
   "claude_desktop_config": {
   "mcpServers": {
-    "cybersecurity": {
+    "AnyOps": {
       "command": "C:\\full\\path\\to\\AynOps\\.venv\\Scripts\\python.exe",
       "args": ["C:\\full\\path\\to\\AynOps\\server.py"],
       "env": {


### PR DESCRIPTION
Changes the MCP server key in `mcp.json` from `"cybersecurity"` to `"AynOps"` on line 117, so it matches the server key already used in the README's Claude Desktop config examples.

The README consistently uses `"AynOps"` as the server key, but `mcp.json` had `"cybersecurity"` instead. Anyone copy-pasting the config from `mcp.json` instead of the README would end up with an inconsistently named server entry.

Fixes #72