### PR TITLE
Fixed: Add timeout handling to port scan tool

### DIFF
--- a/tests/test_port_scan.py
+++ b/tests/test_port_scan.py
@@ -72,7 +72,8 @@ class TestPortScan(unittest.TestCase):
     @patch("tools.portscan_tool.nmap.PortScanner")
     def test_scan_timeout_returns_structured_error(self, mock_cls):
         import nmap
-        mock_cls.return_value.scan.side_effect = nmap.PortScannerTimeout("timed out")
+        timeout_exc = getattr(nmap, "PortScannerTimeout", TimeoutError)
+        mock_cls.return_value.scan.side_effect = timeout_exc("timed out")
 
         result = port_scan("example.com")
 

--- a/tests/test_port_scan.py
+++ b/tests/test_port_scan.py
@@ -26,6 +26,20 @@ class TestPortScan(unittest.TestCase):
         self.assertIn("results", result)
 
     @patch("tools.portscan_tool.nmap.PortScanner")
+    def test_scan_uses_nmap_and_application_timeouts(self, mock_cls):
+        scanner = self._make_scanner_mock()
+        mock_cls.return_value = scanner
+
+        result = port_scan("example.com", "service")
+
+        self.assertTrue(result["success"])
+        scanner.scan.assert_called_once_with(
+            hosts="example.com",
+            arguments="-sV -F --host-timeout 45s",
+            timeout=50,
+        )
+
+    @patch("tools.portscan_tool.nmap.PortScanner")
     def test_scan_includes_port_details(self, mock_cls):
         mock_cls.return_value = self._make_scanner_mock()
         result = port_scan("example.com")
@@ -54,6 +68,16 @@ class TestPortScan(unittest.TestCase):
 
         self.assertFalse(result["success"])
         self.assertIn("Nmap not found", result["error"])
+
+    @patch("tools.portscan_tool.nmap.PortScanner")
+    def test_scan_timeout_returns_structured_error(self, mock_cls):
+        import nmap
+        mock_cls.return_value.scan.side_effect = nmap.PortScannerTimeout("timed out")
+
+        result = port_scan("example.com")
+
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error"], "Port scan timed out")
 
     @patch("tools.portscan_tool.nmap.PortScanner")
     def test_invalid_scan_type_returns_error(self, mock_cls):

--- a/tools/portscan_tool.py
+++ b/tools/portscan_tool.py
@@ -1,5 +1,15 @@
 import nmap
 
+SCAN_CONFIG = {
+    "basic": {"args": "-F --host-timeout 30s", "timeout": 35},
+    "service": {"args": "-sV -F --host-timeout 45s", "timeout": 50},
+    "os": {"args": "-O -F --host-timeout 45s", "timeout": 50},
+    "full": {"args": "-p- --host-timeout 5m", "timeout": 310},
+    "vuln": {"args": "--script vuln -F --host-timeout 90s", "timeout": 100},
+}
+
+PORT_SCAN_TIMEOUT_ERRORS = (TimeoutError, getattr(nmap, "PortScannerTimeout", TimeoutError))
+
 def port_scan(target: str, scan_type: str = "basic") -> dict:
     """
     Perform Nmap port scan on a target IP or domain.
@@ -11,29 +21,25 @@ def port_scan(target: str, scan_type: str = "basic") -> dict:
     - "full"    : All 65535 ports, slow (-p-)
     - "vuln"    : Basic vulnerability scripts (--script vuln -F)
     """
-    scan_args = {
-        "basic":   "-F",
-        "service": "-sV -F",
-        "os":      "-O -F",
-        "full":    "-p-",
-        "vuln":    "--script vuln -F"
-    }
-
-    if scan_type not in scan_args:
+    if scan_type not in SCAN_CONFIG:
         return {
             "success": False,
             "error": (
                 f"Invalid scan_type '{scan_type}'. Valid options are: "
-                f"{', '.join(scan_args.keys())}"
+                f"{', '.join(SCAN_CONFIG.keys())}"
             ),
-            "valid_scan_types": list(scan_args.keys()),
+            "valid_scan_types": list(SCAN_CONFIG.keys()),
         }
 
     try:
         scanner = nmap.PortScanner()
 
-        args = scan_args[scan_type]
-        scanner.scan(hosts=target, arguments=args)
+        config = SCAN_CONFIG[scan_type]
+        scanner.scan(
+            hosts=target,
+            arguments=config["args"],
+            timeout=config["timeout"],
+        )
 
         results = []
         for host in scanner.all_hosts():
@@ -72,6 +78,8 @@ def port_scan(target: str, scan_type: str = "basic") -> dict:
             "results": results
         }
 
+    except PORT_SCAN_TIMEOUT_ERRORS:
+        return {"success": False, "error": "Port scan timed out"}
     except nmap.PortScannerError as e:
         return {"success": False, "error": f"Nmap not found or not installed: {str(e)}"}
     except Exception as e:


### PR DESCRIPTION
## Summary

This PR fixes the reliability issue where `port_scan` could block indefinitely while waiting for the underlying `nmap` process to finish.

The tool now has bounded execution at two levels:
- Adds an `nmap` host-level timeout for every supported scan type
- Adds an application-level timeout around the `python-nmap` scan call

This ensures slow, filtered, or unresponsive targets return a controlled error response instead of causing the MCP tool to hang.

## What Changed

- Added timeout configuration for all supported scan types:
  - `basic`
  - `service`
  - `os`
  - `full`
  - `vuln`
- Added `--host-timeout` to the nmap arguments for each scan type
- Added an application-level timeout for the scan execution
- Added structured timeout handling so timeout failures return a predictable error response
- Added tests to verify:
  - timeout arguments are passed correctly
  - timeout failures return a structured response

## Why

Previously, `scanner.scan()` was called without any timeout. For slow or heavily filtered targets, especially targets that silently drop packets, the scan could take much longer than expected and block the MCP tool from returning.

This change keeps the existing behavior for successful scans while making failure cases safer and more predictable.

## Testing

Ran the targeted port scan tests:

```bash
python -m pytest tests/test_port_scan.py -v
python -m pytest -v
```

Fixes #73 