### PR TITLE
feat: add robots_txt_inspect tool for hidden path reconnaissance

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ It is also listed on glama mcp registry.
 | `cve_lookup` | Search NVD for known CVEs by software name and version (no API key required) |
 | `cloud_exposure_check` | Checks for publicly accessible AWS S3, Azure Blob Storage, and Google Cloud Storage buckets using common bucket naming patterns derived from the target domain |
 | `trace_redirects` | Traces the full HTTP redirect chain hop by hop — flags TLS downgrades, private-IP leaks, redirect loops, cross-domain hops, and overly long chains |
+| `robots_txt_inspect` | Fetch and parse robots.txt to reveal hidden directories and sitemaps |
 
 ## Prompts Available
 | Prompt | Description |

--- a/mcp.json
+++ b/mcp.json
@@ -1,7 +1,7 @@
 {
   "name": "AynOps",
   "version": "1.1.2",
-  "description": "A Model Context Protocol server that gives AI Clients real-time cybersecurity reconnaissance capabilities — WHOIS, DNS enumeration, port scanning, SSL inspection, CVE lookup, IP reputation, ASN lookup and more.",
+  "description": "A Model Context Protocol server that gives AI Clients real-time cybersecurity reconnaissance capabilities \u00e2\u20ac\u201d WHOIS, DNS enumeration, port scanning, SSL inspection, CVE lookup, IP reputation, ASN lookup and more.",
   "author": "Gaohar Imran",
   "license": "MIT",
   "homepage": "https://github.com/AynOps/AynOps",
@@ -11,61 +11,83 @@
   },
   "runtime": "python",
   "runtime_version": ">=3.12",
