### PR TITLE
Add timeout handling to whois lookup

### DIFF
--- a/tests/test_whois_lookup.py
+++ b/tests/test_whois_lookup.py
@@ -1,5 +1,5 @@
 from unittest.mock import MagicMock, patch
-from concurrent.futures import TimeoutError as FuturesTimeoutError
+import socket
 import unittest
 from tools.whois_tool import whois_lookup
 
@@ -52,13 +52,15 @@ class TestWhoisLookup(unittest.TestCase):
         self.assertFalse(result["success"])
         self.assertIn("WHOIS server timeout", result["error"])
 
-    @patch("tools.whois_tool.ThreadPoolExecutor")
-    def test_whois_executor_timeout(self, mock_executor_class):
-        """Test that executor timeout is caught and returns proper error message."""
-        mock_executor = MagicMock()
-        mock_executor_class.return_value.__enter__.return_value = mock_executor
-        mock_executor.submit.return_value.result.side_effect = FuturesTimeoutError()
+    @patch("tools.whois_tool.whois.whois", side_effect=TimeoutError("WHOIS lookup timed out"))
+    def test_whois_timeout_error_caught(self, _):
+        result = whois_lookup("example.com")
+        self.assertFalse(result["success"])
+        self.assertIn("timed out after", result["error"])
+        self.assertIn("10 seconds", result["error"])
 
+    @patch("tools.whois_tool.whois.whois", side_effect=socket.timeout("connection timed out"))
+    def test_whois_socket_timeout_caught(self, _):
         result = whois_lookup("example.com")
         self.assertFalse(result["success"])
         self.assertIn("timed out after", result["error"])

--- a/tests/test_whois_lookup.py
+++ b/tests/test_whois_lookup.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 import unittest
 from tools.whois_tool import whois_lookup
 
@@ -50,6 +50,12 @@ class TestWhoisLookup(unittest.TestCase):
         result = whois_lookup("example.com")
         self.assertFalse(result["success"])
         self.assertIn("WHOIS server timeout", result["error"])
+
+    @patch("tools.whois_tool.whois.whois", side_effect=TimeoutError("WHOIS lookup timed out"))
+    def test_whois_timeout_error_caught(self, _):
+        result = whois_lookup("example.com")
+        self.assertFalse(result["success"])
+        self.assertIn("timed out", result["error"].lower())
 
     @patch("tools.whois_tool.whois.whois")
     def test_whois_none_dates_return_null(self, mock_whois):

--- a/tests/test_whois_lookup.py
+++ b/tests/test_whois_lookup.py
@@ -1,4 +1,5 @@
 from unittest.mock import MagicMock, patch
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 import unittest
 from tools.whois_tool import whois_lookup
 
@@ -51,11 +52,17 @@ class TestWhoisLookup(unittest.TestCase):
         self.assertFalse(result["success"])
         self.assertIn("WHOIS server timeout", result["error"])
 
-    @patch("tools.whois_tool.whois.whois", side_effect=TimeoutError("WHOIS lookup timed out"))
-    def test_whois_timeout_error_caught(self, _):
+    @patch("tools.whois_tool.ThreadPoolExecutor")
+    def test_whois_executor_timeout(self, mock_executor_class):
+        """Test that executor timeout is caught and returns proper error message."""
+        mock_executor = MagicMock()
+        mock_executor_class.return_value.__enter__.return_value = mock_executor
+        mock_executor.submit.return_value.result.side_effect = FuturesTimeoutError()
+
         result = whois_lookup("example.com")
         self.assertFalse(result["success"])
-        self.assertIn("timed out", result["error"].lower())
+        self.assertIn("timed out after", result["error"])
+        self.assertIn("10 seconds", result["error"])
 
     @patch("tools.whois_tool.whois.whois")
     def test_whois_none_dates_return_null(self, mock_whois):

--- a/tools/whois_tool.py
+++ b/tools/whois_tool.py
@@ -1,4 +1,4 @@
-from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
+import socket
 import whois
 from utils.helpers import is_valid_domain
 
@@ -11,11 +11,7 @@ def whois_lookup(domain: str) -> dict:
         if not is_valid_domain(domain):
             return {"success": False, "error": "Invalid domain format"}
 
-        def _fetch_whois():
-            return whois.whois(domain)
-
-        with ThreadPoolExecutor(max_workers=1) as executor:
-            result = executor.submit(_fetch_whois).result(timeout=WHOIS_TIMEOUT_SECONDS)
+        result = whois.whois(domain, timeout=WHOIS_TIMEOUT_SECONDS)
 
         def safe_date(d):
             if d is None:
@@ -37,7 +33,7 @@ def whois_lookup(domain: str) -> dict:
             "country": result.country,
             "org": result.org
         }
-    except FuturesTimeoutError:
+    except (socket.timeout, TimeoutError) as e:
         return {"success": False, "error": f"WHOIS lookup timed out after {WHOIS_TIMEOUT_SECONDS} seconds"}
     except Exception as e:
         return {"success": False, "error": str(e)}

--- a/tools/whois_tool.py
+++ b/tools/whois_tool.py
@@ -1,13 +1,16 @@
 import whois
 from utils.helpers import is_valid_domain
 
+WHOIS_TIMEOUT_SECONDS = 10
+
+
 def whois_lookup(domain: str) -> dict:
     """Perform WHOIS lookup for a domain."""
     try:
         if not is_valid_domain(domain):
             return {"success": False, "error": "Invalid domain format"}
 
-        result = whois.whois(domain)
+        result = whois.whois(domain, timeout=WHOIS_TIMEOUT_SECONDS)
 
         def safe_date(d):
             if d is None:

--- a/tools/whois_tool.py
+++ b/tools/whois_tool.py
@@ -1,3 +1,4 @@
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
 import whois
 from utils.helpers import is_valid_domain
 
@@ -10,7 +11,11 @@ def whois_lookup(domain: str) -> dict:
         if not is_valid_domain(domain):
             return {"success": False, "error": "Invalid domain format"}
 
-        result = whois.whois(domain, timeout=WHOIS_TIMEOUT_SECONDS)
+        def _fetch_whois():
+            return whois.whois(domain)
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            result = executor.submit(_fetch_whois).result(timeout=WHOIS_TIMEOUT_SECONDS)
 
         def safe_date(d):
             if d is None:
@@ -32,5 +37,7 @@ def whois_lookup(domain: str) -> dict:
             "country": result.country,
             "org": result.org
         }
+    except FuturesTimeoutError:
+        return {"success": False, "error": f"WHOIS lookup timed out after {WHOIS_TIMEOUT_SECONDS} seconds"}
     except Exception as e:
         return {"success": False, "error": str(e)}


### PR DESCRIPTION
## Problem

The whois_lookup function performs unbounded WHOIS network operations...

## Solution

- Added timeout handling
- Added timeout detection error handling
- Added timeout regression test

## Testing

- All tests pass

## Related Issue

Fixes #75