### PR TITLE
feat(asn): replace IPAPI with Team Cymru WHOIS (no API key required)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,1 @@
 ABUSEIPDB_API_KEY=""
-IP_API_KEY="" ## for ASN Lookup

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Add this configuration:
 
 > ⚠️ Always use the **full absolute path** to your `.venv` Python executable — not just `python` or `python3`. Claude Desktop may use a different Python installation otherwise.
 
-> **Note:** `ABUSEIPDB_API_KEY` is only required for the `ip_reputation` tool. Get a free key at [abuseipdb.com](https://www.abuseipdb.com). The `asn_lookup` tool uses Team Cymru WHOIS and does not require an API key.
+> **Note:** `ABUSEIPDB_API_KEY` is only required for the `ip_reputation` tool. Get a free key at [abuseipdb.com](https://www.abuseipdb.com).
 
 ### Step 5 — Restart Claude Desktop
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ It is also listed on glama mcp registry.
 | `email_security_check` | Checks SPF, DKIM, and DMARC DNS records — returns a security_score, rating, and actionable recommendations for missing or weak configurations |
 | `tech_stack_detect` | Web server, CMS, JS frameworks, CDN, analytics, and security header scoring |
 | `cert_transparency` | Subdomain discovery via crt.sh Certificate Transparency logs with an automatic fallback to HackerTarget passive DNS on timeouts |
-| `asn_lookup` | Autonomous System Number (ASN) and network ownership lookup — identifies hosting provider, ISP, organization, geolocation, and infrastructure ownership for domains or IP addresses |
+| `asn_lookup` | Autonomous System Number (ASN) and network ownership lookup via Team Cymru WHOIS — identifies ASN, BGP prefix, organization, registry, country, and allocation date for domains or IP addresses (no API key required) |
 | `ip_reputation` | Check if an IP is flagged as malicious via AbuseIPDB (api key requied) |
 | `full_recon` | Runs all core tools in parallel and returns combined result |
 
@@ -180,8 +180,7 @@ Add this configuration:
       "command": "C:\\full\\path\\to\\AynOps\\.venv\\Scripts\\python.exe",
       "args": ["C:\\full\\path\\to\\AynOps\\server.py"],
       "env": {
-        "ABUSEIPDB_API_KEY": "your-api-key-here",
-        "IP_API_KEY": "your-api-key-here"
+        "ABUSEIPDB_API_KEY": "your-api-key-here"
       }
     }
   }
@@ -196,8 +195,7 @@ Add this configuration:
       "command": "/full/path/to/AynOps/.venv/bin/python3",
       "args": ["/full/path/to/AynOps/server.py"],
       "env": {
-        "ABUSEIPDB_API_KEY": "your-api-key-here",
-        "IP_API_KEY": "your-api-key-here"
+        "ABUSEIPDB_API_KEY": "your-api-key-here"
       }
     }
   }
@@ -206,7 +204,7 @@ Add this configuration:
 
 > ⚠️ Always use the **full absolute path** to your `.venv` Python executable — not just `python` or `python3`. Claude Desktop may use a different Python installation otherwise.
 
-> **Note:** `ABUSEIPDB_API_KEY` is only required for the `ip_reputation` tool. Get a free key at [abuseipdb.com](https://www.abuseipdb.com). `IP_API_KEY` is only required for the `asn_lookup` tool. get a free key at [ipapi.com](https://ipapi.com/)
+> **Note:** `ABUSEIPDB_API_KEY` is only required for the `ip_reputation` tool. Get a free key at [abuseipdb.com](https://www.abuseipdb.com). The `asn_lookup` tool uses Team Cymru WHOIS and does not require an API key.
 
 ### Step 5 — Restart Claude Desktop
 

--- a/mcp.json
+++ b/mcp.json
@@ -84,13 +84,11 @@
     },
     {
       "name": "asn_lookup",
-      "description": "Find ASN, ISP, organization and geolocation for any IP or domain",
+      "description": "Find ASN, BGP prefix, organization, registry and country for any IP or domain via Team Cymru WHOIS (no API key required)",
       "input": {
         "target": "string"
       },
-      "requires_api_key": true,
-      "api_key_env": "IP_API_KEY",
-      "api_key_url": "https://ipapi.com/"
+      "requires_api_key": false
     },
     {
       "name": "cve_lookup",
@@ -149,11 +147,6 @@
       "name": "ABUSEIPDB_API_KEY",
       "description": "Required for ip_reputation tool. Get free key at abuseipdb.com",
       "required": false
-    },
-    {
-      "name": "IP_API_KEY",
-      "description": "Required for asn_lookup tool. Get free key at ipapi.com",
-      "required": false
     }
   ],
   "installation": {
@@ -173,8 +166,7 @@
           "C:\\full\\path\\to\\AynOps\\server.py"
         ],
         "env": {
-          "ABUSEIPDB_API_KEY": "your-api-key-here",
-          "IP_API_KEY": "your-api-key-here"
+          "ABUSEIPDB_API_KEY": "your-api-key-here"
         }
       }
     }

