### PR TITLE
feat(robots): preserve per-user-agent rules and crawl-delay groups

### DIFF
--- a/tests/test_robots_txt_tool.py
+++ b/tests/test_robots_txt_tool.py
@@ -43,10 +43,12 @@ Sitemap: https://example.com/sitemap.xml
     assert result["rules"][0]["user_agent"] == "*"
     assert result["rules"][0]["disallow"] == ["/admin", "/backup/"]
     assert result["rules"][0]["allow"] == ["/admin/public"]
-    
+    assert result["rules"][0]["crawl_delay"] is None
+
     assert result["rules"][1]["user_agent"] == "Googlebot"
     assert result["rules"][1]["disallow"] == ["/secret/"]
     assert result["rules"][1]["allow"] == []
+    assert result["rules"][1]["crawl_delay"] is None
 
 @patch("tools.robots_txt_tool.requests.get")
 def test_robots_txt_inspect_fallback_to_http(mock_get):
@@ -141,3 +143,62 @@ def test_robots_txt_inspect_crawl_delay_uses_last_seen_value(mock_get):
 
     assert result["success"] is True
     assert result["crawl_delay"] == "30"
+    # Per-group values are preserved; top-level remains last-seen for compatibility.
+    by_agent = {r["user_agent"]: r for r in result["rules"]}
+    assert by_agent["*"]["crawl_delay"] == "5"
+    assert by_agent["Googlebot"]["crawl_delay"] == "30"
+
+
+@patch("tools.robots_txt_tool.requests.get")
+def test_robots_txt_inspect_preserves_crawl_delay_only_user_agents(mock_get):
+    """User-agent blocks with only Crawl-delay must not be dropped."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.url = "https://example.com/robots.txt"
+    mock_response.text = (
+        "User-agent: SemrushBot*\n"
+        "Crawl-delay: 10\n"
+        "\n"
+        "User-agent: Applebot\n"
+        "Crawl-delay: 10\n"
+        "\n"
+        "User-agent: Bingbot\n"
+        "Crawl-delay: 10\n"
+    )
+    mock_get.return_value = mock_response
+
+    result = robots_txt_inspect("example.com")
+
+    assert result["success"] is True
+    assert result["crawl_delay"] == "10"
+    agents = [r["user_agent"] for r in result["rules"]]
+    assert agents == ["SemrushBot*", "Applebot", "Bingbot"]
+    for rule in result["rules"]:
+        assert rule["allow"] == []
+        assert rule["disallow"] == []
+        assert rule["crawl_delay"] == "10"
+
+
+@patch("tools.robots_txt_tool.requests.get")
+def test_robots_txt_inspect_groups_consecutive_user_agents(mock_get):
+    """Consecutive User-agent lines share the following directives."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.url = "https://example.com/robots.txt"
+    mock_response.text = (
+        "User-agent: Googlebot\n"
+        "User-agent: Googlebot-Image\n"
+        "Disallow: /private/\n"
+        "Crawl-delay: 5\n"
+    )
+    mock_get.return_value = mock_response
+
+    result = robots_txt_inspect("example.com")
+
+    assert result["success"] is True
+    assert len(result["rules"]) == 2
+    assert result["rules"][0]["user_agent"] == "Googlebot"
+    assert result["rules"][1]["user_agent"] == "Googlebot-Image"
+    for rule in result["rules"]:
+        assert rule["disallow"] == ["/private/"]
+        assert rule["crawl_delay"] == "5"

--- a/tools/robots_txt_tool.py
+++ b/tools/robots_txt_tool.py
@@ -1,6 +1,7 @@
 import requests
 from utils.helpers import is_valid_domain
 
