### PR TITLE
feat: add subdomain takeover checker tool (#14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ It is also listed on glama mcp registry.
 | `cloud_exposure_check` | Checks for publicly accessible AWS S3, Azure Blob Storage, and Google Cloud Storage buckets using common bucket naming patterns derived from the target domain |
 | `trace_redirects` | Traces the full HTTP redirect chain hop by hop — flags TLS downgrades, private-IP leaks, redirect loops, cross-domain hops, and overly long chains |
 | `robots_txt_inspect` | Fetch and parse robots.txt to reveal hidden directories and sitemaps |
+| `subdomain_takeover` | Checks discovered subdomains for takeover vulnerabilities — matches CNAMEs against known-vulnerable service fingerprints (GitHub Pages, Heroku, S3, Azure, Ghost, Shopify, Fastly) and confirms via HTTP |
 
 ## Prompts Available
 | Prompt | Description |

--- a/mcp.json
+++ b/mcp.json
@@ -140,6 +140,14 @@
         "domain": "string"
       },
       "requires_api_key": false
+    },
+    {
+      "name": "subdomain_takeover",
+      "description": "Check discovered subdomains for takeover vulnerabilities — resolves CNAMEs, matches known-vulnerable service fingerprints (GitHub Pages, Heroku, S3, Azure, Ghost, Shopify, Fastly), and confirms via an HTTP probe",
+      "input": {
+        "domain": "string"
+      },
+      "requires_api_key": false
     }
   ],
   "environment_variables": [

--- a/server.py
+++ b/server.py
@@ -16,6 +16,7 @@ from tools.email_security_tool import email_security_check
 from tools.redirect_tracer import trace_redirects
 from tools.cloud_exposure_tool import cloud_exposure_check
 from tools.robots_txt_tool import robots_txt_inspect
+from tools.subdomain_takeover_tool import subdomain_takeover
 from tools.prompts.threat_analysis import THREAT_ANALYSIS_PROMPT
 
 mcp = FastMCP("AynOps")
@@ -35,6 +36,7 @@ mcp.tool()(email_security_check)
 mcp.tool()(trace_redirects)
 mcp.tool()(cloud_exposure_check)
 mcp.tool()(robots_txt_inspect)
+mcp.tool()(subdomain_takeover)
 
 @mcp.prompt(
     name="threat_analysis",

--- a/tests/test_subdomain_takeover.py
+++ b/tests/test_subdomain_takeover.py
@@ -106,7 +106,7 @@ def test_no_dangling_cname_is_safe(mock_enum, mock_resolver_class, mock_get):
 @patch("tools.subdomain_takeover_tool.dns.resolver.Resolver")
 @patch("tools.subdomain_takeover_tool.dns_enumeration")
 def test_aggregate_counts(mock_enum, mock_resolver_class, mock_get):
-    """Mixed results: one vulnerable (status-based), one safe (live), one safe (no CNAME)."""
+    """Mixed results: one vulnerable (GitHub Pages, body-based), one safe (live), one safe (no CNAME)."""
     mock_enum.return_value = _enumeration_result(
         ["dev.example.com", "blog.example.com", "www.example.com"]
     )
@@ -130,8 +130,10 @@ def test_aggregate_counts(mock_enum, mock_resolver_class, mock_get):
     def http_side_effect(url, **kwargs):
         response = Mock()
         if "dev.example.com" in url:
-            # GitHub Pages: takeover indicator is a 404 status
-            response.status_code = 404
+            # GitHub Pages: takeover indicator is the unclaimed-site body string.
+            # status_code is intentionally 200 (not 404) to prove the match keys
+            # on the response body, not on a bare status code.
+            response.status_code = 200
             response.text = "There isn't a GitHub Pages site here."
         else:
             # Shopify CNAME but shop is live
@@ -149,6 +151,91 @@ def test_aggregate_counts(mock_enum, mock_resolver_class, mock_get):
     assert result["vulnerable"][0]["subdomain"] == "dev.example.com"
     assert result["vulnerable"][0]["service"] == "GitHub Pages"
     assert result["safe"] == ["blog.example.com", "www.example.com"]
+
+
+@patch("tools.subdomain_takeover_tool.requests.get")
+@patch("tools.subdomain_takeover_tool.dns.resolver.Resolver")
+@patch("tools.subdomain_takeover_tool.dns_enumeration")
+def test_azure_vulnerable_matches_body(mock_enum, mock_resolver_class, mock_get):
+    """Azure CNAME + Azure-specific body string => vulnerable, probed over HTTPS first."""
+    mock_enum.return_value = _enumeration_result(["app.example.com"])
+
+    resolver = Mock()
+    resolver.resolve.return_value = [_cname_record("app.azurewebsites.net.")]
+    mock_resolver_class.return_value = resolver
+
+    mock_response = Mock()
+    # A non-404 status proves the match keys on the body, not on the status code.
+    mock_response.status_code = 200
+    mock_response.text = "404 Web Site not found"
+    mock_get.return_value = mock_response
+
+    result = subdomain_takeover("example.com")
+
+    assert result["success"] is True
+    assert result["total_vulnerable"] == 1
+    assert result["vulnerable"][0]["subdomain"] == "app.example.com"
+    assert result["vulnerable"][0]["service"] == "Azure"
+    # HTTPS is attempted first and succeeded, so exactly one request is made to https://.
+    assert mock_get.call_count == 1
+    assert mock_get.call_args_list[0].args[0].startswith("https://app.example.com")
+
+
+@patch("tools.subdomain_takeover_tool.requests.get")
+@patch("tools.subdomain_takeover_tool.dns.resolver.Resolver")
+@patch("tools.subdomain_takeover_tool.dns_enumeration")
+def test_https_failure_falls_back_to_http(mock_enum, mock_resolver_class, mock_get):
+    """HTTPS connection fails => probe falls back to HTTP and still confirms takeover."""
+    import requests as real_requests
+
+    mock_enum.return_value = _enumeration_result(["app.example.com"])
+
+    resolver = Mock()
+    resolver.resolve.return_value = [_cname_record("app.azurewebsites.net.")]
+    mock_resolver_class.return_value = resolver
+
+    def http_side_effect(url, **kwargs):
+        if url.startswith("https://"):
+            raise real_requests.exceptions.ConnectionError("HTTPS unavailable")
+        response = Mock()
+        response.status_code = 404
+        response.text = "404 Web Site not found"
+        return response
+
+    mock_get.side_effect = http_side_effect
+
+    result = subdomain_takeover("example.com")
+
+    assert result["success"] is True
+    assert result["total_vulnerable"] == 1
+    assert result["vulnerable"][0]["service"] == "Azure"
+    # HTTPS tried first (and failed), then HTTP fallback succeeded.
+    assert mock_get.call_count == 2
+    assert mock_get.call_args_list[0].args[0].startswith("https://app.example.com")
+    assert mock_get.call_args_list[1].args[0].startswith("http://app.example.com")
+
+
+@patch("tools.subdomain_takeover_tool.requests.get")
+@patch("tools.subdomain_takeover_tool.dns.resolver.Resolver")
+@patch("tools.subdomain_takeover_tool.dns_enumeration")
+def test_both_schemes_fail_is_safe(mock_enum, mock_resolver_class, mock_get):
+    """Neither HTTPS nor HTTP connects => not confirmed => safe."""
+    import requests as real_requests
+
+    mock_enum.return_value = _enumeration_result(["app.example.com"])
+
+    resolver = Mock()
+    resolver.resolve.return_value = [_cname_record("app.azurewebsites.net.")]
+    mock_resolver_class.return_value = resolver
+
+    mock_get.side_effect = real_requests.exceptions.ConnectionError("unreachable")
+
+    result = subdomain_takeover("example.com")
+
+    assert result["success"] is True
+    assert result["total_vulnerable"] == 0
+    assert result["safe"] == ["app.example.com"]
+    assert mock_get.call_count == 2
 
 
 @patch("tools.subdomain_takeover_tool.dns_enumeration")

--- a/tests/test_subdomain_takeover.py
+++ b/tests/test_subdomain_takeover.py
@@ -1,0 +1,171 @@
+import unittest
+from unittest.mock import patch, Mock
+
+from tools.subdomain_takeover_tool import subdomain_takeover
+
+
+def _enumeration_result(subdomains):
+    return {
+        "success": True,
+        "domain": "example.com",
+        "records": {},
+        "subdomains_found": subdomains,
+    }
+
+
+def _cname_record(target):
+    record = Mock()
+    record.__str__ = lambda self: target
+    return record
+
+
+@patch("tools.subdomain_takeover_tool.requests.get")
+@patch("tools.subdomain_takeover_tool.dns.resolver.Resolver")
+@patch("tools.subdomain_takeover_tool.dns_enumeration")
+def test_vulnerable_subdomain_is_flagged(mock_enum, mock_resolver_class, mock_get):
+    """Dangling CNAME to a fingerprinted service + takeover indicator => vulnerable."""
+    mock_enum.return_value = _enumeration_result(["blog.example.com", "www.example.com"])
+
+    import dns.resolver as real_dns
+
+    resolver = Mock()
+    resolver.resolve.side_effect = lambda name, rtype, **kwargs: (
+        [_cname_record("example.ghost.io.")]
+        if name == "blog.example.com"
+        else (_ for _ in ()).throw(real_dns.NoAnswer)
+    )
+    mock_resolver_class.return_value = resolver
+
+    mock_response = Mock()
+    mock_response.status_code = 404
+    mock_response.text = "404 Domain Not Found"
+    mock_get.return_value = mock_response
+
+    result = subdomain_takeover("example.com")
+
+    assert result["success"] is True
+    assert result["subdomains_checked"] == 2
+    assert result["total_vulnerable"] == 1
+    assert result["vulnerable"][0]["subdomain"] == "blog.example.com"
+    assert result["vulnerable"][0]["cname"] == "example.ghost.io"
+    assert result["vulnerable"][0]["service"] == "Ghost"
+    assert result["vulnerable"][0]["severity"] == "HIGH"
+    assert "reason" in result["vulnerable"][0]
+    assert result["safe"] == ["www.example.com"]
+    mock_get.assert_called_once()
+
+
+@patch("tools.subdomain_takeover_tool.requests.get")
+@patch("tools.subdomain_takeover_tool.dns.resolver.Resolver")
+@patch("tools.subdomain_takeover_tool.dns_enumeration")
+def test_fingerprint_match_without_indicator_is_safe(mock_enum, mock_resolver_class, mock_get):
+    """CNAME matches a fingerprint but the service is still live => safe."""
+    mock_enum.return_value = _enumeration_result(["blog.example.com"])
+
+    resolver = Mock()
+    resolver.resolve.return_value = [_cname_record("example.ghost.io.")]
+    mock_resolver_class.return_value = resolver
+
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.text = "Welcome to my blog"
+    mock_get.return_value = mock_response
+
+    result = subdomain_takeover("example.com")
+
+    assert result["success"] is True
+    assert result["vulnerable"] == []
+    assert result["total_vulnerable"] == 0
+    assert result["safe"] == ["blog.example.com"]
+
+
+@patch("tools.subdomain_takeover_tool.requests.get")
+@patch("tools.subdomain_takeover_tool.dns.resolver.Resolver")
+@patch("tools.subdomain_takeover_tool.dns_enumeration")
+def test_no_dangling_cname_is_safe(mock_enum, mock_resolver_class, mock_get):
+    """Subdomain with no CNAME record at all => safe, and no HTTP probe is made."""
+    mock_enum.return_value = _enumeration_result(["www.example.com", "mail.example.com"])
+
+    import dns.resolver as real_dns
+
+    resolver = Mock()
+    resolver.resolve.side_effect = real_dns.NoAnswer
+    mock_resolver_class.return_value = resolver
+
+    result = subdomain_takeover("example.com")
+
+    assert result["success"] is True
+    assert result["subdomains_checked"] == 2
+    assert result["vulnerable"] == []
+    assert result["total_vulnerable"] == 0
+    assert result["safe"] == ["www.example.com", "mail.example.com"]
+    mock_get.assert_not_called()
+
+
+@patch("tools.subdomain_takeover_tool.requests.get")
+@patch("tools.subdomain_takeover_tool.dns.resolver.Resolver")
+@patch("tools.subdomain_takeover_tool.dns_enumeration")
+def test_aggregate_counts(mock_enum, mock_resolver_class, mock_get):
+    """Mixed results: one vulnerable (status-based), one safe (live), one safe (no CNAME)."""
+    mock_enum.return_value = _enumeration_result(
+        ["dev.example.com", "blog.example.com", "www.example.com"]
+    )
+
+    import dns.resolver as real_dns
+
+    cnames = {
+        "dev.example.com": [_cname_record("user.github.io.")],
+        "blog.example.com": [_cname_record("example.myshopify.com.")],
+    }
+
+    def resolve_side_effect(name, rtype, **kwargs):
+        if name in cnames:
+            return cnames[name]
+        raise real_dns.NoAnswer
+
+    resolver = Mock()
+    resolver.resolve.side_effect = resolve_side_effect
+    mock_resolver_class.return_value = resolver
+
+    def http_side_effect(url, **kwargs):
+        response = Mock()
+        if "dev.example.com" in url:
+            # GitHub Pages: takeover indicator is a 404 status
+            response.status_code = 404
+            response.text = "There isn't a GitHub Pages site here."
+        else:
+            # Shopify CNAME but shop is live
+            response.status_code = 200
+            response.text = "My awesome shop"
+        return response
+
+    mock_get.side_effect = http_side_effect
+
+    result = subdomain_takeover("example.com")
+
+    assert result["success"] is True
+    assert result["subdomains_checked"] == 3
+    assert result["total_vulnerable"] == 1
+    assert result["vulnerable"][0]["subdomain"] == "dev.example.com"
+    assert result["vulnerable"][0]["service"] == "GitHub Pages"
+    assert result["safe"] == ["blog.example.com", "www.example.com"]
+
+
+@patch("tools.subdomain_takeover_tool.dns_enumeration")
+def test_invalid_domain(mock_enum):
+    result = subdomain_takeover("bad_domain")
+    assert result["success"] is False
+    assert "error" in result
+    mock_enum.assert_not_called()
+
+
+@patch("tools.subdomain_takeover_tool.dns_enumeration")
+def test_enumeration_failure_propagates(mock_enum):
+    mock_enum.return_value = {"success": False, "error": "Domain example.com does not exist"}
+    result = subdomain_takeover("example.com")
+    assert result["success"] is False
+    assert "does not exist" in result["error"]
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/subdomain_takeover_tool.py
+++ b/tools/subdomain_takeover_tool.py
@@ -15,10 +15,10 @@ from utils.helpers import is_valid_domain, normalize_domain
 # (cname_contains, service, takeover indicator)
 # indicator key "status" matches on the HTTP status code, "body" on response text.
 VULNERABLE_FINGERPRINTS = [
-    {"cname_contains": "github.io", "service": "GitHub Pages", "indicator": {"status": 404}},
+    {"cname_contains": "github.io", "service": "GitHub Pages", "indicator": {"body": "There isn't a GitHub Pages site here."}},
     {"cname_contains": "herokuapp.com", "service": "Heroku", "indicator": {"body": "No such app"}},
     {"cname_contains": "amazonaws.com", "service": "AWS S3", "indicator": {"body": "NoSuchBucket"}},
-    {"cname_contains": "azurewebsites.net", "service": "Azure", "indicator": {"status": 404}},
+    {"cname_contains": "azurewebsites.net", "service": "Azure", "indicator": {"body": "404 Web Site not found"}},
     {"cname_contains": "ghost.io", "service": "Ghost", "indicator": {"body": "404 Domain Not Found"}},
     {"cname_contains": "myshopify.com", "service": "Shopify", "indicator": {"body": "Sorry, this shop"}},
     {"cname_contains": "fastly.net", "service": "Fastly", "indicator": {"body": "Fastly error"}},
@@ -53,15 +53,29 @@ def _match_fingerprint(cname: str) -> dict | None:
     return None
 
 
+def _probe(subdomain: str):
+    """Fetch the subdomain over HTTPS first, falling back to HTTP.
+
+    Many hosted services only serve (or redirect to) HTTPS, so try that first
+    and fall back to plain HTTP only when the HTTPS connection itself fails.
+    Returns the response, or None if neither scheme connects.
+    """
+    for scheme in ("https", "http"):
+        try:
+            return requests.get(
+                f"{scheme}://{subdomain}",
+                headers=_REQUEST_HEADERS,
+                timeout=_REQUEST_TIMEOUT,
+            )
+        except requests.exceptions.RequestException:
+            continue
+    return None
+
+
 def _confirms_takeover(subdomain: str, fingerprint: dict) -> bool:
     """HTTP-probe the subdomain and check for the takeover-indicating response."""
-    try:
-        response = requests.get(
-            f"http://{subdomain}",
-            headers=_REQUEST_HEADERS,
-            timeout=_REQUEST_TIMEOUT,
-        )
-    except requests.exceptions.RequestException:
+    response = _probe(subdomain)
+    if response is None:
         return False
 
     indicator = fingerprint["indicator"]

--- a/tools/subdomain_takeover_tool.py
+++ b/tools/subdomain_takeover_tool.py
@@ -1,0 +1,126 @@
+"""Subdomain Takeover Checker Tool.
+
+Discovers subdomains via the existing DNS enumeration logic, resolves each
+subdomain's CNAME record, matches it against known-vulnerable service
+fingerprints (GitHub Pages, Heroku, S3, Azure, Ghost, Shopify, Fastly), and
+confirms the takeover with an HTTP request checking for the service's
+takeover-indicating response.
+"""
+import dns.resolver
+import requests
+
+from tools.dns_tool import PUBLIC_RESOLVERS, dns_enumeration
+from utils.helpers import is_valid_domain, normalize_domain
+
+# (cname_contains, service, takeover indicator)
+# indicator key "status" matches on the HTTP status code, "body" on response text.
+VULNERABLE_FINGERPRINTS = [
+    {"cname_contains": "github.io", "service": "GitHub Pages", "indicator": {"status": 404}},
+    {"cname_contains": "herokuapp.com", "service": "Heroku", "indicator": {"body": "No such app"}},
+    {"cname_contains": "amazonaws.com", "service": "AWS S3", "indicator": {"body": "NoSuchBucket"}},
+    {"cname_contains": "azurewebsites.net", "service": "Azure", "indicator": {"status": 404}},
+    {"cname_contains": "ghost.io", "service": "Ghost", "indicator": {"body": "404 Domain Not Found"}},
+    {"cname_contains": "myshopify.com", "service": "Shopify", "indicator": {"body": "Sorry, this shop"}},
+    {"cname_contains": "fastly.net", "service": "Fastly", "indicator": {"body": "Fastly error"}},
+]
+
+_REQUEST_HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
+}
+_REQUEST_TIMEOUT = 10
+
+
+def _make_resolver() -> dns.resolver.Resolver:
+    resolver = dns.resolver.Resolver(configure=False)
+    resolver.nameservers = PUBLIC_RESOLVERS
+    return resolver
+
+
+def _resolve_cname(subdomain: str, resolver) -> str | None:
+    """Return the subdomain's CNAME target, or None if it has none."""
+    try:
+        answers = resolver.resolve(subdomain, "CNAME", lifetime=5, tcp=True)
+        return str(answers[0]).rstrip(".")
+    except Exception:
+        return None
+
+
+def _match_fingerprint(cname: str) -> dict | None:
+    cname = cname.lower()
+    for fingerprint in VULNERABLE_FINGERPRINTS:
+        if fingerprint["cname_contains"] in cname:
+            return fingerprint
+    return None
+
+
+def _confirms_takeover(subdomain: str, fingerprint: dict) -> bool:
+    """HTTP-probe the subdomain and check for the takeover-indicating response."""
+    try:
+        response = requests.get(
+            f"http://{subdomain}",
+            headers=_REQUEST_HEADERS,
+            timeout=_REQUEST_TIMEOUT,
+        )
+    except requests.exceptions.RequestException:
+        return False
+
+    indicator = fingerprint["indicator"]
+    if "status" in indicator:
+        return response.status_code == indicator["status"]
+    return indicator["body"] in response.text
+
+
+def subdomain_takeover(domain: str) -> dict:
+    """
+    Check discovered subdomains for potential takeover vulnerabilities.
+    A subdomain takeover occurs when a subdomain's CNAME points to an external
+    service (GitHub Pages, Heroku, S3 etc.) that is no longer active.
+    """
+    domain = normalize_domain(domain)
+    if not is_valid_domain(domain):
+        return {"success": False, "error": "Invalid domain format"}
+
+    # Subdomain discovery reuses the existing DNS enumeration tool.
+    enumeration = dns_enumeration(domain)
+    if not enumeration.get("success"):
+        return {
+            "success": False,
+            "error": enumeration.get("error", "DNS enumeration failed"),
+        }
+
+    subdomains = enumeration.get("subdomains_found", [])
+    resolver = _make_resolver()
+
+    vulnerable = []
+    safe = []
+
+    for subdomain in subdomains:
+        cname = _resolve_cname(subdomain, resolver)
+        if not cname:
+            safe.append(subdomain)
+            continue
+
+        fingerprint = _match_fingerprint(cname)
+        if not fingerprint:
+            safe.append(subdomain)
+            continue
+
+        if _confirms_takeover(subdomain, fingerprint):
+            vulnerable.append({
+                "subdomain": subdomain,
+                "cname": cname,
+                "service": fingerprint["service"],
+                "reason": f"CNAME points to unclaimed {fingerprint['service']} service",
+                "severity": "HIGH",
+            })
+        else:
+            safe.append(subdomain)
+
+    return {
+        "success": True,
+        "domain": domain,
+        "subdomains_checked": len(subdomains),
+        "vulnerable": vulnerable,
+        "safe": safe,
+        "total_vulnerable": len(vulnerable),
+    }


### PR DESCRIPTION
Closes #14.

Adds a `subdomain_takeover(domain)` tool that checks discovered subdomains for dangling-CNAME takeover vulnerabilities.

**Flow** (matches the issue spec):
1. Discovers subdomains by reusing the existing `dns_enumeration` from `tools/dns_tool.py`.
2. Resolves each subdomain's CNAME.
3. Matches the CNAME against the known-vulnerable service fingerprints (GitHub Pages, Heroku, AWS S3, Azure, Ghost, Shopify, Fastly).
4. Confirms with an HTTP request checking the takeover-indicating status/body.

Returns the exact output shape from the issue (`success`, `domain`, `subdomains_checked`, `vulnerable[]`, `safe[]`, `total_vulnerable`). Registered in `server.py` like the other tools; no new dependencies (`dns.resolver` + `requests`).

**Tests:** `tests/test_subdomain_takeover.py` — 6 tests, all network-mocked in the existing style (vulnerable match, safe/no-CNAME, non-fingerprinted CNAME, aggregate counts, invalid domain). Full suite: `216 passed`.

**Two judgement calls I'd welcome your steer on:**
- **Azure** — the issue lists the indicator as "Azure 404 page" with no distinct body string, so I implemented it as an HTTP-404 check (like GitHub Pages). That can false-positive on any Azure site that legitimately 404s; happy to switch to a body-string match if you have a canonical one.
- **HTTP probe** — single `http://` request, no `https://` fallback, matching the issue's "make an HTTP request" wording. Easy to add an https attempt if you'd prefer.

Also note: coverage is bounded by `dns_enumeration`, which brute-forces a small common-subdomain list — so this finds takeovers among those, not an exhaustive subdomain sweep. That's inherited from the existing tool the issue asked me to reuse.

---
Generated by Claude Opus 4.8 (brief, review), Kimi K3 (implementation)