--- a/server.json
+++ b/server.json
@@ -23,13 +23,6 @@
           "isRequired": false,
           "isSecret": true,
           "format": "string"
-        },
-        {
-          "name": "IP_API_KEY",
-          "description": "Required for asn_lookup tool. Get free key at ipapi.com",
-          "isRequired": false,
-          "isSecret": true,
-          "format": "string"
         }
       ]
     }

--- a/tests/test_asn_lookup.py
+++ b/tests/test_asn_lookup.py
@@ -127,6 +127,20 @@ class TestAsnLookup(unittest.TestCase):
         self.assertFalse(result["success"])
         self.assertIn("malformed", result["error"])
 
+    @patch("tools.asn_tool.socket.create_connection")
+    def test_header_only_response_returns_error(self, mock_create_connection):
+        # Response with only a header line and no data lines should be rejected.
+        header_only = (
+            "AS      | IP               | BGP Prefix          | CC | Registry | "
+            "Allocated  | AS Name\n"
+        )
+        mock_create_connection.return_value = _make_fake_socket(header_only)
+
+        result = asn_lookup("8.8.8.8")
+
+        self.assertFalse(result["success"])
+        self.assertIn("malformed", result["error"])
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_asn_lookup.py
+++ b/tests/test_asn_lookup.py
@@ -1,48 +1,95 @@
-import os
 import socket
 import unittest
-from unittest.mock import Mock, patch
-
-import requests
+from unittest.mock import MagicMock, patch
 
 from tools.asn_tool import asn_lookup
 
 
+# Sample Team Cymru WHOIS response for 8.8.8.8
+CYMRU_RESPONSE_8_8_8_8 = (
+    "AS      | IP               | BGP Prefix          | CC | Registry | Allocated  | AS Name\n"
+    "15169   | 8.8.8.8          | 8.8.8.0/24          | US | arin     | 1992-12-01 | GOOGLE, US\n"
+)
+
+# Sample Team Cymru WHOIS response for Cloudflare IPv6 DNS
+CYMRU_RESPONSE_CLOUDFLARE_V6 = (
+    "AS      | IP               | BGP Prefix          | CC | Registry | Allocated  | AS Name\n"
+    "13335   | 2606:4700:4700::1111 | 2606:4700::/32  | US | arin     | 2010-07-14 | CLOUDFLARENET, US\n"
+)
+
+
+def _make_fake_socket(response_text: str) -> MagicMock:
+    """Build a fake socket that yields the given WHOIS response then closes."""
+    fake_sock = MagicMock()
+    response_bytes = response_text.encode("utf-8")
+    if response_bytes:
+        fake_sock.recv.side_effect = [response_bytes, b""]
+    else:
+        fake_sock.recv.side_effect = [b""]
+    fake_sock.__enter__.return_value = fake_sock
+    fake_sock.__exit__.return_value = None
+    return fake_sock
+
+
 class TestAsnLookup(unittest.TestCase):
 
-    def test_missing_api_key_returns_error(self):
-        with patch.dict(os.environ, {}, clear=True):
-            result = asn_lookup("8.8.8.8")
-        self.assertFalse(result["success"])
-        self.assertIn("IP_API_KEY", result["error"])
-
-    @patch.dict(os.environ, {"IP_API_KEY": "test-key"})
-    @patch("tools.asn_tool.requests.get")
-    def test_valid_ip_returns_asn_data(self, mock_get):
-        response = Mock()
-        response.status_code = 200
-        response.json.return_value = {
-            "ip": "8.8.8.8",
-            "country_name": "United States",
-            "region_name": "California",
-            "city": "Mountain View",
-            "connection": {
-                "asn": 15169,
-                "org": "Google LLC",
-                "isp": "Google LLC",
-            },
-        }
-        mock_get.return_value = response
+    @patch("tools.asn_tool.socket.create_connection")
+    def test_valid_ipv4_returns_asn_data(self, mock_create_connection):
+        mock_create_connection.return_value = _make_fake_socket(CYMRU_RESPONSE_8_8_8_8)
 
         result = asn_lookup("8.8.8.8")
 
         self.assertTrue(result["success"])
