### PR TITLE
feat(ip_reputation): richer classification and AbuseIPDB metadata

### DIFF
--- a/tests/test_ip_reputation.py
+++ b/tests/test_ip_reputation.py
@@ -1,10 +1,11 @@
-from unittest.mock import Mock, MagicMock, patch, call
-import unittest
-from tools.iprep_tool import ip_reputation
 import os
+import unittest
+from unittest.mock import Mock, patch
+
+from tools.iprep_tool import _classify_reputation, ip_reputation
+
 
 class TestIpReputation(unittest.TestCase):
-
     def test_ip_reputation_requires_valid_ip_and_api_key(self):
         self.assertFalse(ip_reputation("not-an-ip")["success"])
 
@@ -23,6 +24,12 @@ class TestIpReputation(unittest.TestCase):
                 "ipAddress": "1.2.3.4",
                 "abuseConfidenceScore": 95,
                 "totalReports": 342,
+                "numDistinctUsers": 40,
+                "isWhitelisted": False,
+                "isPublic": True,
+                "isTor": False,
+                "ipVersion": 4,
+                "hostnames": ["bad.example"],
                 "countryCode": "CN",
                 "isp": "Example ISP",
                 "domain": "example.net",
@@ -36,10 +43,19 @@ class TestIpReputation(unittest.TestCase):
 
         self.assertTrue(result["success"])
         self.assertTrue(result["is_malicious"])
+        self.assertEqual(result["reputation"], "high-risk")
         self.assertEqual(result["abuse_confidence_score"], 95)
         self.assertEqual(result["total_reports"], 342)
+        self.assertEqual(result["num_distinct_users"], 40)
+        self.assertFalse(result["is_whitelisted"])
+        self.assertTrue(result["is_public"])
+        self.assertFalse(result["is_tor"])
+        self.assertEqual(result["ip_version"], 4)
+        self.assertEqual(result["hostnames"], ["bad.example"])
         self.assertEqual(result["country"], "CN")
         self.assertEqual(result["isp"], "Example ISP")
+        self.assertEqual(result["usage_type"], "Data Center/Web Hosting/Transit")
+        self.assertEqual(result["last_reported_at"], "2026-05-01T00:00:00+00:00")
         mock_get.assert_called_once()
 
     @patch.dict(os.environ, {"ABUSEIPDB_API_KEY": "test-key"})
@@ -47,16 +63,23 @@ class TestIpReputation(unittest.TestCase):
     def test_low_score_not_malicious(self, mock_get):
         response = Mock()
         response.json.return_value = {
-            "data": {"abuseConfidenceScore": 5, "totalReports": 1,
-                     "countryCode": "US", "isp": "Good ISP",
-                     "domain": "good.net", "usageType": "ISP",
-                     "lastReportedAt": None}
+            "data": {
+                "abuseConfidenceScore": 5,
+                "totalReports": 1,
+                "isWhitelisted": False,
+                "countryCode": "US",
+                "isp": "Good ISP",
+                "domain": "good.net",
+                "usageType": "ISP",
+                "lastReportedAt": None,
+            }
         }
         mock_get.return_value = response
 
         result = ip_reputation("8.8.8.8")
         self.assertTrue(result["success"])
         self.assertFalse(result["is_malicious"])  # score < 25
+        self.assertEqual(result["reputation"], "low-risk")
 
     @patch.dict(os.environ, {"ABUSEIPDB_API_KEY": "test-key"})
     @patch("tools.iprep_tool.requests.get")
@@ -64,15 +87,98 @@ class TestIpReputation(unittest.TestCase):
         """Boundary: score == 25 should be flagged malicious."""
         response = Mock()
         response.json.return_value = {
-            "data": {"abuseConfidenceScore": 25, "totalReports": 5,
-                     "countryCode": "RU", "isp": "Some ISP",
-                     "domain": "bad.net", "usageType": "Hosting",
-                     "lastReportedAt": None}
+            "data": {
+                "abuseConfidenceScore": 25,
+                "totalReports": 5,
+                "isWhitelisted": False,
+                "countryCode": "RU",
+                "isp": "Some ISP",
+                "domain": "bad.net",
+                "usageType": "Hosting",
+                "lastReportedAt": None,
+            }
         }
         mock_get.return_value = response
 
         result = ip_reputation("1.1.1.1")
         self.assertTrue(result["is_malicious"])
