### PR TITLE
feat(dns): CAA records, TTL, resolver metadata, AAAA/CNAME subdomain detection (#103)

### DIFF
--- a/tests/test_dns_enumeration.py
+++ b/tests/test_dns_enumeration.py
@@ -29,6 +29,20 @@ class TestDnsEnumeration(unittest.TestCase):
         record.minimum = 5
         return [record]
 
+    def _make_caa_answer(self, flags, tag, value):
+        record = Mock()
+        record.flags = flags
+        record.tag = tag
+        record.value = value
+        return [record]
+
+    def _make_ttl_answer(self, values, ttl):
+        records = self._make_resolver_answer(values)
+        answer = MagicMock()
+        answer.__iter__.return_value = iter(records)
+        answer.rrset.ttl = ttl
+        return answer
+
     def test_invalid_domain(self):
         result = dns_enumeration("bad_domain")
         self.assertFalse(result["success"])
@@ -99,6 +113,94 @@ class TestDnsEnumeration(unittest.TestCase):
         self.assertTrue(result["success"])
         for rtype_records in result["records"].values():
             self.assertEqual(rtype_records, [])
+
+    @patch("tools.dns_tool.dns.resolver.Resolver")
+    def test_caa_records_parsed(self, mock_resolver_class):
+        resolver = Mock()
+        mock_resolver_class.return_value = resolver
+
+        def side_effect(domain, rtype, lifetime=5, tcp=False):
+            import dns.resolver as real_dns
+
+            if domain != "example.com":
+                raise real_dns.NoAnswer
+            if rtype == "CAA":
+                return self._make_caa_answer(0, b"issue", b"letsencrypt.org")
+            raise real_dns.NoAnswer
+
+        resolver.resolve.side_effect = side_effect
+        result = dns_enumeration("example.com")
+
+        self.assertTrue(result["success"])
+        caa = result["records"]["CAA"]
+        self.assertEqual(len(caa), 1)
+        self.assertEqual(caa[0]["flags"], 0)
+        self.assertEqual(caa[0]["tag"], "issue")
+        self.assertEqual(caa[0]["value"], "letsencrypt.org")
+
+    @patch("tools.dns_tool.dns.resolver.Resolver")
+    def test_ttl_included_when_available(self, mock_resolver_class):
+        resolver = Mock()
+        mock_resolver_class.return_value = resolver
+
+        def side_effect(domain, rtype, lifetime=5, tcp=False):
+            import dns.resolver as real_dns
+
+            if domain != "example.com":
+                raise real_dns.NoAnswer
+            if rtype == "A":
+                return self._make_ttl_answer(["93.184.216.34"], 300)
+            raise real_dns.NoAnswer
+
+        resolver.resolve.side_effect = side_effect
+        result = dns_enumeration("example.com")
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["records"]["A"], ["93.184.216.34"])
+        self.assertEqual(result["ttl"]["A"], 300)
+        self.assertNotIn("MX", result["ttl"])
+
+    @patch("tools.dns_tool.dns.resolver.Resolver")
+    def test_subdomain_detected_via_aaaa_and_cname(self, mock_resolver_class):
+        resolver = Mock()
+        mock_resolver_class.return_value = resolver
+
+        def side_effect(domain, rtype, lifetime=5, tcp=False):
+            import dns.resolver as real_dns
+
+            if domain == "example.com":
+                raise real_dns.NoAnswer
+            if domain == "www.example.com" and rtype == "AAAA":
+                return self._make_resolver_answer(["2606:2800:220:1:248:1893:25c8:1946"])
+            if domain == "mail.example.com" and rtype == "CNAME":
+                return self._make_resolver_answer(["example.com."])
+            raise real_dns.NoAnswer
+
+        resolver.resolve.side_effect = side_effect
+        result = dns_enumeration("example.com")
+
+        self.assertTrue(result["success"])
+        self.assertIn("www.example.com", result["subdomains_found"])
+        self.assertIn("mail.example.com", result["subdomains_found"])
+        self.assertNotIn("ftp.example.com", result["subdomains_found"])
+        self.assertEqual(result["subdomains_found"].count("www.example.com"), 1)
+        resolver.resolve.assert_any_call("www.example.com", "A", lifetime=3, tcp=True)
+        resolver.resolve.assert_any_call("www.example.com", "AAAA", lifetime=3, tcp=True)
+        resolver.resolve.assert_any_call("mail.example.com", "CNAME", lifetime=3, tcp=True)
+
+    @patch("tools.dns_tool.dns.resolver.Resolver")
+    def test_resolver_metadata_in_output(self, mock_resolver_class):
+        import dns.resolver as real_dns
+
+        resolver = Mock()
+        resolver.resolve.side_effect = real_dns.NoAnswer
+        mock_resolver_class.return_value = resolver
+        result = dns_enumeration("example.com")
+
+        self.assertTrue(result["success"])
+        self.assertIn("resolver", result)
+        self.assertEqual(result["resolver"]["nameservers"], ["1.1.1.1", "8.8.8.8"])
+        self.assertEqual(result["resolver"]["lifetime"], 5)
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tools/dns_tool.py
+++ b/tools/dns_tool.py
@@ -1,7 +1,22 @@
 import dns.resolver
 from utils.helpers import is_valid_domain, normalize_domain
 
