### PR TITLE
fix: cloud exposure follow-ups (Azure sanitization, README name, tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ It is also listed on glama mcp registry.
 | `full_recon` | Runs all core tools in parallel and returns combined results with claude analysis |
 | `headers_analyzer` | Analyzes HTTP security headers — checks HSTS, CSP, X-Frame-Options, and more with severity ratings and misconfiguration details (Not included in full_recon) |
 | `cve_lookup` | Search NVD for known CVEs by software name and version (no API key required) (Not included in full_recon) |
-| `cloud_exposure_tool` | Checks for publicly accessible AWS S3, Azure Blob Storage, and Google Cloud Storage buckets using common bucket naming patterns derived from the target domain. (Not included in full_recon ) |
+| `cloud_exposure_check` | Checks for publicly accessible AWS S3, Azure Blob Storage, and Google Cloud Storage buckets using common bucket naming patterns derived from the target domain. (Not included in full_recon ) |
 
 ---
 

--- a/tests/test_cloud_exposure.py
+++ b/tests/test_cloud_exposure.py
@@ -32,6 +32,17 @@ def test_generate_bucket_names_azure_fallback():
     assert f"{company}backup" in names
     assert f"backup{company}" in names
 
+def test_generate_bucket_names_azure_sanitizes_hyphenated_company_name():
+    """Regression test: a company name that itself contains a hyphen
+    (e.g. domain "coca-cola.com" -> company_name "coca-cola") must be
+    sanitized before use, since Azure storage account names allow only
+    lowercase letters and digits. Fixing just the suffix separator
+    isn't enough if the hyphen is baked into the company name itself."""
+    names = generate_bucket_names("my-company", "AZURE")
+    assert all("-" not in n and "." not in n for n in names)
+    assert "mycompany" in names
+    assert "mycompanybackup" in names
+
 def test_generate_bucket_names_uniqueness():
     # Duplicates should be filtered out by dict.fromkeys()
     names = generate_bucket_names("test", "AWS S3")
@@ -96,6 +107,19 @@ def test_check_provider_aws(mock_url_response):
     assert result["provider"] == "AWS S3"
     assert result["bucket_name"] == "mybucket"
     mock_url_response.assert_called_once_with("https://mybucket.s3.amazonaws.com/")
+
+@patch("tools.cloud_exposure_tool.url_response")
+def test_check_provider_aws_dotted_bucket_uses_path_style(mock_url_response):
+    """Regression test: a dotted bucket name (e.g. assets.example.com) must
+    use path-style, not virtual-hosted-style, or AWS's wildcard cert
+    (*.s3.amazonaws.com) fails SSL hostname verification and the check
+    always returns ERROR without ever really checking the bucket."""
+    mock_url_response.return_value = {"status": "NOT_FOUND", "severity": "INFO", "note": "x"}
+
+    result = check_provider("assets.example.com", "AWS S3")
+    assert result["provider"] == "AWS S3"
+    assert result["bucket_name"] == "assets.example.com"
+    mock_url_response.assert_called_once_with("https://s3.amazonaws.com/assets.example.com/")
 
 @patch("tools.cloud_exposure_tool.url_response")
 def test_check_provider_gcp(mock_url_response):

--- a/tools/cloud_exposure_tool.py
+++ b/tools/cloud_exposure_tool.py
@@ -1,6 +1,7 @@
 from utils.helpers import is_valid_domain
 import tldextract
 import requests
+import re
 from concurrent.futures import ThreadPoolExecutor , as_completed
 
 COMMON_SUFFIXES = [
@@ -33,6 +34,14 @@ SUBDOMAIN_PREFIXES = [
     "files",
 ]
 
+def _sanitize_for_azure(name: str) -> str:
+    """Azure storage account names allow only lowercase letters and
+    digits; no hyphens, dots, or any other punctuation. A company
+    name that itself contains a hyphen (e.g. "coca-cola") must be
+    stripped here too, not just the suffix separator, or every
+    generated candidate is still an invalid account name."""
+    return re.sub(r"[^a-z0-9]", "", name.lower())
+
 def generate_bucket_names(company_name: str , provider: str) -> list:
     """Generate bucket names for the given company names and return list"""
     if provider in ("AWS S3", "GCP"):
@@ -49,16 +58,17 @@ def generate_bucket_names(company_name: str , provider: str) -> list:
             bucket_names.append(i + "." + company_name + ".com")
     else:
         bucket_names = []
+        azure_company_name = _sanitize_for_azure(company_name)
 
         for i in COMMON_SUFFIXES:
             if i == "":
-                bucket_names.append(company_name)
+                bucket_names.append(azure_company_name)
             else:
-                x = company_name + i
+                x = azure_company_name + i
                 bucket_names.append(x)
 
         for i in SUBDOMAIN_PREFIXES:
-            bucket_names.append(i + company_name)
+            bucket_names.append(i + azure_company_name)
 
     bucket_names = list(dict.fromkeys(bucket_names))
     return bucket_names


### PR DESCRIPTION
Follow-up to #71.

Three small items that came up during review but weren't blocking:

- Azure candidate names are now sanitized (lowercase, hyphens/dots stripped) before use; a company name that itself contains a hyphen (e.g. domain "coca-cola.com") previously still produced invalid Azure storage account names even after the #71 fix, since the hyphen came from the company name itself, not the suffix separator.
- README now correctly lists `cloud_exposure_check` (the actual registered tool name) instead of `cloud_exposure_tool` (the file name), consistent with mcp.json.
- Added regression tests for both the AWS path-style fix and the Azure sanitization, since neither had a dedicated test before.

16/16 tests pass.