### PR TITLE
fix(signals): populate ip_abuse_score correctly and handle list whois dates

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,4 +1,5 @@
-from utils.helpers import is_valid_domain , get_cvss_details , get_english_description
+from utils.helpers import is_valid_domain , get_cvss_details , get_english_description , safe_parse_datetime
+from datetime import datetime, timezone
 import unittest
 
 class TestHelpers(unittest.TestCase):
@@ -54,6 +55,53 @@ class TestHelpers(unittest.TestCase):
 
     def test_empty_descriptions_returns_empty(self):
         self.assertEqual(get_english_description({}), "")
+
+    # ── safe_parse_datetime ─────────────────────────────────
+
+    def test_safe_parse_datetime_iso_string(self):
+        """A standard ISO datetime string parses correctly."""
+        result = safe_parse_datetime("2025-12-25 00:00:00")
+        self.assertEqual(result, datetime(2025, 12, 25, 0, 0, 0))
+
+    def test_safe_parse_datetime_none_input(self):
+        """None or empty input returns None."""
+        self.assertIsNone(safe_parse_datetime(None))
+        self.assertIsNone(safe_parse_datetime(""))
+        self.assertIsNone(safe_parse_datetime([]))
+
+    def test_safe_parse_datetime_passthrough_datetime_object(self):
+        """A datetime object is returned as-is."""
+        dt = datetime(2025, 12, 25, 0, 0, 0, tzinfo=timezone.utc)
+        self.assertEqual(safe_parse_datetime(dt), dt)
+
+    def test_safe_parse_datetime_list_takes_first_element(self):
+        """A list of date strings (python-whois TLD variance) takes the first.
+
+        Regression test for the bug where str(list) produced
+        "['2025-12-25 00:00:00']" which matched no format, silently
+        suppressing domain-expiry warnings in whois_extractor.
+        """
+        result = safe_parse_datetime(["2025-12-25 00:00:00", "2026-01-01 00:00:00"])
+        self.assertEqual(result, datetime(2025, 12, 25, 0, 0, 0))
+
+    def test_safe_parse_datetime_list_of_datetime_objects(self):
+        """A list of datetime objects takes the first element as-is."""
+        dt1 = datetime(2025, 12, 25, 0, 0, 0, tzinfo=timezone.utc)
+        dt2 = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        self.assertEqual(safe_parse_datetime([dt1, dt2]), dt1)
+
+    def test_safe_parse_datetime_empty_list_returns_none(self):
+        """An empty list returns None, not a crash."""
+        self.assertIsNone(safe_parse_datetime([]))
+
+    def test_safe_parse_datetime_list_with_empty_first_element(self):
+        """A list whose first element is empty/None falls through to None."""
+        self.assertIsNone(safe_parse_datetime([None, "2025-12-25"]))
+        self.assertIsNone(safe_parse_datetime(["", "2025-12-25"]))
+
+    def test_safe_parse_datetime_invalid_string_returns_none(self):
+        """A genuinely unparseable string returns None, not a crash."""
+        self.assertIsNone(safe_parse_datetime("not-a-date"))
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_signals_extractors.py
+++ b/tests/test_signals_extractors.py
@@ -1,0 +1,204 @@
+"""Tests for the per-tool signal extractors in tools/signals/.
+
+These tests pin down the contract that each extractor mutates the shared
+`signals` dict in the way the threat-analysis prompt expects. They are
+especially important for the ip_abuse_score signal, which was silently
+always 0 between PR #84 and the fix that moved the assignment into
+ip_reputation_extractor (the AbuseIPDB-backed canonical source).
+"""
+from tools.signals.asn import asn_extractor
+from tools.signals.ip_reputation import ip_reputation_extractor
+from tools.signals.whois import whois_extractor
+from tools.signals.extractor import extract_signals
+
+
+def _base_signals():
+    """Return a fresh signals dict matching extract_signals' initial shape."""
+    return {
+        "domain_expiry_days": None,
+        "dns_missing_records": [],
+        "open_ports": [],
+        "ssl_days_remaining": None,
+        "software_detected": [],
+        "ip_abuse_score": 0,
+        "subdomain_count": 0,
+        "missing_security_headers": [],
+        "email_security": {},
+        "ip_reputation_flagged": False,
+        "auto_warnings": [],
+    }
+
+
+# ── ip_reputation_extractor ──────────────────────────────────────────────
+
+def test_ip_reputation_extractor_populates_abuse_score():
+    """ip_reputation_extractor must assign abuse_confidence_score to ip_abuse_score.
+
+    Regression test for the bug introduced by PR #84: the signal was
+    never assigned here, so it stayed at the initial value of 0 regardless
+    of the real AbuseIPDB confidence score.
+    """
+    result = {
+        "success": True,
+        "is_malicious": False,
+        "abuse_confidence_score": 87,
+    }
+    signals = _base_signals()
+    ip_reputation_extractor(result, signals)
+    assert signals["ip_abuse_score"] == 87
+    assert signals["ip_reputation_flagged"] is False
+
+
+def test_ip_reputation_extractor_coerces_string_score_to_int():
+    """abuse_confidence_score may arrive as a string; the extractor must coerce."""
+    result = {
+        "success": True,
+        "is_malicious": False,
+        "abuse_confidence_score": "42",
+    }
+    signals = _base_signals()
+    ip_reputation_extractor(result, signals)
+    assert signals["ip_abuse_score"] == 42
+
+
+def test_ip_reputation_extractor_defaults_score_to_zero_on_invalid_value():
+    """A missing or non-numeric abuse_confidence_score must fall back to 0."""
+    result = {
+        "success": True,
+        "is_malicious": False,
+        "abuse_confidence_score": "not-a-number",
+    }
+    signals = _base_signals()
+    ip_reputation_extractor(result, signals)
+    assert signals["ip_abuse_score"] == 0
+
+
+def test_ip_reputation_extractor_skips_on_unsuccessful_result():
+    """An unsuccessful ip_reputation result must not touch the signals dict."""
+    result = {"success": False, "error": "AbuseIPDB API request failed"}
+    signals = _base_signals()
+    ip_reputation_extractor(result, signals)
+    # ip_abuse_score stays at its initial value
+    assert signals["ip_abuse_score"] == 0
+    assert signals["ip_reputation_flagged"] is False
+    assert signals["auto_warnings"] == []
+
+
+def test_ip_reputation_extractor_flags_malicious_warning():
+    """When is_malicious is True, a MALICIOUS warning must be appended."""
+    result = {
+        "success": True,
+        "is_malicious": True,
+        "abuse_confidence_score": 95,
+    }
+    signals = _base_signals()
+    ip_reputation_extractor(result, signals)
+    assert signals["ip_abuse_score"] == 95
+    assert signals["ip_reputation_flagged"] is True
+    assert any("MALICIOUS" in w for w in signals["auto_warnings"])
+
+
+def test_ip_reputation_extractor_elevated_warning_above_20():
+    """When not flagged but score > 20, an elevated-risk warning must fire."""
+    result = {
+        "success": True,
+        "is_malicious": False,
+        "abuse_confidence_score": 35,
+    }
+    signals = _base_signals()
+    ip_reputation_extractor(result, signals)
+    assert any("elevated risk" in w for w in signals["auto_warnings"])
+
+
+# ── asn_extractor ────────────────────────────────────────────────────────
+
+def test_asn_extractor_does_not_touch_ip_abuse_score():
+    """asn_extractor must NOT zero out ip_abuse_score.
+
+    The asn_tool result does not carry an abuse score. The previous
+    implementation looked up `abuse_score` (which never existed) and fell
+    back to 0, silently overwriting any value that had been or would be
+    set by ip_reputation_extractor. This test locks in the fix: asn_extractor
+    leaves ip_abuse_score untouched.
+    """
+    result = {
+        "success": True,
+        "ip": "1.2.3.4",
+        "asn": "AS64500",
+        "org": "Test Org",
+        "isp": "Test ISP",
+        "country": "Testland",
+    }
+    signals = _base_signals()
+    signals["ip_abuse_score"] = 73  # pretend ip_reputation already ran
+    asn_extractor(result, signals)
+    assert signals["ip_abuse_score"] == 73  # unchanged
+
+
+def test_asn_extractor_skips_on_unsuccessful_result():
+    """An unsuccessful asn result must not touch the signals dict."""
+    result = {"success": False, "error": "Failed to resolve domain"}
+    signals = _base_signals()
+    asn_extractor(result, signals)
+    assert signals["ip_abuse_score"] == 0
+    assert signals["auto_warnings"] == []
+
+
+# ── extract_signals integration ──────────────────────────────────────────
+
+def test_extract_signals_populates_ip_abuse_score_from_ip_reputation():
+    """End-to-end: extract_signals must populate ip_abuse_score from the
+    ip_reputation tool result, not from the asn tool result.
+
+    This is the integration test that would have caught the original PR #84
+    regression: asn runs in Wave 1, ip_reputation runs in Wave 3, and the
+    extractor order follows the registry. Even though asn_extractor runs
+    first, the final ip_abuse_score value must come from ip_reputation.
+    """
+    results = {
+        "whois": {"success": False},
+        "dns": {"success": False},
+        "ssl": {"success": False},
+        "email_security": {"success": False},
+        "asn": {
+            "success": True,
+            "ip": "1.2.3.4",
+            "asn": "AS64500",
+            "org": "Test Org",
+            "isp": "Test ISP",
+            "country": "Testland",
+        },
+        "ports": {"success": False},
+        "techstack": {"success": False},
+        "ct_logs": {"success": False},
+        "ip_reputation": {
+            "success": True,
+            "is_malicious": False,
+            "abuse_confidence_score": 88,
+        },
+    }
+    signals = extract_signals(results)
+    assert signals["ip_abuse_score"] == 88
+    assert signals["ip_reputation_flagged"] is False
+
+
+def test_extract_signals_leaves_ip_abuse_score_at_zero_when_ip_reputation_missing():
+    """When ip_reputation did not run or failed, ip_abuse_score stays at 0."""
+    results = {
+        "whois": {"success": False},
+        "dns": {"success": False},
+        "ssl": {"success": False},
+        "email_security": {"success": False},
+        "asn": {
+            "success": True,
+            "ip": "1.2.3.4",
+            "asn": "AS64500",
+            "org": "Test Org",
+        },
+        "ports": {"success": False},
+        "techstack": {"success": False},
+        "ct_logs": {"success": False},
+        "ip_reputation": {"success": False, "error": "API down"},
+    }
+    signals = extract_signals(results)
+    assert signals["ip_abuse_score"] == 0

