### PR TITLE
feat: detect Akamai block/challenge pages, not just Cloudflare's (scope gap from #68)

### DIFF
--- a/tests/test_headers_tool.py
+++ b/tests/test_headers_tool.py
@@ -372,6 +372,28 @@ class TestHeadersAnalyzer(unittest.TestCase):
         self.assertTrue(result["success"])
         self.assertTrue(result["headers"]["x-frame-options"]["present"])
 
+    @patch("tools.headers_tool.requests.get")
+    def test_akamai_block_page_is_rejected_not_analyzed(self, mock_get):
+        mock_get.return_value = _resp(403, {
+            "Server": "AkamaiGHost",
+            "Content-Type": "text/html",
+        })
+        result = headers_analyzer("example.com")
+        self.assertFalse(result["success"])
+        self.assertIn("akamai", result["error"].lower())
+
+    @patch("tools.headers_tool.requests.get")
+    def test_normal_akamai_fronted_site_is_analyzed_normally(self, mock_get):
+        mock_get.return_value = _resp(200, {
+            "Server": "Apache",
+            "x-akamai-transformed": "9 16447 0 pmb=mRUM,2",
+            "Set-Cookie": "ak_bmsc=abc123; Domain=.example.com; Path=/",
+            "X-Frame-Options": "SAMEORIGIN",
+        })
+        result = headers_analyzer("example.com")
+        self.assertTrue(result["success"])
+        self.assertTrue(result["headers"]["x-frame-options"]["present"])
+
     # ------------------------------------------------------------------
     # Full redirect-chain recovery
     # ------------------------------------------------------------------

--- a/tests/test_headers_tool.py
+++ b/tests/test_headers_tool.py
@@ -374,6 +374,9 @@ class TestHeadersAnalyzer(unittest.TestCase):
 
     @patch("tools.headers_tool.requests.get")
     def test_akamai_block_page_is_rejected_not_analyzed(self, mock_get):
+        # Real signature confirmed against marriott.com/homedepot.com/
+        # costco.com: a 403 with Server: AkamaiGHost and no origin
+        # headers at all -- Akamai's edge generated this page itself.
         mock_get.return_value = _resp(403, {
             "Server": "AkamaiGHost",
             "Content-Type": "text/html",
@@ -389,6 +392,16 @@ class TestHeadersAnalyzer(unittest.TestCase):
             "x-akamai-transformed": "9 16447 0 pmb=mRUM,2",
             "Set-Cookie": "ak_bmsc=abc123; Domain=.example.com; Path=/",
             "X-Frame-Options": "SAMEORIGIN",
+        })
+        result = headers_analyzer("example.com")
+        self.assertTrue(result["success"])
+        self.assertTrue(result["headers"]["x-frame-options"]["present"])
+
+    @patch("tools.headers_tool.requests.get")
+    def test_akamaighost_on_a_2xx_response_is_not_rejected(self, mock_get):
+        mock_get.return_value = _resp(200, {
+            "Server": "AkamaiGHost",
+            "X-Frame-Options": "DENY",
         })
         result = headers_analyzer("example.com")
         self.assertTrue(result["success"])

--- a/tools/headers_tool.py
+++ b/tools/headers_tool.py
@@ -23,18 +23,22 @@ _SENSITIVE_PERMISSIONS_FEATURES = (
 )
 
 _WAF_BLOCK_PAGE_SIGNATURES = (
-    ("cf-mitigated", "challenge", "Cloudflare"),
-    ("server", "akamaighost", "Akamai"),
+    ("cf-mitigated", "challenge", "Cloudflare", None),
+    ("server", "akamaighost", "Akamai", 400),
 )
 
 