-  "transport": ["stdio"],
+  "transport": [
+    "stdio"
+  ],
   "tools": [
     {
       "name": "whois_lookup",
-      "description": "Query domain registration data — owner, registrar, creation date, expiry, name servers",
-      "input": {"domain": "string"},
+      "description": "Query domain registration data \u00e2\u20ac\u201d owner, registrar, creation date, expiry, name servers",
+      "input": {
+        "domain": "string"
+      },
       "requires_api_key": false
     },
     {
       "name": "dns_enumeration",
       "description": "Enumerate DNS records and brute-force common subdomains",
-      "input": {"domain": "string"},
+      "input": {
+        "domain": "string"
+      },
       "requires_api_key": false
     },
     {
       "name": "port_scan",
       "description": "Nmap-powered port scanner with service and version detection",
-      "input": {"target": "string", "scan_type": "string"},
+      "input": {
+        "target": "string",
+        "scan_type": "string"
+      },
       "requires_api_key": false,
       "requires_system_dependency": "nmap"
     },
     {
       "name": "ssl_inspect",
-      "description": "Inspect SSL/TLS certificate — issuer, expiry, cipher, SANs, TLS version",
-      "input": {"domain": "string", "port": "integer"},
+      "description": "Inspect SSL/TLS certificate \u00e2\u20ac\u201d issuer, expiry, cipher, SANs, TLS version",
+      "input": {
+        "domain": "string",
+        "port": "integer"
+      },
       "requires_api_key": false
     },
     {
       "name": "headers_analyzer",
-      "description": "Analyze HTTP response security headers — checks HSTS, CSP, X-Frame-Options, and more with severity ratings and misconfiguration details",
-      "input": {"domain": "string"},
+      "description": "Analyze HTTP response security headers \u00e2\u20ac\u201d checks HSTS, CSP, X-Frame-Options, and more with severity ratings and misconfiguration details",
+      "input": {
+        "domain": "string"
+      },
       "requires_api_key": false
     },
     {
       "name": "email_security_check",
       "description": "Check SPF, DKIM, and DMARC DNS records for a domain to assess email anti-spoofing configuration",
-      "input": {"domain": "string"},
+      "input": {
+        "domain": "string"
+      },
       "requires_api_key": false
     },
     {
       "name": "tech_stack_detect",
       "description": "Fingerprint web server, CMS, CDN, JS frameworks, and security headers",
-      "input": {"domain": "string"},
+      "input": {
+        "domain": "string"
+      },
       "requires_api_key": false
     },
     {
       "name": "cert_transparency",
       "description": "Subdomain discovery and Certificate Transparency logs with an automatic fallback to HackerTarget passive DNS on timeouts",
-      "input": {"domain": "string"},
+      "input": {
+        "domain": "string"
+      },
       "requires_api_key": false
     },
     {
       "name": "asn_lookup",
       "description": "Find ASN, ISP, organization and geolocation for any IP or domain",
-      "input": {"target": "string"},
+      "input": {
+        "target": "string"
+      },
       "requires_api_key": true,
       "api_key_env": "IP_API_KEY",
       "api_key_url": "https://ipapi.com/"
@@ -73,13 +95,18 @@
     {
       "name": "cve_lookup",
       "description": "Search NVD database for known CVEs by software name and version",
-      "input": {"software": "string", "version": "string"},
+      "input": {
+        "software": "string",
+        "version": "string"
+      },
       "requires_api_key": false
     },
     {
       "name": "ip_reputation",
       "description": "Check if an IP address is flagged as malicious via AbuseIPDB",
-      "input": {"ip_address": "string"},
+      "input": {
+        "ip_address": "string"
+      },
       "requires_api_key": true,
       "api_key_env": "ABUSEIPDB_API_KEY",
       "api_key_url": "https://www.abuseipdb.com"
@@ -87,19 +114,33 @@
     {
       "name": "cloud_exposure_check",
       "description": "Checks for publicly accessible AWS S3, Azure Blob Storage, and Google Cloud Storage buckets from the target domain",
-      "input": {"domain": "string"},
+      "input": {
+        "domain": "string"
+      },
       "requires_api_key": false
     },
     {
       "name": "full_recon",
       "description": "Runs all core tools in parallel against a domain and returns combined results",
-      "input": {"domain": "string"},
+      "input": {
+        "domain": "string"
+      },
       "requires_api_key": false
     },
     {
       "name": "trace_redirects",
       "description": "Trace the full HTTP redirect chain for a URL hop by hop, flagging TLS downgrades, private-IP leaks, redirect loops, cross-domain hops, and overly long chains",
-      "input": {"url": "string"},
+      "input": {
+        "url": "string"
+      },
+      "requires_api_key": false
+    },
+    {
+      "name": "robots_txt_inspect",
+      "description": "Fetch and parse the robots.txt file for a given domain to reveal hidden directories and sitemaps",
+      "input": {
+        "domain": "string"
+      },
       "requires_api_key": false
     }
   ],
@@ -125,17 +166,19 @@
     ]
   },
   "claude_desktop_config": {
-  "mcpServers": {
-    "AynOps": {
-      "command": "C:\\full\\path\\to\\AynOps\\.venv\\Scripts\\python.exe",
-      "args": ["C:\\full\\path\\to\\AynOps\\server.py"],
-      "env": {
-        "ABUSEIPDB_API_KEY": "your-api-key-here",
-        "IP_API_KEY": "your-api-key-here"
+    "mcpServers": {
+      "AynOps": {
+        "command": "C:\\full\\path\\to\\AynOps\\.venv\\Scripts\\python.exe",
+        "args": [
+          "C:\\full\\path\\to\\AynOps\\server.py"
+        ],
+        "env": {
+          "ABUSEIPDB_API_KEY": "your-api-key-here",
+          "IP_API_KEY": "your-api-key-here"
+        }
       }
     }
-  }
-},
+  },
   "tags": [
     "cybersecurity",
     "reconnaissance",

--- a/mcp.json
+++ b/mcp.json
@@ -1,7 +1,7 @@
 {
   "name": "AynOps",
   "version": "1.1.2",
-  "description": "A Model Context Protocol server that gives AI Clients real-time cybersecurity reconnaissance capabilities \u00e2\u20ac\u201d WHOIS, DNS enumeration, port scanning, SSL inspection, CVE lookup, IP reputation, ASN lookup and more.",
+  "description": "A Model Context Protocol server that gives AI Clients real-time cybersecurity reconnaissance capabilities — WHOIS, DNS enumeration, port scanning, SSL inspection, CVE lookup, IP reputation, ASN lookup and more.",
   "author": "Gaohar Imran",
   "license": "MIT",
   "homepage": "https://github.com/AynOps/AynOps",
@@ -17,7 +17,7 @@
   "tools": [
     {
       "name": "whois_lookup",
-      "description": "Query domain registration data \u00e2\u20ac\u201d owner, registrar, creation date, expiry, name servers",
+      "description": "Query domain registration data — owner, registrar, creation date, expiry, name servers",
       "input": {
         "domain": "string"
       },
@@ -43,7 +43,7 @@
     },
     {
       "name": "ssl_inspect",
-      "description": "Inspect SSL/TLS certificate \u00e2\u20ac\u201d issuer, expiry, cipher, SANs, TLS version",
+      "description": "Inspect SSL/TLS certificate — issuer, expiry, cipher, SANs, TLS version",
       "input": {
         "domain": "string",
         "port": "integer"
@@ -52,7 +52,7 @@
     },
     {
       "name": "headers_analyzer",
-      "description": "Analyze HTTP response security headers \u00e2\u20ac\u201d checks HSTS, CSP, X-Frame-Options, and more with severity ratings and misconfiguration details",
+      "description": "Analyze HTTP response security headers — checks HSTS, CSP, X-Frame-Options, and more with severity ratings and misconfiguration details",
       "input": {
         "domain": "string"
       },

--- a/server.py
+++ b/server.py
@@ -15,6 +15,7 @@ from tools.headers_tool import headers_analyzer
 from tools.email_security_tool import email_security_check
 from tools.redirect_tracer import trace_redirects
 from tools.cloud_exposure_tool import cloud_exposure_check
+from tools.robots_txt_tool import robots_txt_inspect
 from tools.prompts.threat_analysis import THREAT_ANALYSIS_PROMPT
 
 mcp = FastMCP("AynOps")
@@ -33,6 +34,7 @@ mcp.tool()(headers_analyzer)
 mcp.tool()(email_security_check)
 mcp.tool()(trace_redirects)
 mcp.tool()(cloud_exposure_check)
+mcp.tool()(robots_txt_inspect)
 
 @mcp.prompt(
     name="threat_analysis",

--- a/tests/test_robots_txt_tool.py
+++ b/tests/test_robots_txt_tool.py
@@ -12,14 +12,16 @@ def test_robots_txt_inspect_invalid_domain():
 def test_robots_txt_inspect_happy_path_https(mock_get):
     mock_response = MagicMock()
     mock_response.status_code = 200
+    mock_response.url = "https://example.com/robots.txt"
     mock_response.text = """
 User-agent: *
-Disallow: /
-Disallow: /admin
+Disallow: /admin # No admins allowed
+Allow: /admin/public
 Disallow: /backup/
-Disallow: /admin
+
+User-agent: Googlebot
+Disallow: /secret/
 Sitemap: https://example.com/sitemap.xml
-Sitemap: https://example.com/sitemap2.xml
 """
     mock_get.return_value = mock_response
     
@@ -27,24 +29,39 @@ Sitemap: https://example.com/sitemap2.xml
     
     assert result["success"] is True
     assert result["domain"] == "example.com"
-    # / should be filtered out, duplicates should be removed, order preserved
-    assert result["disallowed_paths"] == ["/admin", "/backup/"]
-    assert result["sitemaps"] == ["https://example.com/sitemap.xml", "https://example.com/sitemap2.xml"]
+    assert result["robots_url"] == "https://example.com/robots.txt"
+    
+    # Check top level aggregations
+    assert "/admin" in result["disallowed_paths"]
+    assert "/backup/" in result["disallowed_paths"]
+    assert "/secret/" in result["disallowed_paths"]
+    assert result["allowed_paths"] == ["/admin/public"]
+    assert result["sitemaps"] == ["https://example.com/sitemap.xml"]
+    
+    # Check rule sets
+    assert len(result["rules"]) == 2
+    assert result["rules"][0]["user_agent"] == "*"
+    assert result["rules"][0]["disallow"] == ["/admin", "/backup/"]
+    assert result["rules"][0]["allow"] == ["/admin/public"]
+    
+    assert result["rules"][1]["user_agent"] == "Googlebot"
+    assert result["rules"][1]["disallow"] == ["/secret/"]
+    assert result["rules"][1]["allow"] == []
 
 @patch("tools.robots_txt_tool.requests.get")
 def test_robots_txt_inspect_fallback_to_http(mock_get):
-    # First call (HTTPS) raises an exception, second call (HTTP) succeeds
     mock_response = MagicMock()
     mock_response.status_code = 200
+    mock_response.url = "http://example.com/robots.txt"
     mock_response.text = "User-agent: *\nDisallow: /private"
     
-    # Configure side_effect: first call raises RequestException, second returns mock_response
     mock_get.side_effect = [requests.RequestException("Connection error"), mock_response]
     
     result = robots_txt_inspect("example.com")
     
     assert result["success"] is True
     assert result["domain"] == "example.com"
+    assert result["robots_url"] == "http://example.com/robots.txt"
     assert result["disallowed_paths"] == ["/private"]
     assert mock_get.call_count == 2
 

--- a/tests/test_robots_txt_tool.py
+++ b/tests/test_robots_txt_tool.py
@@ -1,0 +1,58 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from tools.robots_txt_tool import robots_txt_inspect
+import requests
+
+def test_robots_txt_inspect_invalid_domain():
+    result = robots_txt_inspect("invalid domain")
+    assert result["success"] is False
+    assert "Invalid domain format" in result["error"]
+
+@patch("tools.robots_txt_tool.requests.get")
+def test_robots_txt_inspect_happy_path_https(mock_get):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = """
+User-agent: *
+Disallow: /
+Disallow: /admin
+Disallow: /backup/
+Disallow: /admin
+Sitemap: https://example.com/sitemap.xml
+Sitemap: https://example.com/sitemap2.xml
+"""
+    mock_get.return_value = mock_response
+    
+    result = robots_txt_inspect("example.com")
+    
+    assert result["success"] is True
+    assert result["domain"] == "example.com"
+    # / should be filtered out, duplicates should be removed, order preserved
+    assert result["disallowed_paths"] == ["/admin", "/backup/"]
+    assert result["sitemaps"] == ["https://example.com/sitemap.xml", "https://example.com/sitemap2.xml"]
+
+@patch("tools.robots_txt_tool.requests.get")
+def test_robots_txt_inspect_fallback_to_http(mock_get):
+    # First call (HTTPS) raises an exception, second call (HTTP) succeeds
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = "User-agent: *\nDisallow: /private"
+    
+    # Configure side_effect: first call raises RequestException, second returns mock_response
+    mock_get.side_effect = [requests.RequestException("Connection error"), mock_response]
+    
+    result = robots_txt_inspect("example.com")
+    
+    assert result["success"] is True
+    assert result["domain"] == "example.com"
+    assert result["disallowed_paths"] == ["/private"]
+    assert mock_get.call_count == 2
+
+@patch("tools.robots_txt_tool.requests.get")
+def test_robots_txt_inspect_failure(mock_get):
+    mock_get.side_effect = requests.RequestException("Timeout")
+    
+    result = robots_txt_inspect("example.com")
+    
+    assert result["success"] is False
+    assert "Failed to fetch robots.txt" in result["error"]

--- a/tools/robots_txt_tool.py
+++ b/tools/robots_txt_tool.py
@@ -1,4 +1,5 @@
 import requests
+from urllib.parse import urlparse
 from utils.helpers import is_valid_domain
 
 def robots_txt_inspect(domain: str) -> dict:
@@ -23,26 +24,82 @@ def robots_txt_inspect(domain: str) -> dict:
             response.raise_for_status()
             
         content = response.text
-        disallowed = []
+        robots_url = response.url
+        
+        # We will parse robots.txt into rules by User-agent
+        rules = []
+        current_agent = "*"
+        current_allow = []
+        current_disallow = []
+        
         sitemaps = []
         
         for line in content.splitlines():
+            # Strip inline comments first
+            if "#" in line:
+                line = line.split("#", 1)[0]
             line = line.strip()
-            if line.lower().startswith("disallow:"):
+            
+            if not line:
+                continue
+                
+            line_lower = line.lower()
+            
+            if line_lower.startswith("user-agent:"):
+                # If we were tracking a previous agent that had rules, save it
+                if current_allow or current_disallow:
+                    rules.append({
+                        "user_agent": current_agent,
+                        "allow": list(dict.fromkeys(current_allow)),
+                        "disallow": list(dict.fromkeys(current_disallow))
+                    })
+                    current_allow = []
+                    current_disallow = []
+                
+                current_agent = line.split(":", 1)[1].strip()
+                
+            elif line_lower.startswith("disallow:"):
                 path = line.split(":", 1)[1].strip()
-                # Filter out generic or empty entries
-                if path and path != "/":
-                    disallowed.append(path)
-            elif line.lower().startswith("sitemap:"):
+                if path:
+                    current_disallow.append(path)
+                    
+            elif line_lower.startswith("allow:"):
+                path = line.split(":", 1)[1].strip()
+                if path:
+                    current_allow.append(path)
+                    
+            elif line_lower.startswith("sitemap:"):
                 sitemap = line.split(":", 1)[1].strip()
                 if sitemap:
                     sitemaps.append(sitemap)
-        
+                    
+        # Add the last rule block if it has anything
+        if current_allow or current_disallow or current_agent == "*":
+            # Avoid adding empty duplicate '*' rules if we haven't seen anything
+            if current_allow or current_disallow or not any(r["user_agent"] == "*" for r in rules):
+                rules.append({
+                    "user_agent": current_agent,
+                    "allow": list(dict.fromkeys(current_allow)),
+                    "disallow": list(dict.fromkeys(current_disallow))
+                })
+
+        # For backward compatibility and top-level summary, aggregate all unique paths
+        all_allowed = []
+        all_disallowed = []
+        for r in rules:
+            all_allowed.extend(r["allow"])
+            all_disallowed.extend(r["disallow"])
+            
         return {
             "success": True,
             "domain": domain,
-            "disallowed_paths": list(dict.fromkeys(disallowed)),
-            "sitemaps": list(dict.fromkeys(sitemaps))
+            "robots_url": robots_url,
+            "allowed_paths": list(dict.fromkeys(all_allowed)),
+            "disallowed_paths": list(dict.fromkeys(all_disallowed)),
+            "sitemaps": list(dict.fromkeys(sitemaps)),
+            "crawl_delay": None,
+            "host": None,
+            "rules": rules
         }
 
     except requests.RequestException as e:

--- a/tools/robots_txt_tool.py
+++ b/tools/robots_txt_tool.py
@@ -1,0 +1,59 @@
+import httpx
+from pydantic import BaseModel, Field
+
+class RobotsTxtResult(BaseModel):
+    domain: str = Field(description="The target domain")
+    found: bool = Field(description="Whether a robots.txt file was found")
+    content: str = Field(description="The raw content of the robots.txt file")
+    disallowed_paths: list[str] = Field(description="List of disallowed paths")
+    sitemaps: list[str] = Field(description="List of sitemaps found")
+    error: str | None = Field(None, description="Error message if the request failed")
+
+def robots_txt_inspect(domain: str) -> RobotsTxtResult:
+    """Fetch and parse the robots.txt file for a given domain to find hidden paths and sitemaps."""
+    url = f"https://{domain}/robots.txt"
+    try:
+        with httpx.Client(timeout=10.0, follow_redirects=True) as client:
+            response = client.get(url)
+            
+            if response.status_code == 200:
+                content = response.text
+                disallowed = []
+                sitemaps = []
+                
+                for line in content.splitlines():
+                    line = line.strip()
+                    if line.lower().startswith("disallow:"):
+                        path = line.split(":", 1)[1].strip()
+                        if path:
+                            disallowed.append(path)
+                    elif line.lower().startswith("sitemap:"):
+                        sitemap = line.split(":", 1)[1].strip()
+                        if sitemap:
+                            sitemaps.append(sitemap)
+                
+                return RobotsTxtResult(
+                    domain=domain,
+                    found=True,
+                    content=content,
+                    disallowed_paths=list(set(disallowed)),
+                    sitemaps=list(set(sitemaps))
+                )
+            else:
+                return RobotsTxtResult(
+                    domain=domain,
+                    found=False,
+                    content="",
+                    disallowed_paths=[],
+                    sitemaps=[],
+                    error=f"HTTP {response.status_code}"
+                )
+    except Exception as e:
+        return RobotsTxtResult(
+            domain=domain,
+            found=False,
+            content="",
+            disallowed_paths=[],
+            sitemaps=[],
+            error=str(e)
+        )

--- a/tools/robots_txt_tool.py
+++ b/tools/robots_txt_tool.py
@@ -1,59 +1,51 @@
-import httpx
-from pydantic import BaseModel, Field
+import requests
+from utils.helpers import is_valid_domain
 
-class RobotsTxtResult(BaseModel):
-    domain: str = Field(description="The target domain")
-    found: bool = Field(description="Whether a robots.txt file was found")
-    content: str = Field(description="The raw content of the robots.txt file")
-    disallowed_paths: list[str] = Field(description="List of disallowed paths")
-    sitemaps: list[str] = Field(description="List of sitemaps found")
-    error: str | None = Field(None, description="Error message if the request failed")
-
-def robots_txt_inspect(domain: str) -> RobotsTxtResult:
-    """Fetch and parse the robots.txt file for a given domain to find hidden paths and sitemaps."""
-    url = f"https://{domain}/robots.txt"
+def robots_txt_inspect(domain: str) -> dict:
+    """
+    Fetch and parse the robots.txt file for a given domain to reveal hidden directories and sitemaps.
+    """
     try:
-        with httpx.Client(timeout=10.0, follow_redirects=True) as client:
-            response = client.get(url)
+        if not is_valid_domain(domain):
+            return {"success": False, "error": "Invalid domain format"}
+
+        headers = {"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"}
+        url_https = f"https://{domain}/robots.txt"
+        url_http = f"http://{domain}/robots.txt"
+        
+        response = None
+        try:
+            response = requests.get(url_https, timeout=10.0, headers=headers)
+            response.raise_for_status()
+        except requests.RequestException:
+            # Fallback to HTTP
+            response = requests.get(url_http, timeout=10.0, headers=headers)
+            response.raise_for_status()
             
-            if response.status_code == 200:
-                content = response.text
-                disallowed = []
-                sitemaps = []
-                
-                for line in content.splitlines():
-                    line = line.strip()
-                    if line.lower().startswith("disallow:"):
-                        path = line.split(":", 1)[1].strip()
-                        if path:
-                            disallowed.append(path)
-                    elif line.lower().startswith("sitemap:"):
-                        sitemap = line.split(":", 1)[1].strip()
-                        if sitemap:
-                            sitemaps.append(sitemap)
-                
-                return RobotsTxtResult(
-                    domain=domain,
-                    found=True,
-                    content=content,
-                    disallowed_paths=list(set(disallowed)),
-                    sitemaps=list(set(sitemaps))
-                )
-            else:
-                return RobotsTxtResult(
-                    domain=domain,
-                    found=False,
-                    content="",
-                    disallowed_paths=[],
-                    sitemaps=[],
-                    error=f"HTTP {response.status_code}"
-                )
+        content = response.text
+        disallowed = []
+        sitemaps = []
+        
+        for line in content.splitlines():
+            line = line.strip()
+            if line.lower().startswith("disallow:"):
+                path = line.split(":", 1)[1].strip()
+                # Filter out generic or empty entries
+                if path and path != "/":
+                    disallowed.append(path)
+            elif line.lower().startswith("sitemap:"):
+                sitemap = line.split(":", 1)[1].strip()
+                if sitemap:
+                    sitemaps.append(sitemap)
+        
+        return {
+            "success": True,
+            "domain": domain,
+            "disallowed_paths": list(dict.fromkeys(disallowed)),
+            "sitemaps": list(dict.fromkeys(sitemaps))
+        }
+
+    except requests.RequestException as e:
+        return {"success": False, "error": f"Failed to fetch robots.txt: {str(e)}"}
     except Exception as e:
-        return RobotsTxtResult(
-            domain=domain,
-            found=False,
-            content="",
-            disallowed_paths=[],
-            sitemaps=[],
-            error=str(e)
-        )
+        return {"success": False, "error": str(e)}


### PR DESCRIPTION
Added a new MCP tool to fetch and parse `robots.txt` files. This tool extracts all `Disallow:` paths and `Sitemap:` URLs, providing critical reconnaissance data by revealing potentially sensitive hidden directories. Fully typed with Pydantic and uses `httpx`.