### PR TITLE
Enhancement: populate ASN-related signals

### DIFF
--- a/tests/test_asn_signals.py
+++ b/tests/test_asn_signals.py
@@ -1,0 +1,49 @@
+"""Regression tests for ASN signal extraction."""
+
+from tools.signals.asn import asn_extractor
+from tools.signals.extractor import extract_signals
+from tools.signals.registry import TOOL_REGISTRY
+
+
+def test_asn_extractor_populates_asn_signals():
+    signals = {"asn_number": None, "asn_isp": None, "ip_abuse_score": 73}
+    result = {
+        "success": True,
+        "asn": "AS64500",
+        "isp": "Example ISP",
+        "org": "Example Org",
+        "country": "Testland",
+    }
+
+    asn_extractor(result, signals)
+
+    assert signals["asn_number"] == "AS64500"
+    assert signals["asn_isp"] == "Example ISP"
+    assert signals["ip_abuse_score"] == 73
+
+
+def test_asn_extractor_preserves_signals_when_lookup_fails():
+    signals = {"asn_number": None, "asn_isp": None}
+
+    asn_extractor({"success": False, "error": "lookup failed"}, signals)
+
+    assert signals == {"asn_number": None, "asn_isp": None}
+
+
+def test_asn_extractor_handles_missing_optional_values():
+    signals = {"asn_number": "old", "asn_isp": "old"}
+
+    asn_extractor({"success": True}, signals)
+
+    assert signals["asn_number"] is None
+    assert signals["asn_isp"] is None
+
+
+def test_extract_signals_exposes_asn_defaults():
+    results = {
+        tool["name"]: {"success": False} for tool in TOOL_REGISTRY
+    }
+    signals = extract_signals(results)
+
+    assert signals["asn_number"] is None
+    assert signals["asn_isp"] is None

--- a/tools/signals/asn.py
+++ b/tools/signals/asn.py
@@ -1,10 +1,6 @@
-def asn_extractor(result , signals):
-    # asn_tool returns {ip, asn, org, isp, country, region, city} — it does
-    # NOT carry an abuse score. The abuse confidence score comes from the
-    # AbuseIPDB-backed ip_reputation tool and is populated by
-    # ip_reputation_extractor. The previous abuse_score lookup here was
-    # dead code: it always fell through to the `0` default, which silently
-    # zeroed out signals["ip_abuse_score"] (see PR #84 for the regression
-    # and the follow-up PR that moved the assignment to ip_reputation).
+def asn_extractor(result, signals):
     if not result.get("success"):
         return
+
+    signals["asn_number"] = result.get("asn")
+    signals["asn_isp"] = result.get("isp")

--- a/tools/signals/extractor.py
+++ b/tools/signals/extractor.py
@@ -11,6 +11,8 @@ def extract_signals(results):
     "ssl_days_remaining":       None,   # ssl
     "software_detected":        [],     # techstack
     "ip_abuse_score":           0,      # ip_reputation
+    "asn_number":               None,   # asn
+    "asn_isp":                  None,   # asn
     "subdomain_count":          0,      # ct_logs
     "missing_security_headers": [],     # headers
     "email_security":           {},     # email_security_tool


### PR DESCRIPTION
## Summary

- Add `asn_number` and `asn_isp` to the shared signals dictionary
- Populate them after successful ASN lookups
- Preserve unsuccessful-lookup behavior and the canonical IP abuse score
- Add dedicated regression tests

## Testing

- 15 relevant tests passed

Closes #117