### PR TITLE
feat(ssl_inspect): certificate fingerprinting and TLS/cipher security analysis (#100)

### DIFF
--- a/tests/test_ssl_inspect.py
+++ b/tests/test_ssl_inspect.py
@@ -157,6 +157,26 @@ class TestSslInspect(unittest.TestCase):
         self.assertTrue(result["success"], f"Expected success but got error: {result.get('error')}")
         self.assertTrue(result["self_signed"])
 
+    def test_self_signed_uses_raw_rdn_tuples(self):
+        # Regression: duplicate RDN attributes must not be collapsed before
+        # comparing subject and issuer. The collapsed dicts are identical here,
+        # but the raw tuple structures differ, so the cert is not self-signed.
+        subject = (
+            (("commonName", "example.com"),),
+            (("organizationalUnitName", "A"),),
+            (("organizationalUnitName", "B"),),
+        )
+        issuer = (
+            (("commonName", "example.com"),),
+            (("organizationalUnitName", "B"),),
+        )
+        cert = self._make_cert()
+        cert["subject"] = subject
+        cert["issuer"] = issuer
+        result = self._run_inspect(cert)
+        self.assertTrue(result["success"], f"Expected success but got error: {result.get('error')}")
+        self.assertFalse(result["self_signed"])
+
     def test_validity_period_days(self):
         # not_before = now - 30d, not_after = now + 90d => validity ~= 120 days
         result = self._run_inspect(self._make_cert(days_valid=90))

--- a/tests/test_ssl_inspect.py
+++ b/tests/test_ssl_inspect.py
@@ -5,21 +5,57 @@ import ssl
 import socket
 from datetime import datetime, timedelta, timezone
 
+try:
+    from cryptography import x509 as cx509
+    from cryptography.x509.oid import NameOID
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import ec, rsa
+    HAS_CRYPTOGRAPHY = True
+except ImportError:
+    HAS_CRYPTOGRAPHY = False
+
 class TestSslInspect(unittest.TestCase):
 
-    def _make_cert(self, days_valid=365):
+    def _make_cert(self, days_valid=365, days_since_not_before=30, sans=None, extra=None):
         now = datetime.now(timezone.utc)
-        not_before = (now - timedelta(days=30)).strftime("%b %d %H:%M:%S %Y GMT")
+        not_before = (now - timedelta(days=days_since_not_before)).strftime("%b %d %H:%M:%S %Y GMT")
         not_after = (now + timedelta(days=days_valid)).strftime("%b %d %H:%M:%S %Y GMT")
-        return {
+        if sans is None:
+            sans = (("DNS", "example.com"), ("DNS", "www.example.com"))
+        cert = {
             "subject": ((("commonName", "example.com"),),),
             "issuer": ((("organizationName", "Let's Encrypt"),),),
             "serialNumber": "DEADBEEF",
             "notBefore": not_before,
             "notAfter": not_after,
-            "subjectAltName": (("DNS", "example.com"), ("DNS", "www.example.com")),
+            "subjectAltName": sans,
             "version": 3,
         }
+        if extra:
+            cert.update(extra)
+        return cert
+
+    def _run_inspect(self, cert, cipher=("TLS_AES_256_GCM_SHA384", "TLSv1.3", 256),
+                     version="TLSv1.3", der_bytes=None):
+        """Run ssl_inspect with the same mocking mechanism as the existing tests."""
+        mock_ssl_sock = MagicMock()
+        if der_bytes is not None:
+            mock_ssl_sock.getpeercert.side_effect = (
+                lambda binary_form=False: der_bytes if binary_form else cert
+            )
+        else:
+            mock_ssl_sock.getpeercert.return_value = cert
+        mock_ssl_sock.cipher.return_value = cipher
+        mock_ssl_sock.version.return_value = version
+
+        with patch("socket.create_connection") as mock_create_connection, \
+             patch("tools.ssl_tool.ssl.create_default_context") as mock_ctx_cls:
+            mock_create_connection.return_value = MagicMock()
+            mock_ctx = MagicMock()
+            # Direct context manager mocking for wrap_socket object
+            mock_ctx.wrap_socket.return_value.__enter__.return_value = mock_ssl_sock
+            mock_ctx_cls.return_value = mock_ctx
+            return ssl_inspect("example.com")
 
     def test_invalid_domain(self):
         result = ssl_inspect("not-valid")
@@ -95,6 +131,187 @@ class TestSslInspect(unittest.TestCase):
         result = ssl_inspect("example.com")
         self.assertFalse(result["success"])
         self.assertIn("SSL verification failed", result["error"])
+
+    # --- issue #100: certificate fingerprinting ---
+
+    def test_wildcard_certificate_and_san_count(self):
+        cert = self._make_cert(sans=(
+            ("DNS", "*.example.com"), ("DNS", "example.com"), ("DNS", "www.example.com"),
+        ))
+        result = self._run_inspect(cert)
+        self.assertTrue(result["success"], f"Expected success but got error: {result.get('error')}")
+        self.assertTrue(result["wildcard_certificate"])
+        self.assertFalse(result["self_signed"])
+        self.assertEqual(result["san_count"], 3)
+
+    def test_non_wildcard_certificate(self):
+        result = self._run_inspect(self._make_cert())
+        self.assertTrue(result["success"], f"Expected success but got error: {result.get('error')}")
+        self.assertFalse(result["wildcard_certificate"])
+        self.assertEqual(result["san_count"], 2)
+
+    def test_self_signed_certificate(self):
+        cert = self._make_cert()
+        cert["issuer"] = cert["subject"]  # issuer == subject => self-signed
+        result = self._run_inspect(cert)
+        self.assertTrue(result["success"], f"Expected success but got error: {result.get('error')}")
+        self.assertTrue(result["self_signed"])
+
+    def test_validity_period_days(self):
+        # not_before = now - 30d, not_after = now + 90d => validity ~= 120 days
+        result = self._run_inspect(self._make_cert(days_valid=90))
+        self.assertTrue(result["success"], f"Expected success but got error: {result.get('error')}")
+        self.assertLessEqual(abs(result["validity_period_days"] - 120), 1)
+
+    # --- issue #100: certificate status ---
+
+    def test_certificate_status_healthy(self):
+        result = self._run_inspect(self._make_cert(days_valid=365))
+        self.assertTrue(result["success"], f"Expected success but got error: {result.get('error')}")
+        self.assertEqual(result["certificate_status"], "Healthy")
+
+    def test_certificate_status_expiring_soon(self):
+        result = self._run_inspect(self._make_cert(days_valid=10))
+        self.assertTrue(result["success"], f"Expected success but got error: {result.get('error')}")
+        self.assertEqual(result["certificate_status"], "Expiring Soon")
+
+    def test_certificate_status_expired(self):
+        result = self._run_inspect(self._make_cert(days_valid=-5))
+        self.assertTrue(result["success"], f"Expected success but got error: {result.get('error')}")
+        self.assertEqual(result["certificate_status"], "Expired")
+        self.assertTrue(result["certificate"]["expired"])
+        # an expired certificate is a hard fail for the overall rating
+        self.assertEqual(result["security_rating"], "Poor")
+
+    # --- issue #100: TLS & cipher security analysis ---
+
+    def test_strong_tls_and_cipher(self):
+        result = self._run_inspect(
+            self._make_cert(days_valid=365),
+            cipher=("TLS_AES_256_GCM_SHA384", "TLSv1.3", 256),
+            version="TLSv1.3",
+        )
+        self.assertTrue(result["success"], f"Expected success but got error: {result.get('error')}")
+        self.assertEqual(result["tls_security"], "Strong")
+        self.assertEqual(result["cipher_security"], "Strong")
+        self.assertFalse(result["weak_tls_version"])
+        self.assertFalse(result["weak_cipher"])
+        # mocked getpeercert returns a dict for binary_form=True, so the
+        # public key type cannot be decoded and must degrade to None
+        self.assertIsNone(result["public_key_type"])
+
+    def test_weak_tls_and_weak_cipher(self):
+        result = self._run_inspect(
+            self._make_cert(days_valid=365),
+            cipher=("RC4-MD5", "TLSv1", 128),
+            version="TLSv1",
+        )
+        self.assertTrue(result["success"], f"Expected success but got error: {result.get('error')}")
+        self.assertEqual(result["tls_security"], "Weak")
+        self.assertEqual(result["cipher_security"], "Weak")
+        self.assertTrue(result["weak_tls_version"])
+        self.assertTrue(result["weak_cipher"])
+        self.assertEqual(result["security_rating"], "Poor")
+
+    def test_weak_cipher_by_low_bits(self):
+        result = self._run_inspect(
+            self._make_cert(days_valid=365),
+            cipher=("TLS_RSA_WITH_DES_CBC_SHA", "TLSv1.2", 56),
+            version="TLSv1.2",
+        )
+        self.assertTrue(result["success"], f"Expected success but got error: {result.get('error')}")
+        self.assertTrue(result["weak_cipher"])
+        self.assertEqual(result["cipher_security"], "Weak")
+        self.assertEqual(result["security_rating"], "Poor")
+
+    # --- issue #100: overall security rating ---
+
+    def test_security_rating_excellent(self):
+        # TLS 1.3 (3) + Strong cipher (3) + Healthy (2) + validity <=398d (2) = 10
+        result = self._run_inspect(
+            self._make_cert(days_valid=90),
+            cipher=("TLS_AES_256_GCM_SHA384", "TLSv1.3", 256),
+            version="TLSv1.3",
+        )
+        self.assertTrue(result["success"], f"Expected success but got error: {result.get('error')}")
+        self.assertEqual(result["security_rating"], "Excellent")
+
+    def test_security_rating_good_boundary(self):
+        # TLS 1.2 (2) + Good cipher (2) + Healthy (2) + validity <=398d (2) = 8 -> Good
+        result = self._run_inspect(
+            self._make_cert(days_valid=90),
+            cipher=("TLS_AES_128_GCM_SHA256", "TLSv1.2", 128),
+            version="TLSv1.2",
+        )
+        self.assertTrue(result["success"], f"Expected success but got error: {result.get('error')}")
+        self.assertEqual(result["tls_security"], "Good")
+        self.assertEqual(result["cipher_security"], "Good")
+        self.assertEqual(result["security_rating"], "Good")
+
+    def test_security_rating_fair(self):
+        # TLS 1.2 (2) + Good cipher (2) + Expiring Soon (1) + validity >825d (0) = 5 -> Fair
+        cert = self._make_cert(days_valid=30, days_since_not_before=800)
+        result = self._run_inspect(
+            cert,
+            cipher=("TLS_AES_128_GCM_SHA256", "TLSv1.2", 128),
+            version="TLSv1.2",
+        )
+        self.assertTrue(result["success"], f"Expected success but got error: {result.get('error')}")
+        self.assertEqual(result["certificate_status"], "Expiring Soon")
+        self.assertEqual(result["security_rating"], "Fair")
+
+    # --- issue #100: public key type ---
+
+    @unittest.skipUnless(HAS_CRYPTOGRAPHY, "cryptography package not installed")
+    def test_public_key_type_ecdsa_and_rsa(self):
+        now = datetime.now(timezone.utc)
+        name = cx509.Name([cx509.NameAttribute(NameOID.COMMON_NAME, "example.com")])
+
+        def make_der(key):
+            builder = (cx509.CertificateBuilder()
+                       .subject_name(name)
+                       .issuer_name(name)
+                       .public_key(key.public_key())
+                       .serial_number(1)
+                       .not_valid_before(now - timedelta(days=1))
+                       .not_valid_after(now + timedelta(days=30)))
+            return builder.sign(key, hashes.SHA256()).public_bytes(serialization.Encoding.DER)
+
+        cert = self._make_cert(days_valid=365)
+
+        ec_der = make_der(ec.generate_private_key(ec.SECP256R1()))
+        result = self._run_inspect(cert, der_bytes=ec_der)
+        self.assertTrue(result["success"], f"Expected success but got error: {result.get('error')}")
+        self.assertEqual(result["public_key_type"], "ECDSA")
+
+        rsa_der = make_der(rsa.generate_private_key(public_exponent=65537, key_size=2048))
+        result = self._run_inspect(cert, der_bytes=rsa_der)
+        self.assertTrue(result["success"], f"Expected success but got error: {result.get('error')}")
+        self.assertEqual(result["public_key_type"], "RSA")
+
+    # --- issue #100: certificate extensions ---
+
+    def test_certificate_extensions(self):
+        cert = self._make_cert(extra={
+            "OCSP": ("http://ocsp.example.com",),
+            "caIssuers": ("http://ca.example.com/issuer.crt",),
+            "crlDistributionPoints": ("http://crl.example.com/a.crl", "http://crl.example.com/b.crl"),
+        })
+        result = self._run_inspect(cert)
+        self.assertTrue(result["success"], f"Expected success but got error: {result.get('error')}")
+        ext = result["certificate_extensions"]
+        self.assertEqual(ext["ocsp_url"], "http://ocsp.example.com")
+        self.assertEqual(ext["ca_issuer_url"], "http://ca.example.com/issuer.crt")
+        self.assertEqual(ext["crl_distribution_points"],
+                         ["http://crl.example.com/a.crl", "http://crl.example.com/b.crl"])
+
+    def test_certificate_extensions_absent(self):
+        result = self._run_inspect(self._make_cert())
+        self.assertTrue(result["success"], f"Expected success but got error: {result.get('error')}")
+        ext = result["certificate_extensions"]
+        self.assertIsNone(ext["ocsp_url"])
+        self.assertIsNone(ext["ca_issuer_url"])
+        self.assertEqual(ext["crl_distribution_points"], [])
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tools/ssl_tool.py
+++ b/tools/ssl_tool.py
@@ -3,10 +3,153 @@ import socket
 from datetime import datetime, timezone
 from utils.helpers import is_valid_domain, normalize_domain
 
+try:
+    # cryptography is present via the MCP stack (fastmcp -> authlib ->
+    # cryptography) but is not a direct requirement; degrade gracefully.
+    from cryptography import x509
+    from cryptography.hazmat.primitives.asymmetric import dsa, ec, ed448, ed25519, rsa
+    _HAS_CRYPTOGRAPHY = True
+except ImportError:  # pragma: no cover
+    _HAS_CRYPTOGRAPHY = False
+
+# --- Security analysis thresholds (issue #100) ------------------------------
+# Heuristics chosen for the analysis below; tune to taste.
+EXPIRING_SOON_DAYS = 30             # cert is "Expiring Soon" within this window
+MAX_PREFERRED_VALIDITY_DAYS = 398   # CA/B Forum maximum lifetime for public TLS certs
+MAX_ACCEPTABLE_VALIDITY_DAYS = 825  # pre-2020 CA/B Forum maximum
+MIN_CIPHER_BITS = 128               # below this a cipher is considered weak
+
+# Well-known weak cipher indicators, per RFC 7457, NIST SP 800-131A and
+# BSI TR-02102-2: RC4, 3DES/single-DES, NULL, EXPORT-grade, MD5 MACs, RC2
+# and anonymous (unauthenticated) key exchange.
+WEAK_CIPHER_PATTERNS = ("RC4", "3DES", "DES-CBC", "NULL", "EXPORT", "EXP",
+                        "MD5", "RC2", "ADH", "AECDH")
+
+_TLS_VERSION_RANK = {
+    "SSLv2": 0, "SSLv3": 1, "TLSv1": 2, "TLSv1.1": 3, "TLSv1.2": 4, "TLSv1.3": 5,
+}
+
+
+def _tls_version_rank(tls_version):
+    return _TLS_VERSION_RANK.get(str(tls_version), -1)
+
+
+def _is_weak_tls(tls_version):
+    """TLS < 1.2 is weak (TLS 1.0/1.1 are deprecated by RFC 8996 / PCI-DSS)."""
+    rank = _tls_version_rank(tls_version)
+    return 0 <= rank < 4
+
+
+def _classify_tls(tls_version):
+    """Strong = TLS 1.3, Good = TLS 1.2, Weak = anything older."""
+    rank = _tls_version_rank(tls_version)
+    if rank >= 5:
+        return "Strong"
+    if rank == 4:
+        return "Good"
+    if rank >= 0:
+        return "Weak"
+    return "Unknown"
+
+
+def _is_weak_cipher(cipher_name, cipher_bits):
+    upper = str(cipher_name).upper()
+    if any(pattern in upper for pattern in WEAK_CIPHER_PATTERNS):
+        return True
+    try:
+        return cipher_bits is not None and int(cipher_bits) < MIN_CIPHER_BITS
+    except (TypeError, ValueError):
+        return False
+
+
+def _classify_cipher(cipher_name, cipher_bits):
+    """Weak if on the weak list or <128 bit; Strong >=256 bit; Good >=128 bit."""
+    if _is_weak_cipher(cipher_name, cipher_bits):
+        return "Weak"
+    try:
+        bits = int(cipher_bits)
+    except (TypeError, ValueError):
+        return "Unknown"
+    return "Strong" if bits >= 256 else "Good"
+
+
+def _certificate_status(days_left):
+    if days_left < 0:
+        return "Expired"
+    if days_left <= EXPIRING_SOON_DAYS:
+        return "Expiring Soon"
+    return "Healthy"
+
+
+def _security_rating(tls_version, cipher_name, cipher_bits, days_left, validity_days):
+    """
+    Overall rating from TLS version, cipher strength, expiry and validity.
+
+    Scoring (max 10):
+      TLS 1.3 = 3, TLS 1.2 = 2, older = 0
+      cipher Strong = 3, Good = 2, Weak/Unknown = 0
+      expiry Healthy = 2, Expiring Soon = 1, Expired = 0
+      validity <=398d = 2, <=825d = 1, longer = 0 (shorter validity = better hygiene)
+
+    Mapping: 9-10 Excellent, 7-8 Good, 4-6 Fair, 0-3 Poor.
+    Hard fail: an expired certificate, a weak TLS version (<1.2) or a weak
+    cipher caps the rating at "Poor" regardless of the score.
+    """
+    cipher_strength = _classify_cipher(cipher_name, cipher_bits)
+
+    if days_left < 0 or _is_weak_tls(tls_version) or cipher_strength == "Weak":
+        return "Poor"
+
+    rank = _tls_version_rank(tls_version)
+    score = 0
+    score += 3 if rank >= 5 else 2 if rank == 4 else 0
+    score += {"Strong": 3, "Good": 2}.get(cipher_strength, 0)
+    score += 2 if days_left > EXPIRING_SOON_DAYS else 1
+    if validity_days <= MAX_PREFERRED_VALIDITY_DAYS:
+        score += 2
+    elif validity_days <= MAX_ACCEPTABLE_VALIDITY_DAYS:
+        score += 1
+
+    if score >= 9:
+        return "Excellent"
+    if score >= 7:
+        return "Good"
+    if score >= 4:
+        return "Fair"
+    return "Poor"
+
+
+def _public_key_type(conn):
+    """Best-effort public key type from the DER certificate; None if unavailable."""
+    if not _HAS_CRYPTOGRAPHY:
+        return None
+    try:
+        der = conn.getpeercert(binary_form=True)
+        key = x509.load_der_x509_certificate(der).public_key()
+    except Exception:
+        return None
+    if isinstance(key, rsa.RSAPublicKey):
+        return "RSA"
+    if isinstance(key, ec.EllipticCurvePublicKey):
+        return "ECDSA"
+    if isinstance(key, dsa.DSAPublicKey):
+        return "DSA"
+    if isinstance(key, ed25519.Ed25519PublicKey):
+        return "Ed25519"
+    if isinstance(key, ed448.Ed448PublicKey):
+        return "Ed448"
+    return type(key).__name__
+
+
 def ssl_inspect(domain: str, port: int = 443) -> dict:
     """
     Inspect SSL/TLS certificate details for a domain.
-    Returns cert validity, issuer, SANs, expiry, and cipher info.
+    Returns cert validity, issuer, SANs, expiry, and cipher info, plus the
+    derived security analysis from issue #100: certificate fingerprinting
+    (wildcard/self-signed/public key type/SAN count/validity period),
+    certificate_status, TLS & cipher strength with weak flags, certificate
+    extensions, and an overall security_rating. All derived fields come from
+    data the connection already provides; no extra network I/O.
     """
     domain = normalize_domain(domain)
     if not is_valid_domain(domain):
@@ -15,18 +158,19 @@ def ssl_inspect(domain: str, port: int = 443) -> dict:
     try:
         context = ssl.create_default_context()
         context.minimum_version = ssl.TLSVersion.TLSv1_2
-        
+
         # Create raw socket, wrap it, and manage the lifecycle of the wrapper
         raw_sock = socket.create_connection((domain, port), timeout=10)
         with context.wrap_socket(raw_sock, server_hostname=domain) as conn:
             cert = conn.getpeercert()
             cipher = conn.cipher()
             tls_version = conn.version()
+            public_key_type = _public_key_type(conn)
 
         # Parse dates and make them timezone-aware (UTC)
         not_before = datetime.strptime(cert["notBefore"], "%b %d %H:%M:%S %Y %Z").replace(tzinfo=timezone.utc)
         not_after  = datetime.strptime(cert["notAfter"],  "%b %d %H:%M:%S %Y %Z").replace(tzinfo=timezone.utc)
-        
+
         now = datetime.now(timezone.utc)
         days_left = (not_after - now).days
 
@@ -35,6 +179,23 @@ def ssl_inspect(domain: str, port: int = 443) -> dict:
 
         def rdn(rdns):
             return {k: v for rdn in rdns for k, v in rdn}
+
+        subject = rdn(cert.get("subject", []))
+        issuer = rdn(cert.get("issuer", []))
+
+        # --- issue #100: certificate fingerprinting ---
+        common_name = subject.get("commonName", "")
+        wildcard = common_name.startswith("*.") or any(s.startswith("*.") for s in sans)
+        self_signed = bool(subject) and subject == issuer
+        validity_days = (not_after - not_before).days
+
+        # --- issue #100: TLS & cipher security analysis ---
+        weak_tls = _is_weak_tls(tls_version)
+        weak_cipher = _is_weak_cipher(cipher[0], cipher[2])
+
+        # --- issue #100: certificate extensions (already decoded by getpeercert) ---
+        ocsp = cert.get("OCSP", ())
+        ca_issuers = cert.get("caIssuers", ())
 
         return {
             "success": True,
@@ -47,8 +208,8 @@ def ssl_inspect(domain: str, port: int = 443) -> dict:
                 "bits": cipher[2]
             },
             "certificate": {
-                "subject": rdn(cert.get("subject", [])),
-                "issuer": rdn(cert.get("issuer", [])),
+                "subject": subject,
+                "issuer": issuer,
                 "serial_number": cert.get("serialNumber"),
                 "not_before": not_before.isoformat(),
                 "not_after": not_after.isoformat(),
@@ -57,6 +218,26 @@ def ssl_inspect(domain: str, port: int = 443) -> dict:
                 "expiring_soon": 0 <= days_left <= 30,
                 "subject_alt_names": sans,
                 "version": cert.get("version")
+            },
+            # Certificate fingerprinting
+            "wildcard_certificate": wildcard,
+            "self_signed": self_signed,
+            "public_key_type": public_key_type,
+            "san_count": len(sans),
+            "validity_period_days": validity_days,
+            # Certificate status
+            "certificate_status": _certificate_status(days_left),
+            # TLS & cipher security
+            "tls_security": _classify_tls(tls_version),
+            "cipher_security": _classify_cipher(cipher[0], cipher[2]),
+            "weak_tls_version": weak_tls,
+            "weak_cipher": weak_cipher,
+            # Overall rating + extensions
+            "security_rating": _security_rating(tls_version, cipher[0], cipher[2], days_left, validity_days),
+            "certificate_extensions": {
+                "ocsp_url": ocsp[0] if ocsp else None,
+                "ca_issuer_url": ca_issuers[0] if ca_issuers else None,
+                "crl_distribution_points": list(cert.get("crlDistributionPoints", ()))
             }
         }
 

--- a/tools/ssl_tool.py
+++ b/tools/ssl_tool.py
@@ -180,13 +180,15 @@ def ssl_inspect(domain: str, port: int = 443) -> dict:
         def rdn(rdns):
             return {k: v for rdn in rdns for k, v in rdn}
 
-        subject = rdn(cert.get("subject", []))
-        issuer = rdn(cert.get("issuer", []))
+        raw_subject = cert.get("subject", ())
+        raw_issuer = cert.get("issuer", ())
+        subject = rdn(raw_subject)
+        issuer = rdn(raw_issuer)
 
         # --- issue #100: certificate fingerprinting ---
         common_name = subject.get("commonName", "")
         wildcard = common_name.startswith("*.") or any(s.startswith("*.") for s in sans)
-        self_signed = bool(subject) and subject == issuer
+        self_signed = bool(raw_subject) and raw_subject == raw_issuer
         validity_days = (not_after - not_before).days
 
         # --- issue #100: TLS & cipher security analysis ---


### PR DESCRIPTION
Closes #100.

Adds derived SSL/TLS security context on top of the certificate metadata `ssl_inspect` already returns. No new network I/O — every field is computed from data already fetched on the open connection (public-key type comes from `getpeercert(binary_form=True)`). Existing output fields are unchanged.

**New fields** (matching the issue's example shapes):
- **Fingerprinting:** `wildcard_certificate`, `self_signed`, `public_key_type` (RSA/ECDSA/…), `san_count`, `validity_period_days` — plus `certificate_extensions` (OCSP / CA-issuer / CRL URLs).
- **Status:** `certificate_status` — Healthy / Expiring Soon / Expired.
- **TLS & cipher:** `tls_security`, `cipher_security`, `weak_tls_version`, `weak_cipher`.
- **Overall:** `security_rating` — Excellent / Good / Fair / Poor.

**Documented thresholds** (all in-module comments, easy to tune):
- Expiring-Soon = 30 days.
- Weak cipher = RC4 / 3DES / single-DES / NULL / EXPORT / MD5 / RC2 / anonymous-DH / < 128-bit (per RFC 7457, NIST SP 800-131A).
- Weak TLS = < 1.2 (RFC 8996 / PCI-DSS).
- Rating = 10-pt score (TLS 0–3 + cipher 0–3 + expiry 0–2 + validity 0–2); ≥9 Excellent / ≥7 Good / ≥4 Fair; expired / weak-TLS / weak-cipher hard-fail to Poor.

**Tests:** `tests/test_ssl_inspect.py` — 16 new cases (wildcard, self-signed, validity, all three statuses, strong/weak TLS & cipher, low-bit cipher, rating boundaries, ECDSA/RSA key type via real DER, extensions present/absent, key-None fallback), same mocking mechanism as the existing tests (which are untouched). Full suite: `226 passed`.

**Two things worth your call:**
- `ssl_tool.py` sets `context.minimum_version = TLSv1_2`, so a live connection can't negotiate TLS < 1.2 and unverified/self-signed/expired certs take the error branch — meaning `weak_tls_version`, `self_signed`, and `Expired` analysis is reachable mainly for locally-trusted certs / a future "probe weak configs" mode. I left the security floor as-is rather than weaken it. 
- `public_key_type` uses `cryptography`, currently only a transitive dep (fastmcp → authlib → cryptography). The import is guarded and falls back to `None` (per the issue's "where available"), but you may want to pin it directly in `requirements.txt`.

All the numeric thresholds are yours to tune — happy to adjust.

---
Generated by Claude Opus 4.8 (brief, review), Kimi K3 (implementation)
