### PR TITLE
feat(cert_transparency): pure crt.sh CT lookups only

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ It is also listed on glama mcp registry.
 | `ssl_inspect` | SSL/TLS certificate — issuer, expiry, cipher strength, SANs, TLS version |
 | `email_security_check` | Checks SPF, DKIM, and DMARC DNS records — returns a security_score, rating, and actionable recommendations for missing or weak configurations |
 | `tech_stack_detect` | Web server, CMS, JS frameworks, CDN, analytics, and security header scoring |
-| `cert_transparency` | Subdomain discovery via crt.sh Certificate Transparency logs with an automatic fallback to HackerTarget passive DNS on timeouts |
+| `cert_transparency` | Certificate Transparency lookups via crt.sh (issuer, validity, wildcards, unique certificate names) |
 | `asn_lookup` | Autonomous System Number (ASN) and network ownership lookup via Team Cymru WHOIS — identifies ASN, BGP prefix, organization, registry, country, and allocation date for domains or IP addresses (no API key required) |
 | `ip_reputation` | Check if an IP is flagged as malicious via AbuseIPDB (api key requied) |
 | `full_recon` | Runs all core tools in parallel and returns combined result |

--- a/mcp.json
+++ b/mcp.json
@@ -76,7 +76,7 @@
     },
     {
       "name": "cert_transparency",
-      "description": "Subdomain discovery and Certificate Transparency logs with an automatic fallback to HackerTarget passive DNS on timeouts",
+      "description": "Certificate Transparency lookups via crt.sh (issuer, validity dates, wildcards, unique certificate names)",
       "input": {
         "domain": "string"
       },

--- a/tests/test_crtsh_tool.py
+++ b/tests/test_crtsh_tool.py
@@ -1,8 +1,9 @@
-import unittest
-from unittest.mock import patch, Mock
-import pytest
+from unittest.mock import Mock, patch
+
 from curl_cffi.requests.errors import RequestsError
+
 from tools.crt_sh_tool import cert_transparency
+
 
 @patch("tools.crt_sh_tool.requests.get")
 def test_cert_transparency_success(mock_get):
@@ -24,6 +25,8 @@ def test_cert_transparency_success(mock_get):
     assert result["source"] == "crt.sh"
     assert "api.example.com" in result["unique_subdomains"]
     assert "dev.example.com" in result["unique_subdomains"]
+    # Pure CT path should not use browser impersonation.
+    assert "impersonate" not in mock_get.call_args.kwargs
 
 
 def test_invalid_domain():
@@ -31,56 +34,40 @@ def test_invalid_domain():
     assert result["success"] is False
 
 
-# Patch BOTH the primary curl_cffi requests AND the standard_requests fallback
-@patch("tools.crt_sh_tool.standard_requests.get")
 @patch("tools.crt_sh_tool.requests.get")
-def test_timeout_with_fallback_success(mock_primary_get, mock_fallback_get):
-    mock_primary_get.side_effect = RequestsError("Operation timed out", 28)
-
-    mock_fallback_response = Mock()
-    mock_fallback_response.status_code = 200
-    mock_fallback_response.text = "api.example.com,1.1.1.1\nvpn.example.com,2.2.2.2"
-    mock_fallback_get.return_value = mock_fallback_response
-
-    result = cert_transparency("example.com")
-
-    assert result["success"] is True
-    assert result["source"] == "hackertarget_fallback"
-    assert "api.example.com" in result["unique_subdomains"]
-    assert "vpn.example.com" in result["unique_subdomains"]
-
-
-@patch("tools.crt_sh_tool.standard_requests.get")
-@patch("tools.crt_sh_tool.requests.get")
-def test_timeout_with_fallback_failure(mock_primary_get, mock_fallback_get):
-    mock_primary_get.side_effect = RequestsError("Operation timed out", 28)
-
-    mock_fallback_response = Mock()
-    mock_fallback_response.status_code = 200
-    mock_fallback_response.text = "API count exceeded - Increase Plan or Log In"
-    mock_fallback_get.return_value = mock_fallback_response
+def test_timeout_returns_clear_ct_error(mock_get):
+    mock_get.side_effect = RequestsError("Operation timed out", 28)
 
     result = cert_transparency("example.com")
 
     assert result["success"] is False
-    assert "error" in result
+    assert result["domain"] == "example.com"
+    assert result["error"] == "Certificate Transparency lookup failed."
+    assert result.get("source") != "hackertarget_fallback"
 
 
-@patch("tools.crt_sh_tool.standard_requests.get")
 @patch("tools.crt_sh_tool.requests.get")
-def test_http_error_trigger_fallback(mock_primary_get, mock_fallback_get):
-    mock_primary_get.side_effect = RequestsError("HTTP 502 Bad Gateway", 502)
-
-    mock_fallback_response = Mock()
-    mock_fallback_response.status_code = 200
-    mock_fallback_response.text = "fallback.example.com,3.3.3.3"
-    mock_fallback_get.return_value = mock_fallback_response
+def test_http_error_returns_clear_ct_error(mock_get):
+    mock_get.side_effect = RequestsError("HTTP 502 Bad Gateway", 502)
 
     result = cert_transparency("example.com")
 
-    assert result["success"] is True
-    assert result["source"] == "hackertarget_fallback"
-    assert "fallback.example.com" in result["unique_subdomains"]
+    assert result["success"] is False
+    assert result["error"] == "Certificate Transparency lookup failed."
+
+
+@patch("tools.crt_sh_tool.requests.get")
+def test_invalid_json_returns_clear_ct_error(mock_get):
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.side_effect = ValueError("No JSON")
+    mock_get.return_value = mock_response
+
+    result = cert_transparency("example.com")
+
+    assert result["success"] is False
+    assert result["error"] == "Certificate Transparency lookup failed."
 
 
 @patch("tools.crt_sh_tool.requests.get")
@@ -123,6 +110,7 @@ def test_wildcard_on_root_domain_is_captured(mock_get):
     assert result["unique_subdomains"] == []
     assert result["total_unique_subdomains"] == 0
 
+
 @patch("tools.crt_sh_tool.requests.get")
 def test_mixed_wildcard_and_concrete_subdomain(mock_get):
     mock_response = Mock()
@@ -142,6 +130,7 @@ def test_mixed_wildcard_and_concrete_subdomain(mock_get):
     assert ".example.com" in result["wildcards_found"]
     assert "api.example.com" in result["unique_subdomains"]
 
+
 @patch("tools.crt_sh_tool.requests.get")
 def test_unrelated_wildcard_is_filtered_out(mock_get):
     mock_response = Mock()
@@ -157,9 +146,10 @@ def test_unrelated_wildcard_is_filtered_out(mock_get):
     mock_get.return_value = mock_response
 
     result = cert_transparency("example.com")
-    
+
     assert result["wildcards_found"] == []
     assert result["unique_subdomains"] == []
+
 
 @patch("tools.crt_sh_tool.requests.get")
 def test_wildcard_suffix_collision_is_filtered_out(mock_get):
@@ -179,6 +169,3 @@ def test_wildcard_suffix_collision_is_filtered_out(mock_get):
     result = cert_transparency("ample.com")
 
     assert result["wildcards_found"] == []
-
-if __name__ == "__main__":
-    unittest.main(verbosity=2)

--- a/tools/crt_sh_tool.py
+++ b/tools/crt_sh_tool.py
@@ -1,53 +1,30 @@
 from curl_cffi import requests
-from curl_cffi.requests.errors import RequestsError 
-from typing import Dict, Any, Set
-import requests as standard_requests  # Used for the quick fallback API
+from curl_cffi.requests.errors import RequestsError
+from typing import Any
 
 from utils.helpers import is_valid_domain
 
-def fetch_from_hackertarget(domain: str) -> Set[str]:
-    """
-    Rapid passive DNS fallback for when crt.sh times out or crashes.
-    Does not require API keys or complex TLS bypassing.
-    """
-    subdomains = set()
-    try:
-        url = f"https://api.hackertarget.com/hostsearch/?q={domain}"
-        # Short timeout because HackerTarget is usually instant
-        response = standard_requests.get(url, timeout=10)
-        if response.status_code == 200 and "error" not in response.text:
-            # HackerTarget returns text data: "subdomain.domain.com,IP"
-            for line in response.text.strip().split("\n"):
-                if "," in line:
-                    subdomain = line.split(",")[0].strip().lower()
-                    # Clean up wildcards if any and ensure it belongs to target
-                    if subdomain.startswith("*."):
-                        subdomain = subdomain[2:]
-                    if subdomain.endswith(domain) and subdomain != domain:
-                        subdomains.add(subdomain)
-    except Exception:
-        pass  # Quietly ignore fallback issues so we can process what we have
-    return subdomains
 
-def cert_transparency(domain: str) -> Dict[str, Any]:
-    """
-    Search crt.sh Certificate Transparency logs with browser spoofing,
-    and automatically falls back to passive DNS if crt.sh times out.
+def cert_transparency(domain: str) -> dict[str, Any]:
+    """Search crt.sh Certificate Transparency logs only.
+
+    This tool intentionally does not fall back to passive DNS sources.
+    When crt.sh is unavailable, it returns a clear failure so callers do
+    not confuse CT results with unrelated subdomain discovery data.
     """
     domain = domain.strip().lower()
 
     if not is_valid_domain(domain):
         return {
             "success": False,
-            "error": "Invalid domain format"
+            "error": "Invalid domain format",
         }
 
     url = f"https://crt.sh/?q=%.{domain}&output=json"
     headers = {"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"}
 
     try:
-        # Try primary source: crt.sh with Chrome impersonation
-        response = requests.get(url, headers=headers, timeout=50, impersonate="chrome")
+        response = requests.get(url, headers=headers, timeout=50)
         response.raise_for_status()
         data = response.json()
 
@@ -58,9 +35,9 @@ def cert_transparency(domain: str) -> Dict[str, Any]:
 
         for entry in data:
             issuer = entry.get("issuer_name", "Unknown")
-            not_before = (entry.get("not_before", "").split("T")[0])
-            not_after = (entry.get("not_after", "").split("T")[0])
-            names = (entry.get("name_value", "").split("\n"))
+            not_before = entry.get("not_before", "").split("T")[0]
+            not_after = entry.get("not_after", "").split("T")[0]
+            names = entry.get("name_value", "").split("\n")
 
             for name in names:
                 name = name.strip().lower()
@@ -84,12 +61,14 @@ def cert_transparency(domain: str) -> Dict[str, Any]:
                     continue
                 seen.add(cert_key)
 
-                certificates.append({
-                    "subdomain": name,
-                    "issuer": issuer,
-                    "not_before": not_before,
-                    "not_after": not_after
-                })
+                certificates.append(
+                    {
+                        "subdomain": name,
+                        "issuer": issuer,
+                        "not_before": not_before,
+                        "not_after": not_after,
+                    }
+                )
 
         return {
             "success": True,
@@ -101,31 +80,12 @@ def cert_transparency(domain: str) -> Dict[str, Any]:
             "wildcards_found": sorted(wildcards),
             "returned_certificates": min(50, len(certificates)),
             "truncated": len(certificates) > 50,
-            "certificates": certificates[:50]
+            "certificates": certificates[:50],
         }
 
-    except (RequestsError, ValueError) as e:
-        # Primary source failed or timed out! Triggering fallback.
-        fallback_subdomains = fetch_from_hackertarget(domain)
-        
-        if fallback_subdomains:
-            return {
-                "success": True,
-                "source": "hackertarget_fallback",
-                "domain": domain,
-                "total_certificates": 0,
-                "total_unique_subdomains": len(fallback_subdomains),
-                "unique_subdomains": sorted(list(fallback_subdomains)),
-                "wildcards_found": [],
-                "returned_certificates": 0,
-                "truncated": False,
-                "certificates": [],
-                "note": f"Primary source (crt.sh) timed out or failed: {str(e)}. Switched to fallback."
-            }
-        
-        # If fallback also yields absolutely nothing, return the timeout error
+    except (RequestsError, ValueError, Exception):
         return {
             "success": False,
             "domain": domain,
-            "error": f"Primary source failed ({str(e)}) and fallback yielded no results."
+            "error": "Certificate Transparency lookup failed.",
         }


### PR DESCRIPTION
## Summary
Closes #104

`cert_transparency` previously fell back to HackerTarget passive DNS when crt.sh failed. That mixed CT semantics with unrelated subdomain discovery data.

### Changes
- Remove `fetch_from_hackertarget` fallback
- Remove unexpected `impersonate=\"chrome\"`
- On crt.sh failure/timeout/invalid data, return:
  ```json
  {\"success\": false, \"domain\": \"...\", \"error\": \"Certificate Transparency lookup failed.\"}
  ```
- Preserve CT success schema (issuer/dates/wildcards/subdomains/counts)
- Update `mcp.json` + README tool description
- Update unit tests for pure CT behavior

## Testing
```bash
uv run pytest tests/test_crtsh_tool.py -v
# 10 passed
```