### PR TITLE
feat: add official MCP threat analysis prompt for full_recon

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ It is also listed on glama mcp registry.
 | `cert_transparency` | Subdomain discovery via crt.sh Certificate Transparency logs with an automatic fallback to HackerTarget passive DNS on timeouts |
 | `asn_lookup` | Autonomous System Number (ASN) and network ownership lookup — identifies hosting provider, ISP, organization, geolocation, and infrastructure ownership for domains or IP addresses |
 | `ip_reputation` | Check if an IP is flagged as malicious via AbuseIPDB (api key requied) |
-| `full_recon` | Runs all core tools in parallel and returns combined results with claude analysis |
+| `full_recon` | Runs all core tools in parallel and returns combined result |
 
 ### Standalone Tools
 
@@ -60,6 +60,11 @@ It is also listed on glama mcp registry.
 | `cve_lookup` | Search NVD for known CVEs by software name and version (no API key required) |
 | `cloud_exposure_check` | Checks for publicly accessible AWS S3, Azure Blob Storage, and Google Cloud Storage buckets using common bucket naming patterns derived from the target domain |
 | `trace_redirects` | Traces the full HTTP redirect chain hop by hop — flags TLS downgrades, private-IP leaks, redirect loops, cross-domain hops, and overly long chains |
+
+## Prompts Available
+| Prompt | Description |
+|---|---|
+| `threat_analysis` | Generate a threat analysis prompt for the `full_recon` tool |
 
 ---
 
@@ -256,8 +261,22 @@ Scan scanme.nmap.org with service detection
 
 ### Full recon
 
+For getting best summarized result for the full_recon tool output, please use the prompt `threat_analysis` ( if your MCP client support ) by following these steps:
+
+> **Note:** Prompt support and automatic prompt chaining vary between MCP clients. Future client updates may improve this workflow.
+
+For Claude Desktop:
+1. Start Claude Desktop
+2. Click on the `+` icon
+3. Click on `connectors`
+4. If the AynOps is connected, it will show the option for `Add from AynOps`.
+5. Then choose the prompt `threat_analysis`
+6. Claude will use the selected prompt to generate a correlated threat intelligence report.
+
+After this ask this example prompt:
+
 ```
-Do a complete security recon on reddit.com
+Do a complete security recon on scanme.nmap.org
 ```
 
 Claude will run all core tools in parallel and deliver a full security analysis.
