### PR TITLE
feat: add HTTP redirect chain tracer tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ It is also listed on glama mcp registry.
 | `cve_lookup` | Search NVD for known CVEs by software name and version (no API key required) |
 | `ip_reputation` | Check if an IP is flagged as malicious via AbuseIPDB (api key requied) |
 | `full_recon` | Runs all core tools in parallel and returns combined results with claude analysis |
+| `trace_redirects` | Traces the full HTTP redirect chain hop by hop — flags TLS downgrades, private-IP leaks, redirect loops, cross-domain hops, and overly long chains |
 
 ---
 

--- a/mcp.json
+++ b/mcp.json
@@ -89,7 +89,7 @@
       "description": "Runs all core tools in parallel against a domain and returns combined results with claude anlaysis",
       "input": {"domain": "string"},
       "requires_api_key": false
-    }
+    },
     {
       "name": "trace_redirects",
       "description": "Trace the full HTTP redirect chain for a URL hop by hop, flagging TLS downgrades, private-IP leaks, redirect loops, cross-domain hops, and overly long chains",

--- a/mcp.json
+++ b/mcp.json
@@ -90,6 +90,12 @@
       "input": {"domain": "string"},
       "requires_api_key": false
     }
+    {
+      "name": "trace_redirects",
+      "description": "Trace the full HTTP redirect chain for a URL hop by hop, flagging TLS downgrades, private-IP leaks, redirect loops, cross-domain hops, and overly long chains",
+      "input": {"url": "string"},
+      "requires_api_key": false
+    }
   ],
   "environment_variables": [
     {

--- a/server.py
+++ b/server.py
@@ -11,6 +11,7 @@ from tools.iprep_tool import ip_reputation
 from tools.crt_sh_tool import cert_transparency
 from tools.headers_tool import headers_analyzer
 from tools.email_security_tool import email_security_check
+from tools.redirect_tracer import trace_redirects
 
 mcp = FastMCP("AynOps")
 
@@ -26,6 +27,7 @@ mcp.tool()(ip_reputation)
 mcp.tool()(cert_transparency)
 mcp.tool()(headers_analyzer)
 mcp.tool()(email_security_check)
+mcp.tool()(trace_redirects)
 
 if __name__ == "__main__":
     mcp.run()

--- a/tests/test_redirect_tracer.py
+++ b/tests/test_redirect_tracer.py
@@ -1,0 +1,372 @@
+import unittest
+from unittest.mock import patch, Mock
+import requests
+from tools.redirect_tracer import trace_redirects
+
+
+def _resp(status_code: int, headers: dict = None):
+    m = Mock()
+    m.status_code = status_code
+    m.headers = headers or {}
+    return m
+
+
+class TestTraceRedirects(unittest.TestCase):
+
+    # ------------------------------------------------------------------
+    # Input validation / normalization
+    # ------------------------------------------------------------------
+
+    def test_invalid_domain_rejected(self):
+        result = trace_redirects("not a domain")
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error"], "Invalid domain format")
+
+    @patch("tools.redirect_tracer.requests.Session.get")
+    def test_bare_domain_defaults_to_http(self, mock_get):
+        """The whole point of this tool is checking whether HTTP gets
+        upgraded to HTTPS, defaulting to https:// would silently skip
+        past a domain that never upgrades at all."""
+        mock_get.return_value = _resp(200)
+        result = trace_redirects("example.com")
+        self.assertEqual(result["original_url"], "http://example.com")
+
+    @patch("tools.redirect_tracer.requests.Session.get")
+    def test_scheme_already_present_is_preserved(self, mock_get):
+        mock_get.return_value = _resp(200)
+        result = trace_redirects("https://example.com")
+        self.assertEqual(result["original_url"], "https://example.com")
+
+    @patch("tools.redirect_tracer.requests.Session.get")
+    def test_url_with_path_is_preserved(self, mock_get):
+        mock_get.return_value = _resp(200)
+        result = trace_redirects("http://example.com/some/path?x=1")
+        self.assertEqual(result["original_url"], "http://example.com/some/path?x=1")
+
+    # ------------------------------------------------------------------
+    # Basic chain structure
+    # ------------------------------------------------------------------
+
+    @patch("tools.redirect_tracer.requests.Session.get")
+    def test_no_redirect_single_hop(self, mock_get):
+        mock_get.return_value = _resp(200)
+        result = trace_redirects("http://example.com")
+        self.assertTrue(result["success"])
+        self.assertEqual(result["total_hops"], 1)
+        self.assertEqual(result["final_url"], "http://example.com")
+        self.assertIsNone(result["chain"][0]["redirect_to"])
+        self.assertIsNone(result["chain"][0]["issue"])
+
+    @patch("tools.redirect_tracer.requests.Session.get")
+    def test_relative_location_header_resolved(self, mock_get):
+        """requests does NOT auto-resolve a relative Location header
+        when allow_redirects=False, confirmed via direct socket-level
+        testing. Must be resolved manually against the current URL."""
+        mock_get.side_effect = [
+            _resp(301, {"Location": "/new-path"}),
+            _resp(200),
+        ]
+        result = trace_redirects("http://example.com/old-path")
+        self.assertEqual(result["chain"][0]["redirect_to"], "http://example.com/new-path")
+        self.assertEqual(result["final_url"], "http://example.com/new-path")
+
+    @patch("tools.redirect_tracer.requests.Session.get")
+    def test_absolute_location_header_used_as_is(self, mock_get):
+        mock_get.side_effect = [
+            _resp(301, {"Location": "https://other.com/page"}),
+            _resp(200),
+        ]
+        result = trace_redirects("http://example.com")
+        self.assertEqual(result["chain"][0]["redirect_to"], "https://other.com/page")
+
+    # ------------------------------------------------------------------
+    # TLS upgrade / downgrade detection
+    # ------------------------------------------------------------------
+
+    @patch("tools.redirect_tracer.requests.Session.get")
+    def test_http_to_https_upgrade_flagged_positively(self, mock_get):
+        mock_get.side_effect = [
+            _resp(301, {"Location": "https://example.com/"}),
+            _resp(200),
+        ]
+        result = trace_redirects("http://example.com")
+        self.assertFalse(any(i["type"] in ("tls_downgrade", "no_tls_upgrade") for i in result["issues_found"]))
+        self.assertIn("HTTP to HTTPS upgrade present — good", result["security_notes"])
+
+    @patch("tools.redirect_tracer.requests.Session.get")
+    def test_http_to_http_no_upgrade_flagged_high(self, mock_get):
+        mock_get.side_effect = [
+            _resp(301, {"Location": "http://example.com/page2"}),
+            _resp(200),
+        ]
+        result = trace_redirects("http://example.com")
+        no_upgrade = [i for i in result["issues_found"] if i["type"] == "no_tls_upgrade"]
+        self.assertEqual(len(no_upgrade), 1)
+        self.assertEqual(no_upgrade[0]["severity"], "high")
+
+    @patch("tools.redirect_tracer.requests.Session.get")
+    def test_https_to_http_downgrade_flagged_critical(self, mock_get):
+        mock_get.side_effect = [
+            _resp(301, {"Location": "http://example.com/insecure"}),
+            _resp(200),
+        ]
+        result = trace_redirects("https://example.com")
+        downgrade = [i for i in result["issues_found"] if i["type"] == "tls_downgrade"]
+        self.assertEqual(len(downgrade), 1)
+        self.assertEqual(downgrade[0]["severity"], "critical")
+
+    @patch("tools.redirect_tracer.requests.Session.get")
+    def test_https_stays_https_no_downgrade_note(self, mock_get):
+        mock_get.side_effect = [
+            _resp(301, {"Location": "https://example.com/page2"}),
+            _resp(200),
+        ]
+        result = trace_redirects("https://example.com")
+        self.assertFalse(any(i["type"] in ("tls_downgrade", "no_tls_upgrade") for i in result["issues_found"]))
+        self.assertIn("Chain stayed on HTTPS throughout — good", result["security_notes"])
+
+    # ------------------------------------------------------------------
+    # Private IP detection
+    # ------------------------------------------------------------------
+
+    @patch("tools.redirect_tracer.requests.Session.get")
+    def test_private_ip_redirect_target_flagged(self, mock_get):
+        mock_get.side_effect = [
+            _resp(301, {"Location": "http://10.0.5.23/internal"}),
+            _resp(200),
+        ]
+        result = trace_redirects("http://example.com")
+        priv = [i for i in result["issues_found"] if i["type"] == "private_ip_leak"]
+        self.assertEqual(len(priv), 1)
+        self.assertEqual(priv[0]["severity"], "high")
+        self.assertNotIn("No internal hostnames leaked in chain", result["security_notes"])
+
+    @patch("tools.redirect_tracer.requests.Session.get")
+    def test_public_ip_redirect_target_not_flagged(self, mock_get):
+        mock_get.side_effect = [
+            _resp(301, {"Location": "http://8.8.8.8/page"}),
+            _resp(200),
+        ]
+        result = trace_redirects("http://example.com")
+        priv = [i for i in result["issues_found"] if i["type"] == "private_ip_leak"]
+        self.assertEqual(len(priv), 0)
+
+    @patch("tools.redirect_tracer.requests.Session.get")
+    def test_normal_hostname_not_flagged_as_private_ip(self, mock_get):
+        mock_get.side_effect = [
+            _resp(301, {"Location": "http://internal-sounding-name.com/"}),
+            _resp(200),
+        ]
+        result = trace_redirects("http://example.com")
+        priv = [i for i in result["issues_found"] if i["type"] == "private_ip_leak"]
+        self.assertEqual(len(priv), 0)
+
+    @patch("tools.redirect_tracer.requests.Session.get")
+    def test_loopback_address_flagged(self, mock_get):
+        mock_get.side_effect = [
+            _resp(301, {"Location": "http://127.0.0.1/admin"}),
+            _resp(200),
+        ]
+        result = trace_redirects("http://example.com")
+        priv = [i for i in result["issues_found"] if i["type"] == "private_ip_leak"]
+        self.assertEqual(len(priv), 1)
+
+    def test_hostname_is_private_ip_handles_none(self):
+        """A malformed redirect target with no parseable
+        host must not raise, just report not-private."""
+        from tools.redirect_tracer import _hostname_is_private_ip
+        self.assertFalse(_hostname_is_private_ip(None))
+        self.assertFalse(_hostname_is_private_ip(""))
+
+    # ------------------------------------------------------------------
+    # Cross-domain detection (including the www-normalization fix)
+    # ------------------------------------------------------------------
+
+    @patch("tools.redirect_tracer.requests.Session.get")
+    def test_bare_to_www_not_flagged_cross_domain(self, mock_get):
+        """example.com -> www.example.com is the single most common
+        redirect pattern on the internet and must not be treated as
+        a cross-domain finding."""
+        mock_get.side_effect = [
+            _resp(301, {"Location": "https://www.example.com/"}),
+            _resp(200),
+        ]
+        result = trace_redirects("http://example.com")
+        cross = [i for i in result["issues_found"] if i["type"] == "cross_domain_redirect"]
+        self.assertEqual(len(cross), 0)
+
+    @patch("tools.redirect_tracer.requests.Session.get")
+    def test_www_to_bare_not_flagged_cross_domain(self, mock_get):
+        mock_get.side_effect = [
+            _resp(301, {"Location": "https://example.com/"}),
+            _resp(200),
+        ]
+        result = trace_redirects("http://www.example.com")
+        cross = [i for i in result["issues_found"] if i["type"] == "cross_domain_redirect"]
+        self.assertEqual(len(cross), 0)
+
+    @patch("tools.redirect_tracer.requests.Session.get")
+    def test_genuinely_different_domain_flagged(self, mock_get):
+        mock_get.side_effect = [
+            _resp(301, {"Location": "https://totally-different-brand.net/"}),
+            _resp(200),
+        ]
+        result = trace_redirects("https://example.com")
+        cross = [i for i in result["issues_found"] if i["type"] == "cross_domain_redirect"]
+        self.assertEqual(len(cross), 1)
+        self.assertEqual(cross[0]["severity"], "high")
+
+    # ------------------------------------------------------------------
+    # Redirect loops
+    # ------------------------------------------------------------------
+
+    @patch("tools.redirect_tracer.requests.Session.get")
+    def test_redirect_loop_detected_and_stops(self, mock_get):
+        mock_get.side_effect = [
+            _resp(301, {"Location": "http://example.com/b"}),
+            _resp(301, {"Location": "http://example.com"}),
+        ]
+        result = trace_redirects("http://example.com")
+        self.assertTrue(result["success"])
+        loop = [i for i in result["issues_found"] if i["type"] == "redirect_loop"]
+        self.assertEqual(len(loop), 1)
+        self.assertEqual(loop[0]["severity"], "medium")
+
+    def test_redirect_loop_hop_number_references_a_real_chain_entry(self):
+        """The loop issue's "hop" field was set to the hypothetical NEXT
+        iteration number (the one that would have re-fetched the repeated
+        URL), which never gets a chain entry recorded for it, break happens
+        before any fetch or append. A consumer looking up chain[hop-1] to see
+        which entry the loop issue refers to would get an IndexError or
+        the wrong entry. The hop must reference the last entry that was
+        actually recorded (len(chain)), which is the hop whose
+        redirect_to points at the now-repeated URL."""
+        with patch("tools.redirect_tracer.requests.Session.get") as mock_get:
+            mock_get.side_effect = [
+                _resp(301, {"Location": "http://example.com/b"}),
+                _resp(301, {"Location": "http://example.com"}),
+            ]
+            result = trace_redirects("http://example.com")
+
+        loop_issue = [i for i in result["issues_found"] if i["type"] == "redirect_loop"][0]
+        chain_hop_numbers = [h["hop"] for h in result["chain"]]
+        self.assertIn(loop_issue["hop"], chain_hop_numbers)
+        self.assertEqual(loop_issue["hop"], len(result["chain"]))
+
+    @patch("tools.redirect_tracer.requests.Session.get")
+    def test_self_redirecting_url_detected_as_loop(self, mock_get):
+        mock_get.return_value = _resp(301, {"Location": "http://example.com"})
+        result = trace_redirects("http://example.com")
+        self.assertTrue(result["success"])
+        loop = [i for i in result["issues_found"] if i["type"] == "redirect_loop"]
+        self.assertEqual(len(loop), 1)
+
+    @patch("tools.redirect_tracer.requests.Session.get")
+    def test_whitespace_only_location_resolves_to_self_and_is_flagged_as_loop(self, mock_get):
+        """A Location header that is present but only whitespace is, per
+        RFC 3986 reference resolution (as implemented by urljoin), an
+        empty relative reference, it resolves back to the current URL,
+        not to a distinct destination. This is correctly caught by the
+        existing loop detection (current_url gets re-visited on the next
+        iteration) rather than needing special-case handling. This test
+        documents that behavior explicitly rather than leaving it as an
+        implicit side effect of urljoin."""
+        mock_get.side_effect = [
+            _resp(301, {"Location": "   "}),
+            _resp(200),
+        ]
+        result = trace_redirects("http://example.com")
+        self.assertTrue(result["success"])
+        loop = [i for i in result["issues_found"] if i["type"] == "redirect_loop"]
+        self.assertEqual(len(loop), 1)
+        self.assertEqual(result["chain"][0]["redirect_to"], "http://example.com")
+
+    # ------------------------------------------------------------------
+    # Chain length
+    # ------------------------------------------------------------------
+
+    @patch("tools.redirect_tracer.requests.Session.get")
+    def test_long_chain_flagged_low_severity(self, mock_get):
+        hops = [_resp(301, {"Location": f"http://example.com/{i}"}) for i in range(6)]
+        hops.append(_resp(200))
+        mock_get.side_effect = hops
+        result = trace_redirects("http://example.com")
+        self.assertEqual(result["total_hops"], 7)
+        long_chain = [i for i in result["issues_found"] if i["type"] == "long_chain"]
+        self.assertEqual(len(long_chain), 1)
+        self.assertEqual(long_chain[0]["severity"], "low")
+
+    @patch("tools.redirect_tracer.requests.Session.get")
+    def test_short_chain_not_flagged_long(self, mock_get):
+        mock_get.side_effect = [
+            _resp(301, {"Location": "https://example.com/"}),
+            _resp(200),
+        ]
+        result = trace_redirects("http://example.com")
+        long_chain = [i for i in result["issues_found"] if i["type"] == "long_chain"]
+        self.assertEqual(len(long_chain), 0)
+
+    @patch("tools.redirect_tracer.requests.Session.get")
+    def test_max_hops_cap_enforced(self, mock_get):
+        """A chain of unique, never-repeating, never-resolving redirects
+        must stop at the hop cap rather than making unbounded requests."""
+        hops = [_resp(301, {"Location": f"http://example.com/page{i}"}) for i in range(30)]
+        mock_get.side_effect = hops
+        result = trace_redirects("http://example.com")
+        self.assertTrue(result["success"])
+        self.assertLessEqual(mock_get.call_count, 15)
+        max_hops = [i for i in result["issues_found"] if i["type"] == "max_hops_exceeded"]
+        self.assertEqual(len(max_hops), 1)
+
+    def test_max_hops_exceeded_hop_number_matches_chain_length(self):
+        """The hop reference on this issue must equal len(chain), not a
+        module constant that happens to equal it today by coincidence."""
+        with patch("tools.redirect_tracer.requests.Session.get") as mock_get:
+            hops = [_resp(301, {"Location": f"http://example.com/page{i}"}) for i in range(30)]
+            mock_get.side_effect = hops
+            result = trace_redirects("http://example.com")
+
+        max_hops_issue = [i for i in result["issues_found"] if i["type"] == "max_hops_exceeded"][0]
+        self.assertEqual(max_hops_issue["hop"], len(result["chain"]))
+
+    # ------------------------------------------------------------------
+    # Malformed responses
+    # ------------------------------------------------------------------
+
+    @patch("tools.redirect_tracer.requests.Session.get")
+    def test_redirect_status_with_no_location_header(self, mock_get):
+        mock_get.return_value = _resp(301, {})
+        result = trace_redirects("http://example.com")
+        self.assertTrue(result["success"])
+        self.assertEqual(result["total_hops"], 1)
+        malformed = [i for i in result["issues_found"] if i["type"] == "malformed_redirect"]
+        self.assertEqual(len(malformed), 1)
+
+    # ------------------------------------------------------------------
+    # Error handling
+    # ------------------------------------------------------------------
+
+    @patch("tools.redirect_tracer.requests.Session.get",
+           side_effect=requests.exceptions.ConnectionError("refused"))
+    def test_connection_error_returns_failure(self, _):
+        result = trace_redirects("http://example.com")
+        self.assertFalse(result["success"])
+        self.assertIn("Connection failed", result["error"])
+
+    @patch("tools.redirect_tracer.requests.Session.get",
+           side_effect=requests.exceptions.Timeout("timed out"))
+    def test_timeout_returns_failure(self, _):
+        result = trace_redirects("http://example.com")
+        self.assertFalse(result["success"])
+        self.assertIn("Connection failed", result["error"])
+
+    @patch("tools.redirect_tracer.requests.Session.get",
+           side_effect=Exception("Unexpected error"))
+    def test_unexpected_exception_returns_failure(self, _):
+        result = trace_redirects("http://example.com")
+        self.assertFalse(result["success"])
+        self.assertIn("error", result)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_redirect_tracer.py
+++ b/tests/test_redirect_tracer.py
@@ -142,6 +142,24 @@ class TestTraceRedirects(unittest.TestCase):
         self.assertNotIn("No internal hostnames leaked in chain", result["security_notes"])
 
     @patch("tools.redirect_tracer.requests.Session.get")
+    def test_private_ip_redirect_target_is_never_fetched(self, mock_get):
+        """Flagging a private-IP target isn't enough on its own, the tool
+        must stop before actually requesting it, or the tool itself becomes
+        an SSRF vector for whatever host it runs on. A second mock response
+        is queued but must never be consumed."""
+        mock_get.side_effect = [
+            _resp(301, {"Location": "http://169.254.169.254/latest/meta-data/"}),
+            _resp(200),  # must never be reached
+        ]
+        result = trace_redirects("http://example.com")
+        self.assertTrue(result["success"])
+        self.assertEqual(mock_get.call_count, 1)
+        self.assertEqual(result["total_hops"], 1)
+        self.assertEqual(result["chain"][0]["redirect_to"], "http://169.254.169.254/latest/meta-data/")
+        priv = [i for i in result["issues_found"] if i["type"] == "private_ip_leak"]
+        self.assertEqual(len(priv), 1)
+
+    @patch("tools.redirect_tracer.requests.Session.get")
     def test_public_ip_redirect_target_not_flagged(self, mock_get):
         mock_get.side_effect = [
             _resp(301, {"Location": "http://8.8.8.8/page"}),

--- a/tests/test_redirect_tracer.py
+++ b/tests/test_redirect_tracer.py
@@ -105,6 +105,23 @@ class TestTraceRedirects(unittest.TestCase):
         self.assertEqual(no_upgrade[0]["severity"], "high")
 
     @patch("tools.redirect_tracer.requests.Session.get")
+    def test_intermediate_http_hop_that_later_upgrades_is_not_flagged(self, mock_get):
+        """Regression test: http -> http -> https must NOT be flagged as
+        no_tls_upgrade just because the first hop stayed on http. Matches
+        real-world chains like http://google.com -> http://www.google.com/
+        -> https://www.google.com/?gws_rd=ssl, where the chain does
+        eventually reach https."""
+        mock_get.side_effect = [
+            _resp(301, {"Location": "http://www.example.com/"}),
+            _resp(302, {"Location": "https://www.example.com/?upgraded=1"}),
+            _resp(200),
+        ]
+        result = trace_redirects("http://example.com")
+        no_upgrade = [i for i in result["issues_found"] if i["type"] == "no_tls_upgrade"]
+        self.assertEqual(len(no_upgrade), 0)
+        self.assertEqual(result["final_url"], "https://www.example.com/?upgraded=1")
+
+    @patch("tools.redirect_tracer.requests.Session.get")
     def test_https_to_http_downgrade_flagged_critical(self, mock_get):
         mock_get.side_effect = [
             _resp(301, {"Location": "http://example.com/insecure"}),
@@ -124,6 +141,18 @@ class TestTraceRedirects(unittest.TestCase):
         result = trace_redirects("https://example.com")
         self.assertFalse(any(i["type"] in ("tls_downgrade", "no_tls_upgrade") for i in result["issues_found"]))
         self.assertIn("Chain stayed on HTTPS throughout — good", result["security_notes"])
+
+    @patch("tools.redirect_tracer.requests.Session.get")
+    def test_https_discovered_but_not_fetched_still_counts_as_reaching_https(self, mock_get):
+        """A chain that hits the hop cap right as it discovers an https
+        target (never actually fetched) should still not be flagged as
+        no_tls_upgrade. It DID reach https, just not within budget."""
+        hops = [_resp(301, {"Location": f"http://example.com/page{i}"}) for i in range(14)]
+        hops.append(_resp(301, {"Location": "https://example.com/final"}))
+        mock_get.side_effect = hops
+        result = trace_redirects("http://example.com")
+        no_upgrade = [i for i in result["issues_found"] if i["type"] == "no_tls_upgrade"]
+        self.assertEqual(len(no_upgrade), 0)
 
     # ------------------------------------------------------------------
     # Private IP detection

--- a/tests/test_redirect_tracer.py
+++ b/tests/test_redirect_tracer.py
@@ -139,6 +139,17 @@ class TestTraceRedirects(unittest.TestCase):
         priv = [i for i in result["issues_found"] if i["type"] == "private_ip_leak"]
         self.assertEqual(len(priv), 1)
         self.assertEqual(priv[0]["severity"], "high")
+        self.assertNotIn("No private IP redirects detected", result["security_notes"])
+
+    @patch("tools.redirect_tracer.requests.Session.get")
+    def test_security_note_wording_matches_what_is_actually_checked(self, mock_get):
+        """The note only reflects the literal-private-IP check, it must
+        not claim "hostnames" in general were checked. This tool does
+        not resolve or inspect hostnames, per _hostname_is_private_ip's
+        own docstring."""
+        mock_get.return_value = _resp(200)
+        result = trace_redirects("http://example.com")
+        self.assertIn("No private IP redirects detected", result["security_notes"])
         self.assertNotIn("No internal hostnames leaked in chain", result["security_notes"])
 
     @patch("tools.redirect_tracer.requests.Session.get")
@@ -156,6 +167,10 @@ class TestTraceRedirects(unittest.TestCase):
         self.assertEqual(mock_get.call_count, 1)
         self.assertEqual(result["total_hops"], 1)
         self.assertEqual(result["chain"][0]["redirect_to"], "http://169.254.169.254/latest/meta-data/")
+        self.assertEqual(
+            result["final_url"], "http://169.254.169.254/latest/meta-data/",
+            "final_url should report the discovered-but-unfetched target, not the last page actually fetched"
+        )
         priv = [i for i in result["issues_found"] if i["type"] == "private_ip_leak"]
         self.assertEqual(len(priv), 1)
 
@@ -335,6 +350,11 @@ class TestTraceRedirects(unittest.TestCase):
         self.assertLessEqual(mock_get.call_count, 15)
         max_hops = [i for i in result["issues_found"] if i["type"] == "max_hops_exceeded"]
         self.assertEqual(len(max_hops), 1)
+        self.assertEqual(
+            result["final_url"], "http://example.com/page14",
+            "final_url should be the destination discovered on the capped-off 15th hop, "
+            "not the URL of the 15th hop itself"
+        )
 
     def test_max_hops_exceeded_hop_number_matches_chain_length(self):
         """The hop reference on this issue must equal len(chain), not a

--- a/tools/redirect_tracer.py
+++ b/tools/redirect_tracer.py
@@ -18,7 +18,21 @@ from utils.helpers import is_valid_domain
 _REDIRECT_STATUSES = (301, 302, 303, 307, 308)
 _MAX_HOPS = 15
 _LONG_CHAIN_THRESHOLD = 5
-_REQUEST_HEADERS = {"User-Agent": "Mozilla/5.0 (compatible; SecurityScanner/1.0)"}
+_REQUEST_HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+    "Accept-Language": "en-US,en;q=0.9",
+    "Accept-Encoding": "gzip, deflate, br, zstd",
+    "Connection": "keep-alive",
+    "Upgrade-Insecure-Requests": "1",
+    "Sec-Fetch-Dest": "document",
+    "Sec-Fetch-Mode": "navigate",
+    "Sec-Fetch-Site": "none",
+    "Sec-Fetch-User": "?1",
+    "Sec-CH-UA": '"Not_A Brand";v="8", "Chromium";v="120", "Google Chrome";v="120"',
+    "Sec-CH-UA-Mobile": "?0",
+    "Sec-CH-UA-Platform": '"Windows"'
+}
 
 
 def _hostname_is_private_ip(hostname: Optional[str]) -> bool:

--- a/tools/redirect_tracer.py
+++ b/tools/redirect_tracer.py
@@ -1,0 +1,231 @@
+"""HTTP Redirect Chain Tracer Tool.
+
+Manually follows a redirect chain hop by hop, recording each response's
+status code and destination, and flags security-relevant patterns along
+the way (TLS downgrade, private IPs, redirect loops, cross-domain hops,
+excessively long chains).
+"""
+from __future__ import annotations
+
+import ipaddress
+from urllib.parse import urljoin, urlparse
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from utils.helpers import is_valid_domain
+
+_REDIRECT_STATUSES = (301, 302, 303, 307, 308)
+_MAX_HOPS = 15
+_LONG_CHAIN_THRESHOLD = 5
+
+
+def _hostname_is_private_ip(hostname: Optional[str]) -> bool:
+    """Return True if hostname is a literal IP address in a private,
+    loopback, or link-local range.
+
+    This checks the literal hostname string, not a DNS-resolved
+    address, e.g. it flags "http://10.0.5.23/", not "http://
+    internal-service.example.com/" even if that name happens to
+    resolve to a private IP. Resolving every hop's hostname would add
+    latency and its own class of edge cases (DNS rebinding, multiple
+    A records). The issue's own wording ("private IP appearing in
+    redirect URL") describes a literal-URL check, not a resolved one.
+    """
+    if not hostname:
+        return False
+    try:
+        addr = ipaddress.ip_address(hostname)
+    except ValueError:
+        return False
+    return addr.is_private or addr.is_loopback or addr.is_link_local
+
+
+def _strip_www(hostname: str) -> str:
+    """Strip a leading "www." for cross-domain comparison purposes.
+
+    Without this, the single most common redirect pattern on the
+    internet -- example.com -> www.example.com -- would be flagged as
+    "cross-domain" on every single trace, which is noise. This only handles
+    the www<->bare case, it does not do full registrable-domain comparison 
+    (e.g. sub.example.co.uk vs example.co.uk), which would require a public
+    suffix list, a new dependency the issue explicitly asks to avoid. A deeper
+    subdomain change (sub.example.com -> example.com) is still flagged, which
+    is the conservative/safe direction to err in for a security tool.
+    """
+    return hostname[4:] if hostname.lower().startswith("www.") else hostname
+
+
+def _normalize_url(url: str) -> str:
+    """Prepend http:// if no scheme is given.
+
+    Deliberately defaults to http://, not https://: the entire point
+    of this tool is to detect whether a domain upgrades HTTP to HTTPS
+    on its own. Defaulting to https:// would silently skip past a
+    domain that never upgrades at all.
+    """
+    url = url.strip()
+    if not url.lower().startswith(("http://", "https://")):
+        url = "http://" + url
+    return url
+
+
+def trace_redirects(url: str) -> dict:
+    """Trace the full redirect chain for a URL, hop by hop.
+
+    Follows redirects manually (allow_redirects=False + loop) instead
+    of relying on requests' built-in auto-follow, so each hop's own
+    status code and destination are visible. Flags TLS downgrades,
+    private-IP destinations, redirect loops, excessively long chains,
+    and cross-domain hops along the way.
+    """
+    original_url = _normalize_url(url)
+
+    parsed = urlparse(original_url)
+    if not parsed.hostname or not is_valid_domain(parsed.hostname):
+        return {"success": False, "error": "Invalid domain format"}
+
+    chain: List[Dict[str, Any]] = []
+    issues_found: List[Dict[str, Any]] = []
+    seen_urls = set()
+    current_url = original_url
+    session = requests.Session()
+
+    try:
+        for hop_number in range(1, _MAX_HOPS + 1):
+            if current_url in seen_urls:
+                # hop_number here is the iteration that WOULD have fetched
+                # current_url again, no chain entry is ever recorded for
+                # it (we break before fetching). Using hop_number directly
+                # would point one past the end of `chain`, since the last
+                # real entry is chain[len(chain)-1] with hop == len(chain).
+                # len(chain) correctly identifies the last recorded hop,
+                # the one whose redirect_to points at the now-repeated URL.
+                issues_found.append({
+                    "hop": len(chain),
+                    "type": "redirect_loop",
+                    "severity": "medium",
+                    "description": f"Redirect loop detected — {current_url} was already visited in this chain",
+                })
+                break
+            seen_urls.add(current_url)
+
+            resp = session.get(current_url, allow_redirects=False, timeout=10)
+            status_code = resp.status_code
+            current_parsed = urlparse(current_url)
+
+            hop_entry: Dict[str, Any] = {
+                "hop": hop_number,
+                "url": current_url,
+                "status_code": status_code,
+                "redirect_to": None,
+                "issue": None,
+            }
+
+            if status_code in _REDIRECT_STATUSES:
+                location = resp.headers.get("Location")
+                if not location:
+                    hop_entry["issue"] = "Redirect status with no Location header — chain cannot continue"
+                    chain.append(hop_entry)
+                    issues_found.append({
+                        "hop": hop_number,
+                        "type": "malformed_redirect",
+                        "severity": "low",
+                        "description": hop_entry["issue"],
+                    })
+                    break
+
+                next_url = urljoin(current_url, location)
+                hop_entry["redirect_to"] = next_url
+                next_parsed = urlparse(next_url)
+
+                hop_issues = []
+
+                if current_parsed.scheme == "https" and next_parsed.scheme == "http":
+                    hop_issues.append("HTTPS to HTTP downgrade")
+                    issues_found.append({
+                        "hop": hop_number, "type": "tls_downgrade", "severity": "critical",
+                        "description": f"Downgrades from HTTPS to HTTP: {current_url} -> {next_url}",
+                    })
+                elif current_parsed.scheme == "http" and next_parsed.scheme == "http":
+                    hop_issues.append("HTTP to HTTP redirect (no TLS upgrade)")
+                    issues_found.append({
+                        "hop": hop_number, "type": "no_tls_upgrade", "severity": "high",
+                        "description": f"Stays on HTTP, never upgrades to HTTPS: {current_url} -> {next_url}",
+                    })
+
+                if _hostname_is_private_ip(next_parsed.hostname):
+                    hop_issues.append("Redirects to a private/internal IP address")
+                    issues_found.append({
+                        "hop": hop_number, "type": "private_ip_leak", "severity": "high",
+                        "description": f"Redirect target's hostname is a private/internal IP: {next_parsed.hostname}",
+                    })
+
+                if (
+                    current_parsed.hostname
+                    and next_parsed.hostname
+                    and _strip_www(current_parsed.hostname) != _strip_www(next_parsed.hostname)
+                ):
+                    hop_issues.append("Redirects to a different domain — verify this is intended")
+                    issues_found.append({
+                        "hop": hop_number, "type": "cross_domain_redirect", "severity": "high",
+                        "description": (
+                            f"Redirects to a different domain: {current_parsed.hostname} -> "
+                            f"{next_parsed.hostname}. This is flagged for review -- it is common "
+                            f"and legitimate for URL shorteners, domain migrations, and OAuth "
+                            f"flows, but can also indicate an unvalidated open-redirect endpoint."
+                        ),
+                    })
+
+                hop_entry["issue"] = "; ".join(hop_issues) if hop_issues else None
+                chain.append(hop_entry)
+                current_url = next_url
+                continue
+
+            chain.append(hop_entry)
+            break
+
+        else:
+            issues_found.append({
+                "hop": len(chain),
+                "type": "max_hops_exceeded",
+                "severity": "medium",
+                "description": f"Redirect chain exceeded the {_MAX_HOPS}-hop limit without resolving",
+            })
+
+    except requests.exceptions.RequestException as e:
+        return {"success": False, "error": f"Connection failed: {str(e)}"}
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+    total_hops = len(chain)
+    if total_hops > _LONG_CHAIN_THRESHOLD:
+        issues_found.append({
+            "hop": None,
+            "type": "long_chain",
+            "severity": "low",
+            "description": f"Chain has {total_hops} hops, longer than the recommended {_LONG_CHAIN_THRESHOLD} (SEO/performance impact)",
+        })
+
+    final_url = chain[-1]["url"] if chain else original_url
+
+    security_notes = []
+    has_downgrade = any(i["type"] == "tls_downgrade" for i in issues_found)
+    has_no_upgrade = any(i["type"] == "no_tls_upgrade" for i in issues_found)
+    if not has_downgrade and not has_no_upgrade:
+        if original_url.startswith("http://") and final_url.startswith("https://"):
+            security_notes.append("HTTP to HTTPS upgrade present — good")
+        elif original_url.startswith("https://"):
+            security_notes.append("Chain stayed on HTTPS throughout — good")
+    if not any(i["type"] == "private_ip_leak" for i in issues_found):
+        security_notes.append("No internal hostnames leaked in chain")
+
+    return {
+        "success": True,
+        "original_url": original_url,
+        "final_url": final_url,
+        "total_hops": total_hops,
+        "chain": chain,
+        "issues_found": issues_found,
+        "security_notes": security_notes,
+    }

--- a/tools/redirect_tracer.py
+++ b/tools/redirect_tracer.py
@@ -18,6 +18,7 @@ from utils.helpers import is_valid_domain
 _REDIRECT_STATUSES = (301, 302, 303, 307, 308)
 _MAX_HOPS = 15
 _LONG_CHAIN_THRESHOLD = 5
+_REQUEST_HEADERS = {"User-Agent": "Mozilla/5.0 (compatible; SecurityScanner/1.0)"}
 
 
 def _hostname_is_private_ip(hostname: Optional[str]) -> bool:
@@ -110,7 +111,9 @@ def trace_redirects(url: str) -> dict:
                 break
             seen_urls.add(current_url)
 
-            resp = session.get(current_url, allow_redirects=False, timeout=10)
+            resp = session.get(
+                current_url, allow_redirects=False, timeout=10, headers=_REQUEST_HEADERS
+            )
             status_code = resp.status_code
             current_parsed = urlparse(current_url)
 
@@ -154,11 +157,18 @@ def trace_redirects(url: str) -> dict:
                         "description": f"Stays on HTTP, never upgrades to HTTPS: {current_url} -> {next_url}",
                     })
 
-                if _hostname_is_private_ip(next_parsed.hostname):
+                is_private_target = _hostname_is_private_ip(next_parsed.hostname)
+                if is_private_target:
                     hop_issues.append("Redirects to a private/internal IP address")
                     issues_found.append({
                         "hop": hop_number, "type": "private_ip_leak", "severity": "high",
-                        "description": f"Redirect target's hostname is a private/internal IP: {next_parsed.hostname}",
+                        "description": (
+                            f"Redirect target's hostname is a private/internal IP: "
+                            f"{next_parsed.hostname}. Trace halted here — this tool "
+                            f"does not follow redirects into private/internal address "
+                            f"space, since doing so would make the tool itself an SSRF "
+                            f"vector for whatever host it runs on."
+                        ),
                     })
 
                 if (
@@ -179,6 +189,10 @@ def trace_redirects(url: str) -> dict:
 
                 hop_entry["issue"] = "; ".join(hop_issues) if hop_issues else None
                 chain.append(hop_entry)
+
+                if is_private_target:
+                    break
+
                 current_url = next_url
                 continue
 

--- a/tools/redirect_tracer.py
+++ b/tools/redirect_tracer.py
@@ -150,12 +150,6 @@ def trace_redirects(url: str) -> dict:
                         "hop": hop_number, "type": "tls_downgrade", "severity": "critical",
                         "description": f"Downgrades from HTTPS to HTTP: {current_url} -> {next_url}",
                     })
-                elif current_parsed.scheme == "http" and next_parsed.scheme == "http":
-                    hop_issues.append("HTTP to HTTP redirect (no TLS upgrade)")
-                    issues_found.append({
-                        "hop": hop_number, "type": "no_tls_upgrade", "severity": "high",
-                        "description": f"Stays on HTTP, never upgrades to HTTPS: {current_url} -> {next_url}",
-                    })
 
                 is_private_target = _hostname_is_private_ip(next_parsed.hostname)
                 if is_private_target:
@@ -226,6 +220,23 @@ def trace_redirects(url: str) -> dict:
     # hitting the hop cap mid-redirect), that discovered destination is
     # the true final URL, not just the last URL actually fetched.
     final_url = (chain[-1].get("redirect_to") or chain[-1]["url"]) if chain else original_url
+
+    # Evaluated against the whole chain, not per-hop. An intermediate
+    # http hop that later upgrades to https should not be flagged, only
+    # a chain that never reaches https anywhere should be.
+    if original_url.startswith("http://") and not any(
+        hop["url"].startswith("https://") or (hop.get("redirect_to") or "").startswith("https://")
+        for hop in chain
+    ):
+        issues_found.append({
+            "hop": None,
+            "type": "no_tls_upgrade",
+            "severity": "high",
+            "description": (
+                f"The chain starting at {original_url} never reaches HTTPS at any "
+                f"point (ended at {final_url})."
+            ),
+        })
 
     security_notes = []
     has_downgrade = any(i["type"] == "tls_downgrade" for i in issues_found)

--- a/tools/redirect_tracer.py
+++ b/tools/redirect_tracer.py
@@ -221,7 +221,11 @@ def trace_redirects(url: str) -> dict:
             "description": f"Chain has {total_hops} hops, longer than the recommended {_LONG_CHAIN_THRESHOLD} (SEO/performance impact)",
         })
 
-    final_url = chain[-1]["url"] if chain else original_url
+    # If the last hop discovered a further destination but the tracer
+    # stopped before fetching it (private-IP halt, redirect loop, or
+    # hitting the hop cap mid-redirect), that discovered destination is
+    # the true final URL, not just the last URL actually fetched.
+    final_url = (chain[-1].get("redirect_to") or chain[-1]["url"]) if chain else original_url
 
     security_notes = []
     has_downgrade = any(i["type"] == "tls_downgrade" for i in issues_found)
@@ -232,7 +236,7 @@ def trace_redirects(url: str) -> dict:
         elif original_url.startswith("https://"):
             security_notes.append("Chain stayed on HTTPS throughout — good")
     if not any(i["type"] == "private_ip_leak" for i in issues_found):
-        security_notes.append("No internal hostnames leaked in chain")
+        security_notes.append("No private IP redirects detected")
 
     return {
         "success": True,


### PR DESCRIPTION
Closes #25

Adds `trace_redirects(url) -> dict`, follows redirects hop-by-hop (max 15 hops) and flags:
- HTTP→HTTP (high), HTTPS→HTTP downgrade (critical).
- Private/internal IP target (high) — chain halts before fetching it, so this tool can't be turned into an SSRF vector.
- Redirect loop (medium), chain >5 hops (low), cross-domain redirect (high).

32 tests, passed, mocked HTTP.

Not included: wiring into full_recon.py.