--- a/tests/test_signals_extractors.py
+++ b/tests/test_signals_extractors.py
@@ -8,7 +8,6 @@ ip_reputation_extractor (the AbuseIPDB-backed canonical source).
 """
 from tools.signals.asn import asn_extractor
 from tools.signals.ip_reputation import ip_reputation_extractor
-from tools.signals.whois import whois_extractor
 from tools.signals.extractor import extract_signals
 
 
@@ -62,11 +61,28 @@ def test_ip_reputation_extractor_coerces_string_score_to_int():
 
 
 def test_ip_reputation_extractor_defaults_score_to_zero_on_invalid_value():
-    """A missing or non-numeric abuse_confidence_score must fall back to 0."""
+    """A non-numeric abuse_confidence_score must fall back to 0."""
     result = {
         "success": True,
         "is_malicious": False,
         "abuse_confidence_score": "not-a-number",
+    }
+    signals = _base_signals()
+    ip_reputation_extractor(result, signals)
+    assert signals["ip_abuse_score"] == 0
+
+
+def test_ip_reputation_extractor_defaults_score_to_zero_when_key_missing():
+    """A missing abuse_confidence_score key must fall back to 0.
+
+    AbuseIPDB responses normally include the field, but defensive coding
+    requires the extractor to tolerate its absence (int(None) raises
+    TypeError, which the try/except catches).
+    """
+    result = {
+        "success": True,
+        "is_malicious": False,
+        # abuse_confidence_score intentionally omitted
     }
     signals = _base_signals()
     ip_reputation_extractor(result, signals)

--- a/tools/signals/asn.py
+++ b/tools/signals/asn.py
@@ -1,19 +1,10 @@
 def asn_extractor(result , signals):
-    if result.get("success"):
-        score = result.get("abuse_score") or result.get("data", {}).get("abuse_score", 0)
-        try:
-            score = int(score)
-        except (TypeError, ValueError):
-            score = 0
-        signals["ip_abuse_score"] = score
-        if score > 50:
-            signals["auto_warnings"].append(
-                f"ASN abuse score {score}/100 — HIGH malicious activity reported on this IP range"
-            )
-        elif score > 20:
-            signals["auto_warnings"].append(
-                f"ASN abuse score {score}/100 — elevated, investigate hosting provider"
-            )
-
-    else:
+    # asn_tool returns {ip, asn, org, isp, country, region, city} — it does
+    # NOT carry an abuse score. The abuse confidence score comes from the
+    # AbuseIPDB-backed ip_reputation tool and is populated by
+    # ip_reputation_extractor. The previous abuse_score lookup here was
+    # dead code: it always fell through to the `0` default, which silently
+    # zeroed out signals["ip_abuse_score"] (see PR #84 for the regression
+    # and the follow-up PR that moved the assignment to ip_reputation).
+    if not result.get("success"):
         return

--- a/tools/signals/extractor.py
+++ b/tools/signals/extractor.py
@@ -10,7 +10,7 @@ def extract_signals(results):
     "open_ports":               [],     # ports
     "ssl_days_remaining":       None,   # ssl
     "software_detected":        [],     # techstack
-    "ip_abuse_score":           0,      # asn
+    "ip_abuse_score":           0,      # ip_reputation
     "subdomain_count":          0,      # ct_logs
     "missing_security_headers": [],     # headers
     "email_security":           {},     # email_security_tool

--- a/tools/signals/ip_reputation.py
+++ b/tools/signals/ip_reputation.py
@@ -7,6 +7,10 @@ def ip_reputation_extractor(result , signals):
             rep_score = int(rep_score)
         except (TypeError, ValueError):
             rep_score = 0
+        # ip_reputation is the canonical source for the abuse confidence
+        # score (AbuseIPDB). The asn_tool result does not carry this field,
+        # so the signal must be populated here, not in asn_extractor.
+        signals["ip_abuse_score"] = rep_score
         if flagged:
             signals["auto_warnings"].append(
                 f"IP flagged as MALICIOUS "

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -54,11 +54,25 @@ def safe_parse_datetime(date_input) -> datetime | None:
     """Helper to catch and resolve structural variances in string dates."""
     if not date_input:
         return None
-    
+
     # If the input is already a datetime object (some tools return structured objects)
     if isinstance(date_input, datetime):
         return date_input
-        
+
+    # python-whois returns a list of datetimes for some TLDs (e.g. when the
+    # registrar exposes both registry and registrar expiration dates). Take
+    # the first element — they are typically identical, and the alternative
+    # (str(list)) yields "['2025-12-25 00:00:00']" which matches no format
+    # and silently suppresses domain-expiry warnings downstream.
+    if isinstance(date_input, list):
+        if not date_input:
+            return None
+        date_input = date_input[0]
+        if not date_input:
+            return None
+        if isinstance(date_input, datetime):
+            return date_input
+
     clean_str = str(date_input).strip().replace("Z", "+00:00")
     
     # Try common formats sequentially


### PR DESCRIPTION
# fix(signals): populate `ip_abuse_score` correctly and handle list whois dates

Two independent bug fixes in the `full_recon` signals pipeline, plus a small review-feedback commit. Both regressions were introduced by PR #84 (the fullrecon modular refactor) and both actively degrade the threat-analysis output that gets fed to the LLM.

## Summary

| Bug | Effect | Root cause |
| --- | --- | --- |
| `ip_abuse_score` always `0` | Threat-analysis prompt is always fed `IP abuse score : 0/100` regardless of the real AbuseIPDB confidence score — even when the IP is flagged malicious with score 95. | `asn_extractor` looked up `abuse_score` from the `asn_tool` result, but `asn_tool` never returned that field. The canonical score lives in `ip_reputation.abuse_confidence_score`, but `ip_reputation_extractor` never assigned it to the signal. |
| whois `expiration_date` list silently dropped | `domain_expiry_days` stays `None` (rendered as `unknown`) and the `Domain EXPIRED …` / `Domain expires in N days — CRITICAL renewal required` auto-warnings never fire for TLDs where `python-whois` returns a list of dates. | `safe_parse_datetime` did `str(date_input).strip()` on a list, producing `"['2025-12-25 00:00:00']"` which matched no parse format and fell through to `None`. |

Both bugs were found by code review of merged PR #84 (no issue was filed — they are small, well-scoped, and follow the project's "Pull requests are welcome!" policy in `contributing.md`).

## Why This Change

- **Real misinformation to the LLM**: The threat-analysis prompt explicitly reads `IP abuse score : {signals.get('ip_abuse_score', 0)}/100` and `IP flagged malicious: {signals.get('ip_reputation_flagged', False)}`. With the bug, an IP with `abuse_confidence_score=95, is_malicious=True` would be rendered as `IP abuse score : 0/100` and `IP flagged malicious: True` simultaneously — a contradictory, misleading picture. For scores in 1–24, the IP looks completely clean when it isn't.
- **Silent suppression of critical warnings**: The `Domain EXPIRED` / `Domain expires in N days — CRITICAL renewal required` warnings are designed to be high-priority signals for the LLM. When `python-whois` returns a list of expiration dates (which happens for some TLDs/registrars that expose both registry and registrar expiration), the warning is silently dropped.
- **Survived review**: PR #84 went through maintainer + Copilot review and was merged. The signals pipeline had no unit tests at the time (this PR adds the first ones). External follow-up is genuinely valuable here.
- **Small and contained**: ~50 lines of source changes + ~250 lines of tests. No new dependencies, no API changes, fully backward-compatible.
- **No conflict with PRs #106, #107, #108** (different files; this PR touches `tools/signals/*.py`, `utils/helpers.py`, and the corresponding test files).

## What Changed

### Commit 1 — `fix(signals): populate ip_abuse_score from ip_reputation, not asn`

**`tools/signals/ip_reputation.py`** (+4 lines)
- Added `signals["ip_abuse_score"] = rep_score` after the `int(rep_score)` coercion, with an inline comment explaining that `ip_reputation` is the canonical source (AbuseIPDB) and `asn_tool` does not carry this field.

**`tools/signals/asn.py`** (-18 / +9 lines)
- Removed the dead `result.get("abuse_score") or result.get("data", {}).get("abuse_score", 0)` lookup. It always fell through to `0` because `asn_tool` returns `{ip, asn, org, isp, country, region, city}` — no `abuse_score` field.
- Removed the two dead `auto_warnings` branches (`> 50` HIGH and `> 20` elevated). They never fired because `score` was always `0`. The equivalent `MALICIOUS` and `elevated risk` warnings already live in `ip_reputation_extractor`.
- Left a comment explaining why the function is now a no-op for the abuse score (and pointing to `ip_reputation_extractor` as the canonical source).

**`tests/test_signals_extractors.py`** (new file)
- 10 tests covering: ip_reputation_extractor populates score, coerces string, defaults on invalid, skips on failure, MALICIOUS warning, elevated warning; asn_extractor does NOT touch ip_abuse_score, skips on failure; extract_signals integration (score from ip_reputation end-to-end, stays 0 when ip_reputation failed).

### Commit 2 — `fix(helpers): handle list input in safe_parse_datetime for whois dates`

**`utils/helpers.py`** (+16 / -2 lines)
- Added an `isinstance(date_input, list)` branch in `safe_parse_datetime` that:
  - Returns `None` for an empty list.
  - Takes the first element (registry and registrar expiration dates are typically identical; first-seen is the pragmatic choice).
  - Returns `None` if the first element is empty/None.
  - Passthrough if the first element is already a `datetime` object.
- Inline comment explains the `python-whois` TLD variance and why first-element is the right pick.

**`tests/test_helpers.py`** (+49 / -1 lines)
- 8 new tests for `safe_parse_datetime`: ISO string parses; `None` / `""` / `[]` return `None`; `datetime` passthrough; **list of strings takes first element** (regression); list of `datetime` objects takes first; empty list returns `None`; list with empty/None first element returns `None`; unparseable string returns `None`.

### Commit 3 — `review(signals): address cross-review feedback`

Small fixes from multi-agent code review (all MINOR/NIT, non-blocking but worth cleaning up before merge):

**`tests/test_signals_extractors.py`** (+20 / -3 lines)
- Removed unused `whois_extractor` import (the test file covers `asn` and `ip_reputation` extractors; `whois_extractor` is not exercised here).
- Added `test_ip_reputation_extractor_defaults_score_to_zero_when_key_missing` to pin down the defensive-coding contract: when `abuse_confidence_score` is absent from the result dict, `int(None)` raises `TypeError` and the `try/except` falls back to `0`. Previously only the non-numeric-string case was tested.

**`tools/signals/extractor.py`** (+1 / -1 lines)
- Updated the stale comment at line 13 from `# asn` to `# ip_reputation`. The signal is now canonically sourced from `ip_reputation_extractor` (per commit `c1d459c`), so the old `# asn` label was actively misleading.

### What's NOT changed (intentionally)
- **Return shape of `extract_signals`**: Same keys, same initial values. Only the value of `ip_abuse_score` changes from `0` to the real AbuseIPDB score when `ip_reputation` succeeds.
- **Warning semantics**: The `MALICIOUS` and `elevated risk` warnings from `ip_reputation_extractor` are unchanged. The dead `> 50` HIGH warning from `asn_extractor` is removed — it was redundant with the `MALICIOUS` warning (which fires at `abuse_confidence_score >= 25` per `iprep_tool.py`).
- **`asn_extractor` function signature**: Preserved (still callable as `asn_extractor(result, signals)`). The function is now effectively a no-op for the abuse score, with a comment explaining why. Future enhancements (e.g. extracting ASN org/country into signals) can build on it.
- **`safe_parse_datetime` scalar path**: Unchanged. Only list inputs take the new branch. String and datetime inputs follow the exact same code path as before.
- **`whois_extractor` in `tools/signals/whois.py`**: Unchanged — it already calls `safe_parse_datetime(expiry)` correctly; the fix is in the helper, not the caller.

## Verification

```
$ python -m pytest tests/test_signals_extractors.py tests/test_helpers.py tests/test_full_recon.py tests/test_whois_lookup.py -v
39 passed, 10 subtests passed in 0.27s
```

Full test suite (all tools): `193 passed in 0.59s` — no regressions.

Manual reproduction of Bug 1 (before this PR):
```python
# results = {"asn": {"success": True, "ip": "1.2.3.4", ...},
#            "ip_reputation": {"success": True, "is_malicious": True,
#                              "abuse_confidence_score": 95}}
# Before: signals["ip_abuse_score"] == 0  (BUG — even though score is 95)
# After:  signals["ip_abuse_score"] == 95 (FIXED)
```

Manual reproduction of Bug 2 (before this PR):
```python
# safe_parse_datetime(["2025-12-25 00:00:00", "2026-01-01 00:00:00"])
# Before: None  (BUG — str(list) matches no format)
# After:  datetime(2025, 12, 25, 0, 0, 0)  (FIXED — takes first element)
```

## Files Changed

```
 tests/test_helpers.py            |  50 ++++++++-
 tests/test_signals_extractors.py | 220 +++++++++++++++++++++++++++++++++++++++
 tools/signals/asn.py             |  27 ++---
 tools/signals/extractor.py       |   2 +-
 tools/signals/ip_reputation.py   |   4 +
 utils/helpers.py                 |  18 +++-
 6 files changed, 299 insertions(+), 22 deletions(-)
```

## Checklist

- [x] Both fixes follow the existing `try/except` + `{"success": ...}` pattern from `contributing.md` (the extractors and helpers already follow it).
- [x] No new dependencies; no API changes; backward-compatible.
- [x] All pre-existing tests in `test_helpers.py`, `test_full_recon.py`, `test_whois_lookup.py` still pass; full suite (193 tests) passes.
- [x] 11 new tests for signals extractors + 8 new tests for `safe_parse_datetime` = 19 new tests.
- [x] No real network calls in tests (all extractors tested with plain dicts).
- [x] `signals` dict shape preserved — only the value of `ip_abuse_score` changes from `0` to the real AbuseIPDB score when `ip_reputation` succeeds.
- [x] `safe_parse_datetime` scalar path unchanged — only list inputs take the new branch.
- [x] Inline comments explain the canonical-source decision and the `python-whois` TLD variance.
- [x] Minimal diff — no scope creep, no bundled unrelated cleanup. Commit 3 is strictly review feedback.

## Related

- Follow-up to PR #84 by @gaoharimran29-glitch (the fullrecon modular refactor that introduced both regressions).
- No issue was filed — both bugs are small and well-scoped enough to fix directly per `contributing.md`'s "Pull requests are welcome!" policy.
- No conflict with PRs #106, #107, #108 (different files).
