### PR TITLE
infra: remove unused EXPOSE 8000 from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,4 @@ COPY utils ./utils
 
 ENV PYTHONUNBUFFERED=1
 
-EXPOSE 8000
-
 CMD ["uv", "run", "server.py"]


### PR DESCRIPTION
### Summary
Removed `EXPOSE 8000` from the Dockerfile since the MCP server uses stdio transport (not HTTP/SSE) and never actually listens on port 8000.

### Changes
* Deleted `EXPOSE 8000` instruction from `Dockerfile`.

### Why This Matters
* **Prevents user confusion:** Users won't try to forward ports using `docker run -p 8000:8000`.
* **Aligns with actual behaviour:** Matches the stdio transport documented in `server.json`/`mcp.json`.
* **Removes misleading code:** Eliminates inaccurate "documentation-as-code."

### Testing
* Verified `Dockerfile` no longer contains `EXPOSE 8000`.
* Confirmed `server.py` uses stdio transport via `mcp.run()` with no arguments.

### Related Issue
Fixes #74

---

### Note to Maintainers 
Hi! This is my first open-source contribution. I'm excited to help improve AynOps! Please let me know if any changes are needed.