### PR TITLE
docs: split tools section by full recon coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ It is also listed on glama mcp registry.
 
 ## Tools Available
 
+### Included in `full_recon`
+
 | Tool | Description |
 |---|---|
 | `whois_lookup` | Domain registration data — owner, registrar, creation date, expiry, name servers |
@@ -49,9 +51,14 @@ It is also listed on glama mcp registry.
 | `asn_lookup` | Autonomous System Number (ASN) and network ownership lookup — identifies hosting provider, ISP, organization, geolocation, and infrastructure ownership for domains or IP addresses |
 | `ip_reputation` | Check if an IP is flagged as malicious via AbuseIPDB (api key requied) |
 | `full_recon` | Runs all core tools in parallel and returns combined results with claude analysis |
-| `headers_analyzer` | Analyzes HTTP security headers — checks HSTS, CSP, X-Frame-Options, and more with severity ratings and misconfiguration details (Not included in full_recon) |
-| `cve_lookup` | Search NVD for known CVEs by software name and version (no API key required) (Not included in full_recon) |
-| `cloud_exposure_tool` | Checks for publicly accessible AWS S3, Azure Blob Storage, and Google Cloud Storage buckets using common bucket naming patterns derived from the target domain. (Not included in full_recon ) |
+
+### Standalone Tools
+
+| Tool | Description |
+|---|---|
+| `headers_analyzer` | Analyzes HTTP security headers — checks HSTS, CSP, X-Frame-Options, and more with severity ratings and misconfiguration details |
+| `cve_lookup` | Search NVD for known CVEs by software name and version (no API key required) |
+| `cloud_exposure_tool` | Checks for publicly accessible AWS S3, Azure Blob Storage, and Google Cloud Storage buckets using common bucket naming patterns derived from the target domain |
 
 ---
 


### PR DESCRIPTION
## Summary
- split the Tools Available section into Included in `full_recon` and Standalone Tools
- remove repeated `Not included in full_recon` notes from tool descriptions
- keep existing descriptions while making `full_recon` coverage clearer

Fixes #88.