### PR TITLE
feat: add per-hop severity analysis to headers_analyzer (scope gap from #68)

### DIFF
--- a/tests/test_headers_tool.py
+++ b/tests/test_headers_tool.py
@@ -468,6 +468,63 @@ class TestHeadersAnalyzer(unittest.TestCase):
         self.assertEqual(result["domain"], "www.example.com")
 
     # ------------------------------------------------------------------
+    # Per-hop severity analysis
+    # ------------------------------------------------------------------
+
+    @patch("tools.headers_tool.requests.get")
+    def test_intermediate_redirect_hop_gets_its_own_severity_analysis(self, mock_get):
+        mock_get.side_effect = [
+            _resp(301, {
+                "Location": "https://example.com/home",
+            }),
+            _resp(200, {
+                "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+                "Content-Security-Policy": "default-src 'self'",
+                "X-Frame-Options": "DENY",
+            }),
+        ]
+        result = headers_analyzer("example.com")
+
+        first_hop = result["redirect_chain"][0]
+        self.assertIn("analysis", first_hop)
+        self.assertFalse(
+            first_hop["analysis"]["strict-transport-security"]["present"]
+        )
+        self.assertEqual(
+            first_hop["analysis"]["strict-transport-security"]["severity"], "high"
+        )
+
+    @patch("tools.headers_tool.requests.get")
+    def test_final_hop_analysis_matches_top_level_headers(self, mock_get):
+        """The top-level `headers` key and the final hop's own
+        `redirect_chain[-1]["analysis"]` must be identical. If these
+        ever diverge, something is computing the "site's" analysis
+        differently from "the last hop's" analysis, which should
+        never happen.
+        """
+        mock_get.side_effect = [
+            _resp(301, {"Location": "https://example.com/home"}),
+            _resp(200, {
+                "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+                "X-Frame-Options": "DENY",
+            }),
+        ]
+        result = headers_analyzer("example.com")
+        self.assertEqual(
+            result["headers"], result["redirect_chain"][-1]["analysis"]
+        )
+
+    @patch("tools.headers_tool.requests.get")
+    def test_single_hop_chain_still_has_analysis_key(self, mock_get):
+        mock_get.return_value = _resp(200, {"X-Frame-Options": "DENY"})
+        result = headers_analyzer("example.com")
+        self.assertEqual(len(result["redirect_chain"]), 1)
+        self.assertIn("analysis", result["redirect_chain"][0])
+        self.assertEqual(
+            result["redirect_chain"][0]["analysis"], result["headers"]
+        )
+
+    # ------------------------------------------------------------------
     # Error handling
     # ------------------------------------------------------------------
 

--- a/tools/headers_tool.py
+++ b/tools/headers_tool.py
@@ -80,8 +80,20 @@ def headers_analyzer(domain: str) -> dict:
     Returns
     -------
     dict
-        ``{"success": True, "domain": ..., "headers": {...}}`` on success,
-        or ``{"success": False, "error": ...}`` on failure.
+        On success: ``{"success": True, "domain": ..., "requested_url": ...,
+        "final_url": ..., "redirected": bool, "redirect_chain": [...],
+        "headers": {...}}``.
+
+        ``headers`` is the severity analysis of the final hop (the actual
+        page a browser would land on). ``redirect_chain`` lists every hop
+        walked to get there, each with its own ``url``, ``status_code``,
+        raw ``headers``, and an ``analysis`` (same structure and rules as
+        the top-level ``headers``, run against that hop's own response;
+        see ``_analyze_raw_headers`` for the caveat on interpreting
+        findings from non-final hops). The last entry in ``redirect_chain``
+        always mirrors the top-level ``headers`` exactly.
+
+        On failure: ``{"success": False, "error": ...}``.
     """
     domain = normalize_domain(domain)
     if not is_valid_domain(domain):
@@ -166,6 +178,52 @@ def headers_analyzer(domain: str) -> dict:
     except Exception as e:
         return {"success": False, "error": str(e)}
 
+    headers = _analyze_raw_headers(raw_headers)
+
+    redirect_chain = []
+    for h in hops:
+        # Computed once, reused for both the raw view and the analysis
+        # below, avoids lowercasing the same dict twice per hop.
+        hop_headers = {k.lower(): v for k, v in h["headers"].items()}
+        redirect_chain.append({
+            "url": h["url"],
+            "status_code": h["status_code"],
+            "headers": hop_headers,
+            "analysis": _analyze_raw_headers(hop_headers),
+        })
+
+    return {
+        "success": True,
+        "domain": domain,
+        "requested_url": requested_url,
+        "final_url": final_url,
+        "redirected": redirected,
+        "redirect_chain": redirect_chain,
+        "headers": headers,
+    }
+
+
+def _analyze_raw_headers(raw_headers: dict) -> dict:
+    """Run every header check against one response's headers.
+
+    Takes a single hop's lowercased headers dict and returns the same
+    ``headers`` analysis structure used at the top level of
+    ``headers_analyzer``'s result. Factored out so the exact same rules
+    apply whether it's being run on the final page or an intermediate
+    redirect hop.
+
+    Caveat this does NOT attempt to solve: content-dependent headers
+    (CSP, X-Frame-Options, X-Content-Type-Options, Permissions-Policy,
+    Referrer-Policy) are checked the same way on every hop, including
+    bare redirect responses that never carry them because there's no
+    page content at that layer to protect. A load-balancer-issued 301
+    will near-universally show "CSP missing, severity high" here;
+    that's an accurate description of THAT response, not a finding
+    about the site. Building a per-status-code significance model to
+    suppress that would be a separate, more speculative feature; this
+    function stays a plain, uniform ruleset and leaves interpretation
+    of intermediate-hop findings to the caller.
+    """
     headers: dict[str, Any] = {}
 
     # --- Strict-Transport-Security ---
@@ -366,19 +424,4 @@ def headers_analyzer(domain: str) -> dict:
                 "severity": "low",
             }
 
-    return {
-        "success": True,
-        "domain": domain,
-        "requested_url": requested_url,
-        "final_url": final_url,
-        "redirected": redirected,
-        "redirect_chain": [
-            {
-                "url": h["url"],
-                "status_code": h["status_code"],
-                "headers": {k.lower(): v for k, v in h["headers"].items()},
-            }
-            for h in hops
-        ],
-        "headers": headers,
-    }
+    return headers


### PR DESCRIPTION
Related to #62 (redirect-chain scope gap left open by #68)

## Problem
PR #68 explicitly left one gap: severity scoring only ran on the final hop. Intermediate redirect hops in `redirect_chain` exposed raw headers only, no analysis.

## Root cause
Scoring logic lived inline inside `headers_analyzer()`, called once against the final hop only.

## Fix
Extracted scoring into `_analyze_raw_headers(raw_headers) -> dict`, called once per hop. Each `redirect_chain[i]` now has an `"analysis"` key alongside the existing raw `"headers"`. Also updated `headers_analyzer`'s docstring, which never documented `redirect_chain` even pre-#68.

Content-dependent headers (CSP, X-Frame-Options, X-Content-Type-Options, Permissions-Policy, Referrer-Policy) will show as "missing" on most redirect hops, since a bare 301/302 carries no page content. Building a per-status-code significance model to suppress it is a separate, more speculative feature, out of scope here.

## Validation
Added 3 regression tests. Confirmed all 3 fail against pre-fix code (`AssertionError: 'analysis' not found`) before confirming they pass against the fix.
```
pytest tests/test_headers_tool.py -v --cov=tools.headers_tool
44 passed, 100% coverage
```
`server.py`'s only touchpoint is passthrough registration via `mcp.tool()`.

## Does NOT resolve
No per-status-code weighting of which findings are meaningful on a redirect hop vs the final response.