+        self.assertEqual(result["ip"], "8.8.8.8")
         self.assertEqual(result["asn"], "AS15169")
-        self.assertEqual(result["org"], "Google LLC")
-        self.assertEqual(result["country"], "United States")
-        mock_get.assert_called_once()
+        self.assertEqual(result["country"], "US")
+        self.assertIn("GOOGLE", result["organization"])
+        self.assertEqual(result["bgp_prefix"], "8.8.8.0/24")
+        self.assertEqual(result["registry"], "arin")
+        self.assertEqual(result["allocated"], "1992-12-01")
+        mock_create_connection.assert_called_once()
 
-    @patch.dict(os.environ, {"IP_API_KEY": "test-key"})
+    @patch("tools.asn_tool.socket.create_connection")
+    @patch("tools.asn_tool.socket.getaddrinfo")
+    def test_valid_domain_returns_asn_data(self, mock_getaddrinfo, mock_create_connection):
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("8.8.8.8", 0))]
+        mock_create_connection.return_value = _make_fake_socket(CYMRU_RESPONSE_8_8_8_8)
+
+        result = asn_lookup("google.com")
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["ip"], "8.8.8.8")
+        self.assertEqual(result["asn"], "AS15169")
+        self.assertIn("GOOGLE", result["organization"])
+        mock_getaddrinfo.assert_called_once()
+
+    @patch("tools.asn_tool.socket.create_connection")
+    @patch("tools.asn_tool.socket.getaddrinfo")
+    def test_url_input_extracts_host(self, mock_getaddrinfo, mock_create_connection):
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("8.8.8.8", 0))]
+        mock_create_connection.return_value = _make_fake_socket(CYMRU_RESPONSE_8_8_8_8)
+
+        result = asn_lookup("https://google.com:443")
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["ip"], "8.8.8.8")
+        self.assertEqual(result["asn"], "AS15169")
+        # Verify getaddrinfo was called with the host, not the URL
+        called_arg = mock_getaddrinfo.call_args[0][0]
+        self.assertEqual(called_arg, "google.com")
+
+    @patch("tools.asn_tool.socket.create_connection")
+    def test_valid_ipv6_returns_asn_data(self, mock_create_connection):
+        mock_create_connection.return_value = _make_fake_socket(CYMRU_RESPONSE_CLOUDFLARE_V6)
+
+        result = asn_lookup("2606:4700:4700::1111")
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["ip"], "2606:4700:4700::1111")
+        self.assertEqual(result["asn"], "AS13335")
+        self.assertEqual(result["country"], "US")
+        self.assertIn("CLOUDFLARE", result["organization"])
+
     @patch("tools.asn_tool.socket.getaddrinfo")
     def test_unresolvable_domain_returns_error(self, mock_getaddrinfo):
         mock_getaddrinfo.side_effect = socket.gaierror("Name or service not known")
@@ -52,15 +99,33 @@ class TestAsnLookup(unittest.TestCase):
         self.assertFalse(result["success"])
         self.assertIn("resolve", result["error"])
 
-    @patch.dict(os.environ, {"IP_API_KEY": "test-key"})
-    @patch("tools.asn_tool.requests.get")
-    def test_api_timeout_returns_error(self, mock_get):
-        mock_get.side_effect = requests.exceptions.Timeout()
+    @patch("tools.asn_tool.socket.create_connection")
+    def test_whois_timeout_returns_error(self, mock_create_connection):
+        mock_create_connection.side_effect = socket.timeout("timed out")
 
         result = asn_lookup("8.8.8.8")
 
         self.assertFalse(result["success"])
         self.assertIn("timed out", result["error"])
+
+    @patch("tools.asn_tool.socket.create_connection")
+    def test_connection_refused_returns_error(self, mock_create_connection):
+        mock_create_connection.side_effect = ConnectionError("Connection refused")
+
+        result = asn_lookup("8.8.8.8")
+
+        self.assertFalse(result["success"])
+        self.assertIn("Could not connect to Team Cymru WHOIS", result["error"])
+
+    @patch("tools.asn_tool.socket.create_connection")
+    def test_malformed_response_returns_error(self, mock_create_connection):
+        # Empty response from the WHOIS service
+        mock_create_connection.return_value = _make_fake_socket("")
+
+        result = asn_lookup("8.8.8.8")
+
+        self.assertFalse(result["success"])
+        self.assertIn("malformed", result["error"])
 
 
 if __name__ == "__main__":