+
 def robots_txt_inspect(domain: str) -> dict:
     """
     Fetch and parse the robots.txt file for a given domain to reveal hidden directories and sitemaps.
@@ -12,7 +13,7 @@ def robots_txt_inspect(domain: str) -> dict:
         headers = {"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"}
         url_https = f"https://{domain}/robots.txt"
         url_http = f"http://{domain}/robots.txt"
-        
+
         response = None
         try:
             response = requests.get(url_https, timeout=10.0, headers=headers)
@@ -21,90 +22,106 @@ def robots_txt_inspect(domain: str) -> dict:
             # Fallback to HTTP
             response = requests.get(url_http, timeout=10.0, headers=headers)
             response.raise_for_status()
-            
+
         content = response.text
         robots_url = response.url
-        
-        # We will parse robots.txt into rules by User-agent
+
+        # Parse robots.txt into per-User-agent rule groups.
+        # Consecutive User-agent lines share the following directives.
         rules = []
-        current_agent = "*"
-        current_allow = []
-        current_disallow = []
-        
+        current_agents: list[str] = []
+        current_allow: list[str] = []
+        current_disallow: list[str] = []
+        current_crawl_delay = None
+        seen_directive_in_group = False
+
         sitemaps = []
-        crawl_delay = None
+        crawl_delay = None  # last-seen top-level value (backward compatible)
         host = None
+
+        def flush_group() -> None:
+            nonlocal current_agents, current_allow, current_disallow
+            nonlocal current_crawl_delay, seen_directive_in_group
+            if not current_agents:
+                return
+            allow = list(dict.fromkeys(current_allow))
+            disallow = list(dict.fromkeys(current_disallow))
+            for agent in current_agents:
+                rules.append(
+                    {
+                        "user_agent": agent,
+                        "allow": list(allow),
+                        "disallow": list(disallow),
+                        "crawl_delay": current_crawl_delay,
+                    }
+                )
+            current_agents = []
+            current_allow = []
+            current_disallow = []
+            current_crawl_delay = None
+            seen_directive_in_group = False
 
         for line in content.splitlines():
             # Strip inline comments first
             if "#" in line:
                 line = line.split("#", 1)[0]
             line = line.strip()
-            
+
             if not line:
                 continue
-                
+
             line_lower = line.lower()
-            
+
             if line_lower.startswith("user-agent:"):
-                # If we were tracking a previous agent that had rules, save it
-                if current_allow or current_disallow:
-                    rules.append({
-                        "user_agent": current_agent,
-                        "allow": list(dict.fromkeys(current_allow)),
-                        "disallow": list(dict.fromkeys(current_disallow))
-                    })
-                    current_allow = []
-                    current_disallow = []
-                
-                current_agent = line.split(":", 1)[1].strip()
-                
+                agent = line.split(":", 1)[1].strip()
+                if not agent:
+                    continue
+                # A User-agent after directives starts a new rule group.
+                if seen_directive_in_group:
+                    flush_group()
+                current_agents.append(agent)
+
             elif line_lower.startswith("disallow:"):
                 path = line.split(":", 1)[1].strip()
                 if path:
                     current_disallow.append(path)
-                    
+                seen_directive_in_group = True
+
             elif line_lower.startswith("allow:"):
                 path = line.split(":", 1)[1].strip()
                 if path:
                     current_allow.append(path)
-                    
+                seen_directive_in_group = True
+
             elif line_lower.startswith("sitemap:"):
                 sitemap = line.split(":", 1)[1].strip()
                 if sitemap:
                     sitemaps.append(sitemap)
 
             elif line_lower.startswith("crawl-delay:"):
-                # Crawl-delay is a non-standard (non-RFC 9309) directive that some crawlers honor.
-                # It's typically interpreted per User-agent; this tool exposes the last-seen value.
+                # Crawl-delay is non-standard; honor it per User-agent group.
                 value = line.split(":", 1)[1].strip()
                 if value:
-                    crawl_delay = value
+                    current_crawl_delay = value
+                    crawl_delay = value  # keep last-seen top-level for compatibility
+                seen_directive_in_group = True
 
             elif line_lower.startswith("host:"):
-                # `Host:` is a non-standard but widely-recognized directive
-                # (originally from Yandex) used to specify the primary mirror.
+                # Host is non-standard but widely recognized (originally Yandex).
                 value = line.split(":", 1)[1].strip()
                 if value:
                     host = value
 
-        # Add the last rule block if it has anything
-        if current_allow or current_disallow or current_agent == "*":
-            # Avoid adding empty duplicate '*' rules if we haven't seen anything
-            if current_allow or current_disallow or not any(r["user_agent"] == "*" for r in rules):
-                rules.append({
-                    "user_agent": current_agent,
-                    "allow": list(dict.fromkeys(current_allow)),
-                    "disallow": list(dict.fromkeys(current_disallow))
-                })
+        # Flush the final group even when it only has Crawl-delay / empty paths.
+        flush_group()
 
-        # For backward compatibility and top-level summary, aggregate all unique paths
+        # Top-level summary aggregates unique paths across all groups.
         all_allowed = []
         all_disallowed = []
         for r in rules:
             all_allowed.extend(r["allow"])
             all_disallowed.extend(r["disallow"])
-            
+
         return {
             "success": True,
             "domain": domain,
@@ -114,7 +131,7 @@ def robots_txt_inspect(domain: str) -> dict:
             "sitemaps": list(dict.fromkeys(sitemaps)),
             "crawl_delay": crawl_delay,
             "host": host,
-            "rules": rules
+            "rules": rules,
         }
 
     except requests.RequestException as e:


### PR DESCRIPTION
## Summary
Closes #110

`robots_txt_inspect` previously only kept rule groups that contained Allow/Disallow, so common crawl-delay-only User-agent blocks were dropped.

### Changes
- Preserve all User-agent groups, including crawl-delay-only blocks
- Support consecutive `User-agent` lines sharing the same directives
- Store `crawl_delay` on each rule
- Keep top-level `allowed_paths` / `disallowed_paths` / `sitemaps` / last-seen `crawl_delay` for compatibility

### Example
```txt
User-agent: SemrushBot*
Crawl-delay: 10

User-agent: Applebot
Crawl-delay: 10
```
now returns per-agent rules instead of only a single top-level crawl_delay.

## Testing
```bash
uv run pytest tests/test_robots_txt_tool.py -v
# 9 passed
```