### PR TITLE
fix(subdomain_takeover): perform case-insensitive response matching

### DIFF
--- a/tools/subdomain_takeover_tool.py
+++ b/tools/subdomain_takeover_tool.py
@@ -81,7 +81,7 @@ def _confirms_takeover(subdomain: str, fingerprint: dict) -> bool:
     indicator = fingerprint["indicator"]
     if "status" in indicator:
         return response.status_code == indicator["status"]
-    return indicator["body"] in response.text
+    return indicator["body"].lower() in response.text.lower()
 
 
 def subdomain_takeover(domain: str) -> dict:


### PR DESCRIPTION
## Summary

This is a follow up commit PR improves takeover fingerprint detection by making HTTP response body matching case-insensitive.

Previously, takeover indicators were matched using a direct string comparison in recently added pr #121 :

```python
indicator["body"] in response.text
```

This could miss valid matches when providers return the same message with different capitalization.

Examples:

* `No such app`
* `No Such App`
* `NO SUCH APP`

## Changes

* Convert both the expected fingerprint and response body to lowercase before comparison.
* No changes to the public API or output format.
* No changes to takeover fingerprints themselves.

## Benefits

* Reduces false negatives caused by capitalization differences.
* Makes fingerprint matching more resilient across provider response variations.
* Maintains existing behavior while improving detection reliability.