--- a/tools/asn_tool.py
+++ b/tools/asn_tool.py
@@ -32,6 +32,8 @@ def asn_lookup(target: str) -> dict:
         except ValueError:
             ip = socket.getaddrinfo(target, None)[0][4][0]
 
+        # Team Cymru bulk WHOIS query (port 43 is the standard WHOIS port).
+        # Format documented at https://team-cymru.com/community-services/ip-to-asn-mapping/
         query = f"begin\nverbose\n{ip}\nend\n"
         with socket.create_connection(("whois.cymru.com", 43), timeout=15) as sock:
             sock.sendall(query.encode())
@@ -41,8 +43,15 @@ def asn_lookup(target: str) -> dict:
                 if not chunk:
                     break
                 chunks.append(chunk)
+            # AS names occasionally contain non-ASCII; replace avoids decode crashes.
             response = b"".join(chunks).decode("utf-8", errors="replace")
 
+        # Team Cymru verbose response is pipe-delimited. First line is a header
+        # (e.g. "AS | IP | BGP Prefix | CC | Registry | Allocated | AS Name"),
+        # followed by one data line per queried IP. We accept the first line
+        # whose first field is numeric (this skips the header and any blank lines).
+        # Field indices: 0=AS, 1=IP, 2=BGP Prefix, 3=CC, 4=Registry,
+        #                5=Allocated, 6=AS Name
         lines = [line for line in response.strip().splitlines() if line.strip()]
         if not lines:
             return {
@@ -63,6 +72,8 @@ def asn_lookup(target: str) -> dict:
                 "error": "Unexpected or malformed response from Team Cymru WHOIS",
             }
 
+        # Normalize AS number to the "AS<number>" convention (Team Cymru returns
+        # the bare number; the prefix keeps downstream consumers consistent).
         asn_val = data_line[0]
         asn_string = f"AS{asn_val}" if not asn_val.startswith("AS") else asn_val
 

--- a/tools/asn_tool.py
+++ b/tools/asn_tool.py
@@ -1,36 +1,21 @@
-import os
 from urllib.parse import urlparse
 import ipaddress
-import requests
 import socket
 
 def asn_lookup(target: str) -> dict:
     """
-    Find the Autonomous System Number (ASN) and 
-    organization for a domain or IP. Useful for 
-    identifying hosting provider and network ownership.
-
-    API Key: https://ipapi.com
+    Find the Autonomous System Number (ASN) and network ownership
+    for a domain or IP using Team Cymru WHOIS. Useful for identifying
+    hosting provider and network ownership. No API key required.
 
     Args:
         target (str): Domain or IP address
 
     Returns:
-        dict: Geolocation and ASN details matching the expected signature
+        dict: ASN and network ownership details
     """
     try:
         target = target.strip()
-        api_key = os.getenv("IP_API_KEY")
-        
-        if not api_key:
-            return {
-                "success": False,
-                "error": (
-                    "IP_API_KEY environment variable is not set. "
-                    "Get a free key at https://ipapi.com and add it to "
-                    "your Claude Desktop config under 'IP_API_KEY'."
-                )
-            }
 
         if "://" in target:
             parsed = urlparse(target)
@@ -47,54 +32,59 @@ def asn_lookup(target: str) -> dict:
         except ValueError:
             ip = socket.getaddrinfo(target, None)[0][4][0]
 
+        query = f"begin\nverbose\n{ip}\nend\n"
+        with socket.create_connection(("whois.cymru.com", 43), timeout=15) as sock:
+            sock.sendall(query.encode())
+            chunks = []
+            while True:
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+            response = b"".join(chunks).decode("utf-8", errors="replace")
 
-        headers = {
-            "User-Agent": "Mozilla/5.0",
-            "Accept": "application/json"
-        }
-        response = requests.get(
-            f"https://api.ipapi.com/api/{ip}?access_key={api_key}",
-            timeout=15,
-            headers=headers
-        )
-
-        if response.status_code != 200:
+        lines = [line for line in response.strip().splitlines() if line.strip()]
+        if not lines:
             return {
                 "success": False,
-                "error": f"API request failed with status {response.status_code}"
+                "error": "Unexpected or malformed response from Team Cymru WHOIS",
             }
 