+        self.assertEqual(result["reputation"], "suspicious")
+
+    @patch.dict(os.environ, {"ABUSEIPDB_API_KEY": "test-key"})
+    @patch("tools.iprep_tool.requests.get")
+    def test_whitelisted_ip_is_trusted_even_with_reports(self, mock_get):
+        response = Mock()
+        response.json.return_value = {
+            "data": {
+                "abuseConfidenceScore": 0,
+                "totalReports": 120,
+                "numDistinctUsers": 65,
+                "isWhitelisted": True,
+                "isPublic": True,
+                "isTor": False,
+                "ipVersion": 4,
+                "hostnames": ["dns.google"],
+                "countryCode": "US",
+                "isp": "Google LLC",
+                "domain": "google.com",
+                "usageType": "Content Delivery Network",
+                "lastReportedAt": "2026-04-01T00:00:00+00:00",
+            }
+        }
+        mock_get.return_value = response
+
+        result = ip_reputation("8.8.8.8")
+        self.assertTrue(result["success"])
+        self.assertFalse(result["is_malicious"])
+        self.assertEqual(result["reputation"], "trusted")
+        self.assertTrue(result["is_whitelisted"])
+        self.assertEqual(result["total_reports"], 120)
+        self.assertEqual(result["usage_type"], "Content Delivery Network")
+
+    @patch.dict(os.environ, {"ABUSEIPDB_API_KEY": "test-key"})
+    @patch("tools.iprep_tool.requests.get")
+    def test_clean_ip_with_no_reports(self, mock_get):
+        response = Mock()
+        response.json.return_value = {
+            "data": {
+                "abuseConfidenceScore": 0,
+                "totalReports": 0,
+                "isWhitelisted": False,
+                "countryCode": "DE",
+                "isp": "Clean ISP",
+                "domain": "clean.net",
+                "usageType": "ISP",
+                "lastReportedAt": None,
+            }
+        }
+        mock_get.return_value = response
+
+        result = ip_reputation("9.9.9.9")
+        self.assertTrue(result["success"])
+        self.assertFalse(result["is_malicious"])
+        self.assertEqual(result["reputation"], "clean")
+
+    def test_classify_reputation_priority(self):
+        self.assertEqual(
+            _classify_reputation(is_whitelisted=True, abuse_score=99, total_reports=1000),
+            "trusted",
+        )
+        self.assertEqual(
+            _classify_reputation(is_whitelisted=False, abuse_score=80, total_reports=1),
+            "high-risk",
+        )
+        self.assertEqual(
+            _classify_reputation(is_whitelisted=False, abuse_score=30, total_reports=2),
+            "suspicious",
+        )
+        self.assertEqual(
+            _classify_reputation(is_whitelisted=False, abuse_score=0, total_reports=10),
+            "low-risk",
+        )
+        self.assertEqual(
+            _classify_reputation(is_whitelisted=False, abuse_score=0, total_reports=0),
+            "clean",
+        )
 
     def test_ipv6_address_accepted(self):
         with patch.dict(os.environ, {}, clear=True):
@@ -86,6 +192,7 @@ class TestIpReputation(unittest.TestCase):
                 result = ip_reputation(bad_ip)
                 self.assertFalse(result["success"])
                 self.assertIn("Invalid IP", result["error"])
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tools/iprep_tool.py
+++ b/tools/iprep_tool.py
@@ -1,11 +1,44 @@
 import ipaddress
-import requests
 import os
+
+import requests
+
+
+def _classify_reputation(
+    *,
+    is_whitelisted: bool | None,
+    abuse_score: int,
+    total_reports: int,
+) -> str:
+    """Return a human-readable reputation label.
+
+    Priority:
+    1. trusted  - explicitly whitelisted by AbuseIPDB
+    2. high-risk - high abuse confidence
+    3. suspicious - moderate confidence or many reports with some confidence
+    4. low-risk - some reports but very low confidence
+    5. clean - no meaningful abuse signal
+    """
+    if is_whitelisted:
+        return "trusted"
+    if abuse_score >= 75:
+        return "high-risk"
+    if abuse_score >= 25:
+        return "suspicious"
+    if total_reports > 0 and abuse_score > 0:
+        return "low-risk"
+    if total_reports > 0:
+        return "low-risk"
+    return "clean"
+
 
 def ip_reputation(ip_address: str) -> dict:
     """
     Check whether an IP address is reported as malicious using AbuseIPDB.
     Requires ABUSEIPDB_API_KEY in the environment.
+
+    Returns both the legacy is_malicious boolean and a richer reputation
+    classification based on whitelist metadata and abuse confidence.
     """
     try:
         ip = str(ipaddress.ip_address(ip_address.strip()))
@@ -29,13 +62,29 @@ def ip_reputation(ip_address: str) -> dict:
         response.raise_for_status()
         data = response.json().get("data", {})
 
-        abuse_score = data.get("abuseConfidenceScore", 0)
+        abuse_score = data.get("abuseConfidenceScore", 0) or 0
+        total_reports = data.get("totalReports", 0) or 0
+        is_whitelisted = data.get("isWhitelisted")
+        reputation = _classify_reputation(
+            is_whitelisted=is_whitelisted,
+            abuse_score=int(abuse_score),
+            total_reports=int(total_reports),
+        )
+
         return {
             "success": True,
             "ip": ip,
-            "is_malicious": abuse_score >= 25,
+            # Keep legacy flag for compatibility; whitelist overrides malicious.
+            "is_malicious": bool(abuse_score >= 25 and not is_whitelisted),
+            "reputation": reputation,
             "abuse_confidence_score": abuse_score,
-            "total_reports": data.get("totalReports", 0),
+            "total_reports": total_reports,
+            "num_distinct_users": data.get("numDistinctUsers"),
+            "is_whitelisted": is_whitelisted,
+            "is_public": data.get("isPublic"),
+            "is_tor": data.get("isTor"),
+            "ip_version": data.get("ipVersion"),
+            "hostnames": data.get("hostnames") or [],
             "country": data.get("countryCode"),
             "isp": data.get("isp"),
             "domain": data.get("domain"),


### PR DESCRIPTION
## Summary
Closes #101

`ip_reputation` previously reduced AbuseIPDB results to a single boolean based on `abuseConfidenceScore >= 25`. That hides useful context (for example Google DNS can have reports but be whitelisted).

### Changes
- Add human-readable `reputation`:
  - `trusted` (whitelisted)
  - `high-risk` (score >= 75)
  - `suspicious` (score >= 25)
  - `low-risk` (reports with low/zero score)
  - `clean`
- Include additional AbuseIPDB fields:
  - `is_whitelisted`, `is_public`, `is_tor`
  - `num_distinct_users`, `hostnames`, `ip_version`
  - keep existing score/report/country/isp/domain/usage_type/last_reported_at
- Preserve legacy `is_malicious` (whitelist overrides malicious)

## Testing
```bash
uv run pytest tests/test_ip_reputation.py -v
# 9 passed
```