### PR TITLE
feat: normalize domain inputs before validation

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,4 +1,4 @@
-from utils.helpers import is_valid_domain , get_cvss_details , get_english_description , safe_parse_datetime
+from utils.helpers import is_valid_domain, normalize_domain, get_cvss_details, get_english_description, safe_parse_datetime
 from datetime import datetime, timezone
 import unittest
 
@@ -15,6 +15,21 @@ class TestHelpers(unittest.TestCase):
             with self.subTest(domain=d):
                 self.assertFalse(is_valid_domain(d))
 
+
+    # ── normalize_domain ─────────────────────────────────────
+    def test_normalize_domain_strips_and_lowercases(self):
+        self.assertEqual(normalize_domain("  Google.COM  "), "google.com")
+
+    def test_normalize_domain_removes_trailing_dot(self):
+        self.assertEqual(normalize_domain("google.com."), "google.com")
+
+    def test_normalize_domain_empty_after_strip(self):
+        self.assertEqual(normalize_domain("   "), "")
+        self.assertEqual(normalize_domain(None), "")
+
+    def test_normalize_domain_then_validates(self):
+        self.assertTrue(is_valid_domain(normalize_domain("Google.COM")))
+        self.assertTrue(is_valid_domain(normalize_domain("google.com.")))
     # ── get_cvss_details ─────────────────────────────────────
     def test_cvss_v31_extraction(self):
         cve = {

--- a/tools/cloud_exposure_tool.py
+++ b/tools/cloud_exposure_tool.py
@@ -1,4 +1,4 @@
-from utils.helpers import is_valid_domain
+from utils.helpers import is_valid_domain, normalize_domain
 import tldextract
 import requests
 import re
@@ -139,6 +139,7 @@ def check_provider(bucket, provider):
 
 def cloud_exposure_check(domain: str) -> dict:
     """Takes domain as input and return complete metrics and results for cloud urls exposed or not for a company"""
+    domain = normalize_domain(domain)
     if not is_valid_domain(domain):
         return {"success": False, "error": "Invalid domain format"}
     

--- a/tools/crt_sh_tool.py
+++ b/tools/crt_sh_tool.py
@@ -3,7 +3,7 @@ from curl_cffi.requests.errors import RequestsError
 from typing import Dict, Any, Set
 import requests as standard_requests  # Used for the quick fallback API
 
-from utils.helpers import is_valid_domain
+from utils.helpers import is_valid_domain, normalize_domain
 
 def fetch_from_hackertarget(domain: str) -> Set[str]:
     """
@@ -36,6 +36,7 @@ def cert_transparency(domain: str) -> Dict[str, Any]:
     """
     domain = domain.strip().lower()
 
+    domain = normalize_domain(domain)
     if not is_valid_domain(domain):
         return {
             "success": False,

--- a/tools/dns_tool.py
+++ b/tools/dns_tool.py
@@ -1,5 +1,5 @@
 import dns.resolver
-from utils.helpers import is_valid_domain
+from utils.helpers import is_valid_domain, normalize_domain
 
 PUBLIC_RESOLVERS = ["1.1.1.1", "8.8.8.8"]
 
@@ -29,6 +29,7 @@ def dns_enumeration(domain: str) -> dict:
     Enumerate DNS records for a domain.
     Returns A, AAAA, MX, NS, TXT, CNAME, SOA records.
     """
+    domain = normalize_domain(domain)
     if not is_valid_domain(domain):
         return {"success": False, "error": "Invalid domain format"}
 

--- a/tools/email_security_tool.py
+++ b/tools/email_security_tool.py
@@ -3,7 +3,7 @@ import concurrent.futures
 import dns.resolver
 import dns.exception
 from typing import Any, Dict, List, Tuple
-from utils.helpers import is_valid_domain
+from utils.helpers import is_valid_domain, normalize_domain
 
 # Base generic defaults
 BASE_DKIM_SELECTORS = [
@@ -193,6 +193,7 @@ def email_security_check(domain: str) -> dict:
     """
     domain = domain.strip().lower()
 
+    domain = normalize_domain(domain)
     if not is_valid_domain(domain):
         return {"success": False, "error": "Invalid domain format"}
 

--- a/tools/fullrecon_tool.py
+++ b/tools/fullrecon_tool.py
@@ -1,6 +1,6 @@
 from tools.signals.registry import TOOL_REGISTRY
 from collections import defaultdict
-from utils.helpers import is_valid_domain
+from utils.helpers import is_valid_domain, normalize_domain
 from tools.signals.extractor import extract_signals
 import concurrent.futures
 from datetime import datetime, timezone
@@ -52,6 +52,7 @@ def full_recon(domain: str) -> dict:
     """Execute all registered reconnaissance tools in dependency-aware waves,
     extract security signals, and build the final threat analysis payload.
     """
+    domain = normalize_domain(domain)
     if not is_valid_domain(domain):
         return {"success": False, "error": "Invalid domain format"}
 

--- a/tools/headers_tool.py
+++ b/tools/headers_tool.py
@@ -10,7 +10,7 @@ from curl_cffi import requests
 from curl_cffi.requests.errors import RequestsError
 from typing import Any, List, Dict
 
-from utils.helpers import is_valid_domain
+from utils.helpers import is_valid_domain, normalize_domain
 
 _REDIRECT_STATUSES = (301, 302, 303, 307, 308)
 _MAX_REDIRECT_HOPS = 8
@@ -83,6 +83,7 @@ def headers_analyzer(domain: str) -> dict:
         ``{"success": True, "domain": ..., "headers": {...}}`` on success,
         or ``{"success": False, "error": ...}`` on failure.
     """
+    domain = normalize_domain(domain)
     if not is_valid_domain(domain):
         return {"success": False, "error": "Invalid domain format"}
 

--- a/tools/redirect_tracer.py
+++ b/tools/redirect_tracer.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, List, Optional
 
 import requests
 
-from utils.helpers import is_valid_domain
+from utils.helpers import is_valid_domain, normalize_domain
 
 _REDIRECT_STATUSES = (301, 302, 303, 307, 308)
 _MAX_HOPS = 15
@@ -97,7 +97,8 @@ def trace_redirects(url: str) -> dict:
     original_url = _normalize_url(url)
 
     parsed = urlparse(original_url)
-    if not parsed.hostname or not is_valid_domain(parsed.hostname):
+    hostname = normalize_domain(parsed.hostname)
+    if not parsed.hostname or not is_valid_domain(hostname):
         return {"success": False, "error": "Invalid domain format"}
 
     chain: List[Dict[str, Any]] = []

--- a/tools/robots_txt_tool.py
+++ b/tools/robots_txt_tool.py
@@ -1,11 +1,12 @@
 import requests
-from utils.helpers import is_valid_domain
+from utils.helpers import is_valid_domain, normalize_domain
 
 def robots_txt_inspect(domain: str) -> dict:
     """
     Fetch and parse the robots.txt file for a given domain to reveal hidden directories and sitemaps.
     """
     try:
+        domain = normalize_domain(domain)
         if not is_valid_domain(domain):
             return {"success": False, "error": "Invalid domain format"}
 

--- a/tools/ssl_tool.py
+++ b/tools/ssl_tool.py
@@ -1,13 +1,14 @@
 import ssl
 import socket
 from datetime import datetime, timezone
-from utils.helpers import is_valid_domain
+from utils.helpers import is_valid_domain, normalize_domain
 
 def ssl_inspect(domain: str, port: int = 443) -> dict:
     """
     Inspect SSL/TLS certificate details for a domain.
     Returns cert validity, issuer, SANs, expiry, and cipher info.
     """
+    domain = normalize_domain(domain)
     if not is_valid_domain(domain):
         return {"success": False, "error": "Invalid domain format"}
 

--- a/tools/techstack_tool.py
+++ b/tools/techstack_tool.py
@@ -1,11 +1,12 @@
 import requests
-from utils.helpers import is_valid_domain
+from utils.helpers import is_valid_domain, normalize_domain
 
 def tech_stack_detect(domain: str) -> dict:
     """
     Detect technology stack of a website.
     Identifies web server, frameworks, CMS, CDN, analytics, and security headers.
     """
+    domain = normalize_domain(domain)
     if not is_valid_domain(domain):
         return {"success": False, "error": "Invalid domain format"}
 

--- a/tools/whois_tool.py
+++ b/tools/whois_tool.py
@@ -1,12 +1,13 @@
 import socket
 import whois
-from utils.helpers import is_valid_domain
+from utils.helpers import is_valid_domain, normalize_domain
 
 WHOIS_TIMEOUT_SECONDS = 10
 
 def whois_lookup(domain: str) -> dict:
     """Perform WHOIS lookup for a domain."""
     try:
+        domain = normalize_domain(domain)
         if not is_valid_domain(domain):
             return {"success": False, "error": "Invalid domain format"}
 

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -16,6 +16,20 @@ def is_valid_domain(domain: str) -> bool:
 
     return _DOMAIN_PATTERN.fullmatch(domain) is not None
 
+def normalize_domain(domain: str | None) -> str:
+    """Normalize a user-provided domain for consistent validation.
+
+    - strip surrounding whitespace
+    - lowercase
+    - remove a single trailing dot (FQDN form)
+
+    Returns an empty string when the input is missing/blank after normalization.
+    """
+    if domain is None:
+        return ""
+    normalized = str(domain).strip().lower().rstrip(".")
+    return normalized
+
 def get_cvss_details(cve: dict) -> dict:
     """Extract CVSS severity and base score from an NVD CVE object.
 

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -21,7 +21,7 @@ def normalize_domain(domain: str | None) -> str:
 
     - strip surrounding whitespace
     - lowercase
-    - remove a single trailing dot (FQDN form)
+    - remove trailing dots (FQDN form)
 
     Returns an empty string when the input is missing/blank after normalization.
     """


### PR DESCRIPTION
## Summary
Closes #96

Adds shared domain normalization and applies it before `is_valid_domain()` in domain-accepting tools.

### Changes
- `utils/helpers.py`: new `normalize_domain()`
  - strip whitespace
  - lowercase
  - remove trailing `.`
  - empty after normalize → `\"\"`
- Tools updated to normalize before validation:
  - dns / ssl / whois / robots / crt.sh / headers / techstack / email security / cloud exposure / full recon
  - redirect tracer normalizes `parsed.hostname`
- `tests/test_helpers.py`: coverage for normalize + validate path

### Expected
Inputs like `Google.COM`, ` google.com `, `google.com.` all become `google.com` before validation.

## Testing
```bash
python3 -m unittest tests.test_helpers -v
# 12 tests OK
```