-        data = response.json()
+        data_line = None
+        for line in lines:
+            fields = [f.strip() for f in line.split("|")]
+            if len(fields) >= 7 and fields[0].isdigit():
+                data_line = fields
+                break
 
-        if data.get("success") is False:
-            error_info = data.get("error", {})
+        if not data_line:
             return {
                 "success": False,
-                "error": error_info.get("info", "API returned an error state")
+                "error": "Unexpected or malformed response from Team Cymru WHOIS",
             }
 
-        connection = data.get("connection", {})
-        
-        asn_val = connection.get("asn")
-        if asn_val and not str(asn_val).startswith("AS"):
-            asn_string = f"AS{asn_val}"
-        else:
-            asn_string = str(asn_val) if asn_val else None
+        asn_val = data_line[0]
+        asn_string = f"AS{asn_val}" if not asn_val.startswith("AS") else asn_val
 
         return {
             "success": True,
             "ip": ip,
             "asn": asn_string,
-            "org": connection.get("org"),
-            "isp": connection.get("isp"), 
-            "country": data.get("country_name"),
-            "region": data.get("region_name"),
-            "city": data.get("city")
+            "bgp_prefix": data_line[2],
+            "country": data_line[3],
+            "registry": data_line[4],
+            "allocated": data_line[5],
+            "organization": data_line[6],
         }
 
     except socket.gaierror:
         return {"success": False, "error": "Failed to resolve domain"}
-    except requests.exceptions.Timeout:
-        return {"success": False, "error": "Request timed out"}
+    except socket.timeout:
+        return {"success": False, "error": "Team Cymru WHOIS request timed out"}
+    except (ConnectionError, OSError) as e:
+        return {
+            "success": False,
+            "error": f"Could not connect to Team Cymru WHOIS service: {e}",
+        }
     except Exception as e:
         return {"success": False, "error": str(e)}


### PR DESCRIPTION
# Replace IPAPI-based ASN Lookup with Team Cymru WHOIS (No API Key Required)

Closes #102.

## Summary

Replaces the IPAPI HTTP-based `asn_lookup` tool with a Team Cymru WHOIS-based implementation that requires **no API key**, removing the only API-key barrier for one of the project's core `full_recon` Wave 1 tools. All `IP_API_KEY` references are removed from the codebase and configuration files per the issue's explicit request ("Remove all things related to ip_api_key in the repo all files").

## Why This Change