+# Public resolvers used for every lookup.
 PUBLIC_RESOLVERS = ["1.1.1.1", "8.8.8.8"]
+
+# Central resolver timing configuration (seconds).
+RESOLVER_TIMEOUT = 2.0
+RESOLVER_LIFETIME = 5
+SUBDOMAIN_LIFETIME = 3
+
+# Record types enumerated for the target domain.
+RECORD_TYPES = ["A", "AAAA", "MX", "NS", "TXT", "CNAME", "SOA", "CAA"]
+
+# Common subdomains tried during brute-force discovery; adjust to taste.
+COMMON_SUBDOMAINS = ["www", "mail", "ftp", "admin", "api", "dev", "staging", "vpn", "remote", "portal"]
+
+# A subdomain counts as found if any of these record types resolves for it.
+SUBDOMAIN_RECORD_TYPES = ("A", "AAAA", "CNAME")
 
 
 def _clean_name(value) -> str:
@@ -18,28 +33,61 @@ def _format_txt_record(record) -> str:
     return str(record)
 
 
+def _format_caa_record(record) -> dict:
+    tag = getattr(record, "tag", None)
+    value = getattr(record, "value", None)
+    if tag is None or value is None:
+        return {"raw": str(record)}
+    return {
+        "flags": getattr(record, "flags", 0),
+        "tag": tag.decode("utf-8") if isinstance(tag, bytes) else str(tag),
+        "value": value.decode("utf-8") if isinstance(value, bytes) else str(value),
+    }
+
+
+def _record_ttl(answers):
+    rrset = getattr(answers, "rrset", None)
+    return getattr(rrset, "ttl", None)
+
+
 def _make_resolver() -> dns.resolver.Resolver:
     resolver = dns.resolver.Resolver(configure=False)
     resolver.nameservers = PUBLIC_RESOLVERS
+    resolver.timeout = RESOLVER_TIMEOUT
+    resolver.lifetime = RESOLVER_LIFETIME
     return resolver
+
+
+def _resolver_metadata(resolver) -> dict:
+    return {
+        "nameservers": [str(ns) for ns in resolver.nameservers],
+        "timeout": resolver.timeout,
+        "lifetime": resolver.lifetime,
+    }
 
 
 def dns_enumeration(domain: str) -> dict:
     """
     Enumerate DNS records for a domain.
-    Returns A, AAAA, MX, NS, TXT, CNAME, SOA records.
+    Returns A, AAAA, MX, NS, TXT, CNAME, SOA, CAA records (CAA surfaces
+    certificate authority restrictions), TTL per record type when available,
+    common subdomains discovered via A/AAAA/CNAME lookups, and metadata about
+    the resolver used.
     """
     domain = normalize_domain(domain)
     if not is_valid_domain(domain):
         return {"success": False, "error": "Invalid domain format"}
 
-    record_types = ["A", "AAAA", "MX", "NS", "TXT", "CNAME", "SOA"]
     records = {}
+    ttls = {}
     resolver = _make_resolver()
 
-    for rtype in record_types:
+    for rtype in RECORD_TYPES:
         try:
