### PR TITLE
Potential fix for code scanning alert no. 22: Incomplete URL substring sanitization

### DIFF
--- a/tests/test_subdomain_takeover.py
+++ b/tests/test_subdomain_takeover.py
@@ -1,5 +1,6 @@
 import unittest
 from unittest.mock import patch, Mock
+from urllib.parse import urlparse
 
 from tools.subdomain_takeover_tool import subdomain_takeover
 
@@ -211,8 +212,12 @@ def test_https_failure_falls_back_to_http(mock_enum, mock_resolver_class, mock_g
     assert result["vulnerable"][0]["service"] == "Azure"
     # HTTPS tried first (and failed), then HTTP fallback succeeded.
     assert mock_get.call_count == 2
-    assert mock_get.call_args_list[0].args[0].startswith("https://app.example.com")
-    assert mock_get.call_args_list[1].args[0].startswith("http://app.example.com")
+    first_url = urlparse(mock_get.call_args_list[0].args[0])
+    second_url = urlparse(mock_get.call_args_list[1].args[0])
+    assert first_url.scheme == "https"
+    assert first_url.hostname == "app.example.com"
+    assert second_url.scheme == "http"
+    assert second_url.hostname == "app.example.com"
 
 
 @patch("tools.subdomain_takeover_tool.requests.get")


### PR DESCRIPTION
Potential fix for [https://github.com/AynOps/AynOps/security/code-scanning/22](https://github.com/AynOps/AynOps/security/code-scanning/22)

The best fix is to stop using substring/prefix matching for URL validation in the assertion and instead parse each recorded URL and assert on structured components (`scheme`, `hostname`). This removes ambiguity and aligns with CodeQL’s recommendation.

In `tests/test_subdomain_takeover.py`, update the assertions in `test_https_failure_falls_back_to_http` (lines around 214–215) to:
- parse `mock_get.call_args_list[0].args[0]` and `mock_get.call_args_list[1].args[0]` via `urllib.parse.urlparse`,
- assert first call has scheme `https` and hostname `app.example.com`,
- assert second call has scheme `http` and hostname `app.example.com`.

Also add `from urllib.parse import urlparse` near the imports at the top of the same file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