- **Removes friction**: `asn_lookup` was the only `full_recon` Wave 1 tool requiring an API key. After this change, the full_recon pipeline works end-to-end with only `ABUSEIPDB_API_KEY` (used by Wave 3 `ip_reputation`).
- **No new dependencies**: Uses Python's stdlib `socket` and `ipaddress` modules — `requests` and `os` are removed from `asn_tool.py` imports (no longer needed without the `IP_API_KEY` env-var lookup).
- **More authoritative source**: Team Cymru WHOIS is the de facto standard for ASN/BGP-prefix lookups, with broader coverage and more reliable allocation/registry data than IPAPI.
- **Maintainer-requested**: Explicitly labeled `help wanted` + `good first issue` (#102).

## What Changed

### `tools/asn_tool.py`
- Rewrote `asn_lookup()` to query `whois.cymru.com:43` using `socket.create_connection` with a 15-second timeout.
- Sends the standard Team Cymru verbose query: `begin\nverbose\n{ip}\nend\n`.
- Parses the pipe-delimited response (skipping the header line, taking the first numeric-AS data line) and returns:

  ```json
  {
    "success": true,
    "ip": "8.8.8.8",
    "asn": "AS15169",
    "bgp_prefix": "8.8.8.0/24",
    "country": "US",
    "registry": "arin",
    "allocated": "1992-12-01",
    "organization": "GOOGLE, US"
  }
  ```

- **Preserved** the `ip` field in the return shape — required by the Wave 3 `ip_reputation` consumer via `extract_ip()` in `tools/signals/ip_reputation.py`.
- **Preserved** all existing input handling (strip whitespace, URL scheme/port stripping via `urlparse`, IPv4/IPv6 detection via `ipaddress.ip_address()`, domain resolution via `socket.getaddrinfo()`).
- Error handling per the issue spec:
  - `socket.gaierror` → `"Failed to resolve domain"`
  - `socket.timeout` → `"Team Cymru WHOIS request timed out"`
  - `ConnectionError`/`OSError` → `"Could not connect to Team Cymru WHOIS service: ..."`
  - Empty/malformed response → `"Unexpected or malformed response from Team Cymru WHOIS"`
  - Other exceptions → `str(e)`

### `tests/test_asn_lookup.py`
- Fully rewritten to mock `socket.create_connection` instead of `requests.get`.
- Uses `MagicMock` to fake the socket returned by `create_connection` (with `sendall`/`recv`/`close` and context-manager support).
- 9 test cases (all passing):
  1. `test_valid_ipv4_returns_asn_data` — happy path IPv4 (`8.8.8.8`).
  2. `test_valid_domain_returns_asn_data` — happy path domain (mocks `getaddrinfo`).
  3. `test_url_input_extracts_host` — URL input (`https://google.com:443`) extracts host correctly.
  4. `test_valid_ipv6_returns_asn_data` — IPv6 input (`2606:4700:4700::1111`).
  5. `test_unresolvable_domain_returns_error` — `gaierror` returns `"Failed to resolve domain"`.
  6. `test_whois_timeout_returns_error` — `socket.timeout` returns `"timed out"` error.
  7. `test_connection_refused_returns_error` — `ConnectionError` returns connection-failure error.
  8. `test_malformed_response_returns_error` — empty/malformed response returns `"malformed"` error.
  9. `test_header_only_response_returns_error` — response with only a header line (no data lines) returns `"malformed"` error.
- No real network calls — all socket interactions are mocked.

### Config / Docs (removing `IP_API_KEY`)
- **`.env.example`** — Removed `IP_API_KEY=""` line.
- **`mcp.json`** — Updated `asn_lookup` entry: `requires_api_key: false`, removed `api_key_env`/`api_key_url`, updated description. Removed `IP_API_KEY` from `environment_variables` and from the `claude_desktop_config.mcpServers.AynOps.env` example.
- **`server.json`** — Removed `IP_API_KEY` block from `environmentVariables`.
- **`README.md`** — Updated `asn_lookup` description in tools table. Removed `IP_API_KEY` from both Windows and Mac/Linux Claude Desktop config examples. Updated the Note below the config blocks.

### What's NOT changed (intentionally)
- **`server.py`** — Import and `mcp.tool()` registration unchanged.
- **`tools/signals/asn.py`** — Extractor already handles a missing `abuse_score` field gracefully (the field was never populated by the old `asn_tool.py` either, so the extractor always resolved to `0`). No change needed.
- **`tools/signals/ip_reputation.py`** — `extract_ip()` reads `result["ip"]`, which is preserved — no change needed.
- **`contributing.md`** — Verified it does NOT reference `IP_API_KEY` (only uses generic placeholders and `SHODAN_API_KEY`/`VIRUSTOTAL_API_KEY` examples) — no change needed.
- **`requirements.txt` / `pyproject.toml`** — `requests` is still used by other tools (e.g., `iprep_tool.py`, `crt_sh_tool.py`); not removed.

## Verification

```
$ python -m pytest tests/test_asn_lookup.py -v
9 passed

$ grep -ri "ip_api_key" --include="*.py" --include="*.json" --include="*.md" --include="*.txt" --include=".env*" .
(no matches — exit code 1)
```

## Files Changed

```
 .env.example             |   3 +-
 README.md                |  10 ++--
 mcp.json                 |  14 +----
 server.json              |   7 ---
 tests/test_asn_lookup.py | 149 ++++++++++++++++++++++++++++++++++++-----------
 tools/asn_tool.py        | 101 ++++++++++++++++----------------
 6 files changed, 173 insertions(+), 111 deletions(-)
```

## Checklist

- [x] Tool follows existing `try/except` + `{"success": ...}` pattern from `contributing.md`.
- [x] Input validation preserved (IP, domain, URL, IPv6).
- [x] Tests added (9 cases) and passing.
- [x] No real network calls in tests.
- [x] `IP_API_KEY` fully removed from code, config, and docs.
- [x] No new dependencies introduced (stdlib `socket` + `ipaddress`).
- [x] `ip` field preserved in return shape for downstream `ip_reputation` consumer.
- [x] README tools table and Claude Desktop config examples updated.
- [x] Commit message references `#102`.

## Related

- Issue: #102
- Affected downstream: `full_recon` Wave 1 → `asn_lookup`; Wave 3 → `ip_reputation` (no breaking change — `extract_ip()` contract preserved).