@@ -270,6 +289,20 @@ What do the open ports mean from an attacker's perspective?
 Is this SSL configuration strong enough for a financial services company?
 Cross-reference the open ports with known CVEs for the detected services.
 ```
+
+## ⚠️ Important: LLM Client Behavior
+
+AynOps is an **MCP server**, which means tool execution is orchestrated by your MCP client (e.g., Claude Desktop, Cursor, VS Code, etc.), not by AynOps itself.
+
+### Tool execution may vary
+
+Some LLM clients perform safety checks before invoking MCP tools. As a result, requests such as:
+
+> "Run a full security recon on example.com"
+
+may be allowed in one conversation but declined in another, even when using the same server.
+
+This behavior is determined by the **LLM client**, not by AynOps.
 
 ## ⚠️ Legal & Ethical Usage
 

--- a/mcp.json
+++ b/mcp.json
@@ -92,7 +92,7 @@
     },
     {
       "name": "full_recon",
-      "description": "Runs all core tools in parallel against a domain and returns combined results with claude anlaysis",
+      "description": "Runs all core tools in parallel against a domain and returns combined results",
       "input": {"domain": "string"},
       "requires_api_key": false
     },

--- a/server.py
+++ b/server.py
@@ -1,4 +1,6 @@
 from fastmcp import FastMCP
+from fastmcp.prompts import PromptResult
+
 from tools.whois_tool import whois_lookup
 from tools.dns_tool import dns_enumeration
 from tools.portscan_tool import port_scan
@@ -13,6 +15,7 @@ from tools.headers_tool import headers_analyzer
 from tools.email_security_tool import email_security_check
 from tools.redirect_tracer import trace_redirects
 from tools.cloud_exposure_tool import cloud_exposure_check
+from tools.prompts.threat_analysis import THREAT_ANALYSIS_PROMPT
 
 mcp = FastMCP("AynOps")
 
@@ -30,6 +33,22 @@ mcp.tool()(headers_analyzer)
 mcp.tool()(email_security_check)
 mcp.tool()(trace_redirects)
 mcp.tool()(cloud_exposure_check)
+
+@mcp.prompt(
+    name="threat_analysis",
+    description="Generate a structured cybersecurity threat analysis from AynOps full reconnaissance results.",
+    tags={"security", "analysis", "full_recon", "threat_intelligence"},
+    meta={"tool": "full_recon", "category": "security_analysis",}
+)
+def threat_analysis() -> PromptResult:
+    """
+    Generate a threat analysis prompt for the `full_recon` tool.
+    """
+    return PromptResult(
+        messages=THREAT_ANALYSIS_PROMPT,
+        description="Threat analysis prompt for AynOps full reconnaissance results.",
+        meta={"tool": "full_recon",}
+    )
 
 if __name__ == "__main__":
     mcp.run()

--- a/tests/test_full_recon.py
+++ b/tests/test_full_recon.py
@@ -117,14 +117,12 @@ def test_full_recon_invalid_domain(mock_is_valid):
     mock_is_valid.assert_called_once_with("invalid_domain!!")
 
 
-@patch("tools.fullrecon_tool.THREAT_ANALYSIS_PROMPT")
 @patch("tools.fullrecon_tool.extract_signals")
 @patch("tools.fullrecon_tool.TOOL_REGISTRY")
 @patch("tools.fullrecon_tool.is_valid_domain")
-def test_full_recon_success(mock_is_valid, mock_registry, mock_extract, mock_prompt):
+def test_full_recon_success(mock_is_valid, mock_registry, mock_extract):
     """Simulates a completely successful run across multiple dependency waves."""
     mock_is_valid.return_value = True
-    mock_prompt.format.return_value = "Formatted AI Prompt String"
     mock_extract.return_value = {"open_ports": [], "software_detected": []}
 
     # Define mock execution actions for tools

--- a/tools/fullrecon_tool.py
+++ b/tools/fullrecon_tool.py
@@ -4,7 +4,6 @@ from utils.helpers import is_valid_domain
 from tools.signals.extractor import extract_signals
 import concurrent.futures
 from datetime import datetime, timezone
-from tools.prompts.threat_analysis import THREAT_ANALYSIS_PROMPT
 
 def _format_signals_block(signals: dict) -> str:
     """Format extracted signals into a human-readable summary for the threat analysis prompt"""
@@ -149,5 +148,5 @@ def full_recon(domain: str) -> dict:
         },
         "raw_results": results,
         "pre_extracted_signals": signals,
-        "instructions": THREAT_ANALYSIS_PROMPT.format(domain=domain, scanned_at=scanned_at, signals_block=_format_signals_block(signals))
+        "signals_block":_format_signals_block(signals)
     }

--- a/tools/prompts/threat_analysis.py
+++ b/tools/prompts/threat_analysis.py
@@ -2,7 +2,7 @@
 
 THREAT_ANALYSIS_PROMPT = """\
 You are a senior penetration tester reviewing raw reconnaissance data collected
-from 10 automated tools about the target domain below.
+from all the automated tools about the target domain below.
 
 YOUR JOB IS CORRELATION, NOT ENUMERATION.
 Do NOT summarise each tool individually.
@@ -19,8 +19,8 @@ Follow this exact output structure — no prose outside it:
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 🛡️  AynOps Threat Intelligence Report
-Target : {domain}
-Scanned: {scanned_at}
+Target : domain ( Add domain from the tool output )
+Scanned: scanned_at ( Add scanned_at from the tool output )
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 ## Executive Summary
@@ -76,7 +76,7 @@ Risk Level: CRITICAL (80–100) / HIGH (60–79) / MEDIUM (40–59) / LOW (0–3
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 PRE-EXTRACTED SIGNALS (use these; do not re-derive from raw JSON):
-{signals_block}
+signals_block ( Add signals_block from the tool output )
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 EVIDENCE QUALITY RULES — follow these strictly:


### PR DESCRIPTION
## Summary

Fix #93
This PR introduces an official MCP Prompt for the `full_recon` workflow.

Instead of relying solely on an embedded instruction block returned by the tool, the threat analysis prompt is now exposed as a first-class MCP Prompt that can be discovered and selected by MCP-compatible clients.

## Changes

- Added a new `threat_analysis` MCP Prompt.
- Moved the full threat analysis instructions into the official prompt.
- Registered prompt metadata (name, description, tags, and metadata).
- Removed unnecessary prompt input parameters to simplify the user experience.
- Updated the prompt to analyze the output of the most recently executed `full_recon` tool using the conversation context.

## Why

Embedding prompt instructions inside tool responses may cause some LLMs to treat them as untrusted tool output or prompt injection. By exposing the analysis as an official MCP Prompt, the project aligns more closely with the MCP specification and enables a cleaner separation between tool execution and report generation.

## Testing

- Verified the prompt is discoverable by MCP clients.
- Verified selecting the prompt before running `full_recon` produces the expected structured threat intelligence report.
- Confirmed the prompt works without requiring manual input parameters.