-def _detect_waf_block_page(raw_headers: dict) -> str | None:
-    """Return the provider name if raw_headers looks like a WAF's own
-    block/challenge page rather than real site content, else None.
+def _detect_waf_block_page(raw_headers: dict, status_code: int) -> str | None:
+    """Return the provider name if raw_headers (and, where required,
+    status_code) look like a WAF's own block/challenge page rather
+    than real site content, else None.
     """
-    for header_name, expected_value, provider in _WAF_BLOCK_PAGE_SIGNATURES:
-        if raw_headers.get(header_name, "").lower() == expected_value:
-            return provider
+    for header_name, expected_value, provider, min_status in _WAF_BLOCK_PAGE_SIGNATURES:
+        if raw_headers.get(header_name, "").lower() != expected_value:
+            continue
+        if min_status is not None and status_code < min_status:
+            continue
+        return provider
     return None
 
 
@@ -176,7 +180,7 @@ def headers_analyzer(domain: str) -> dict:
         # were the site's real security posture would be actively
         # misleading. Checked via a small signature table so adding a
         # new provider is a one-line addition, not new branching logic.
-        blocked_by = _detect_waf_block_page(raw_headers)
+        blocked_by = _detect_waf_block_page(raw_headers, final_hop["status_code"])
         if blocked_by:
             return {
                 "success": False,

--- a/tools/headers_tool.py
+++ b/tools/headers_tool.py
@@ -22,6 +22,21 @@ _SENSITIVE_PERMISSIONS_FEATURES = (
     "camera", "microphone", "geolocation", "payment", "usb",
 )
 
+_WAF_BLOCK_PAGE_SIGNATURES = (
+    ("cf-mitigated", "challenge", "Cloudflare"),
+    ("server", "akamaighost", "Akamai"),
+)
+
+
+def _detect_waf_block_page(raw_headers: dict) -> str | None:
+    """Return the provider name if raw_headers looks like a WAF's own
+    block/challenge page rather than real site content, else None.
+    """
+    for header_name, expected_value, provider in _WAF_BLOCK_PAGE_SIGNATURES:
+        if raw_headers.get(header_name, "").lower() == expected_value:
+            return provider
+    return None
+
 
 def _walk_redirect_chain(url: str, max_hops: int = _MAX_REDIRECT_HOPS) -> List[Dict[str, Any]]:
     """Manually follow redirects one hop at a time, capturing each
@@ -155,21 +170,21 @@ def headers_analyzer(domain: str) -> dict:
         # accurate.
         raw_headers = {k.lower(): v for k, v in final_hop["headers"].items()}
 
-        # Defensive check: if a WAF challenge still gets through despite
-        # impersonation (e.g. a stricter Cloudflare policy, or a different
-        # provider), its headers belong to the challenge page, not the
-        # site. Analyzing them as if they were the site's real security
-        # posture would be actively misleading. cf-mitigated is Cloudflare's
-        # own signal for this; confirmed present on a real challenge response
-        # observed during investigation.
-        if raw_headers.get("cf-mitigated") == "challenge":
+        # Defensive check: if a WAF challenge/block page gets served
+        # instead of the real site despite impersonation, its headers
+        # belong to that page, not the site; analyzing them as if they
+        # were the site's real security posture would be actively
+        # misleading. Checked via a small signature table so adding a
+        # new provider is a one-line addition, not new branching logic.
+        blocked_by = _detect_waf_block_page(raw_headers)
+        if blocked_by:
             return {
                 "success": False,
                 "error": (
-                    "Received a bot-detection challenge page instead of the "
-                    "real site (Cloudflare challenge detected). Headers from "
-                    "a challenge page do not reflect the site's actual "
-                    "configuration, so no analysis was performed."
+                    f"Received a bot-detection challenge/block page instead "
+                    f"of the real site ({blocked_by} detected). Headers "
+                    f"from this page do not reflect the site's actual "
+                    f"configuration, so no analysis was performed."
                 ),
             }
 


### PR DESCRIPTION
Related to #62 (scope gap left by #68)

## Problem
PR #68 added Cloudflare block-page detection only. Other WAF providers' block pages get silently analyzed as real content.

## Fix
Generalized the Cloudflare-only `cf-mitigated` check into a `_WAF_BLOCK_PAGE_SIGNATURES` table + `_detect_waf_block_page()` helper. Added Akamai: `server: AkamaiGHost`, confirmed on 3 domains (marriott.com, homedepot.com, costco.com) serving 403 block pages with no origin headers. 12/15 other Akamai-fronted domains sampled showed no AkamaiGHost.

Cloudflare behavior unchanged for confirmed cases; match is now case-insensitive (was exact-match), doesn't affect the confirmed signal.

## Validation
```
pytest tests/test_headers_tool.py -v --cov=tools.headers_tool
47 passed, 100% coverage
```
3 new regression tests; block-page test confirmed failing pre-fix, passing post-fix.

## Does NOT resolve
- AWS/CloudFront: CDN ≠ WAF identity (`reuters.com` = CloudFront + DataDome).
- Imperva: 1 sample.
- Sucuri: 0 samples, wrong domain category.
- Akamai JS-challenges without `AkamaiGHost` (`expedia.com`, `Server: istio-envoy`): not caught.