-            answers = resolver.resolve(domain, rtype, lifetime=5, tcp=True)
+            answers = resolver.resolve(domain, rtype, lifetime=RESOLVER_LIFETIME, tcp=True)
+            ttl = _record_ttl(answers)
+            if ttl is not None:
+                ttls[rtype] = ttl
             if rtype == "MX":
                 records[rtype] = [
                     {"preference": r.preference, "exchange": _clean_name(r.exchange)}
@@ -58,6 +106,8 @@ def dns_enumeration(domain: str) -> dict:
                 }
             elif rtype == "TXT":
                 records[rtype] = [_format_txt_record(r) for r in answers]
+            elif rtype == "CAA":
+                records[rtype] = [_format_caa_record(r) for r in answers]
             elif rtype in {"NS", "CNAME"}:
                 records[rtype] = [_clean_name(r) for r in answers]
             else:
@@ -69,21 +119,26 @@ def dns_enumeration(domain: str) -> dict:
         except Exception:
             records[rtype] = []
 
-    # Subdomain brute-force (common subdomains)
-    common_subdomains = ["www", "mail", "ftp", "admin", "api", "dev", "staging", "vpn", "remote", "portal"]
+    # Subdomain brute-force (common subdomains); a subdomain counts as found
+    # when any of A/AAAA/CNAME resolves, so IPv6-only and aliased hosts are
+    # not missed.
     found_subdomains = []
 
-    for sub in common_subdomains:
-        try:
-            full = f"{sub}.{domain}"
-            resolver.resolve(full, "A", lifetime=3, tcp=True)
-            found_subdomains.append(full)
-        except Exception:
-            pass
+    for sub in COMMON_SUBDOMAINS:
+        full = f"{sub}.{domain}"
+        for rtype in SUBDOMAIN_RECORD_TYPES:
+            try:
+                resolver.resolve(full, rtype, lifetime=SUBDOMAIN_LIFETIME, tcp=True)
+                found_subdomains.append(full)
+                break
+            except Exception:
+                continue
 
     return {
         "success": True,
         "domain": domain,
         "records": records,
-        "subdomains_found": found_subdomains
+        "subdomains_found": found_subdomains,
+        "ttl": ttls,
+        "resolver": _resolver_metadata(resolver)
     }


### PR DESCRIPTION
Closes #103.

Enhances the DNS enumeration tool with the six improvements from the issue, all backward-compatible (existing `records` / `subdomains_found` output is unchanged; new keys are additive):

1. **CAA records** — `CAA` added to the enumerated types; each formatted as `{flags, tag, value}` (bytes-decoded, with a `{raw}` fallback), surfacing CA restrictions like `issue: letsencrypt.org`.
2. **Centralized resolver config** — nameservers, `timeout`, and `lifetime` now live in `_make_resolver()`; both the enumeration and subdomain loops use the single resolver it returns.
3. **Configurable common subdomains** — the hardcoded list is now a module-level `COMMON_SUBDOMAINS` constant.
4. **AAAA/CNAME subdomain detection** — subdomain discovery now counts a name as found if any of `A`/`AAAA`/`CNAME` resolves, so IPv6-only and aliased hosts aren't missed.
5. **TTL values** — new `ttl` output key mapping record-type → TTL where available.
6. **Resolver metadata** — new `resolver` output key (`nameservers`, `timeout`, `lifetime`).

**Tests:** `tests/test_dns_enumeration.py` — 4 new cases (CAA parsing, TTL presence, AAAA/CNAME subdomain detection, resolver metadata) plus mock helpers, in the existing style. Full suite: `214 passed`. The pre-existing DNS tests are unchanged.

Two small notes:
- The existing tests pin the exact `resolve(..., lifetime=…, tcp=True)` call kwargs, so I kept per-call `lifetime` at the call sites (referencing the new constants) rather than relying solely on the resolver-level default — a touch redundant, but it avoids changing existing tests.
- `README.md`'s record list (line ~45) still reads "A, AAAA, MX, NS, TXT, CNAME, SOA" — I left it to keep the diff scoped, but happy to add `CAA` there if you'd like.

---
Generated by Claude Opus 4.8 (brief, review), Kimi K3 (implementation)
