### PR TITLE
feat(ip-reputation): add reputation classification and expose AbuseIP…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "packaging>=26.2",
     "pip>=26.1.2",
     "pytest==9.0.3",
+    "python-dotenv>=1.2.2",
     "python-nmap>=0.7.1",
     "python-whois>=0.9.6",
     "reportlab>=4.5.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ requests-toolbelt==1.0.0
 pytest==9.0.3
 curl_cffi==0.15.0
 tldextract==5.3.1
+python-dotenv==1.2.2

--- a/tests/test_ip_reputation.py
+++ b/tests/test_ip_reputation.py
@@ -1,9 +1,37 @@
-from unittest.mock import Mock, MagicMock, patch, call
-import unittest
-from tools.iprep_tool import ip_reputation
 import os
+import unittest
+from unittest.mock import Mock, patch
+from requests.exceptions import HTTPError, RequestException, Timeout
+from tools.iprep_tool import classify_reputation, ip_reputation
+
+class TestClassifyReputation(unittest.TestCase):
+    """Direct unit tests for the classification rules logic."""
+
+    def test_trusted_when_whitelisted(self):
+        # Whitelisted takes priority even if abuse score is high
+        self.assertEqual(classify_reputation(True, 90, True), "trusted")
+        self.assertEqual(classify_reputation(True, 0, False), "trusted")
+
+    def test_high_risk_threshold(self):
+        self.assertEqual(classify_reputation(False, 75, False), "high-risk")
+        self.assertEqual(classify_reputation(False, 100, False), "high-risk")
+
+    def test_suspicious_threshold_and_tor(self):
+        # Suspicious if score >= 25 OR if it's a Tor node
+        self.assertEqual(classify_reputation(False, 25, False), "suspicious")
+        self.assertEqual(classify_reputation(False, 74, False), "suspicious")
+        self.assertEqual(classify_reputation(False, 0, True), "suspicious")
+
+    def test_low_risk(self):
+        self.assertEqual(classify_reputation(False, 1, False), "low-risk")
+        self.assertEqual(classify_reputation(False, 24, False), "low-risk")
+
+    def test_clean(self):
+        self.assertEqual(classify_reputation(False, 0, False), "clean")
+
 
 class TestIpReputation(unittest.TestCase):
+    """Integration tests for the main ip_reputation function."""
 
     def test_ip_reputation_requires_valid_ip_and_api_key(self):
         self.assertFalse(ip_reputation("not-an-ip")["success"])
@@ -28,6 +56,8 @@ class TestIpReputation(unittest.TestCase):
                 "domain": "example.net",
                 "usageType": "Data Center/Web Hosting/Transit",
                 "lastReportedAt": "2026-05-01T00:00:00+00:00",
+                "isWhitelisted": False,
+                "isTor": False,
             }
         }
         mock_get.return_value = response
@@ -36,6 +66,7 @@ class TestIpReputation(unittest.TestCase):
 
         self.assertTrue(result["success"])
         self.assertTrue(result["is_malicious"])
+        self.assertEqual(result["reputation"], "high-risk")
         self.assertEqual(result["abuse_confidence_score"], 95)
         self.assertEqual(result["total_reports"], 342)
         self.assertEqual(result["country"], "CN")
@@ -47,16 +78,22 @@ class TestIpReputation(unittest.TestCase):
     def test_low_score_not_malicious(self, mock_get):
         response = Mock()
         response.json.return_value = {
-            "data": {"abuseConfidenceScore": 5, "totalReports": 1,
-                     "countryCode": "US", "isp": "Good ISP",
-                     "domain": "good.net", "usageType": "ISP",
-                     "lastReportedAt": None}
+            "data": {
+                "abuseConfidenceScore": 5,
+                "totalReports": 1,
+                "countryCode": "US",
+                "isp": "Good ISP",
+                "domain": "good.net",
+                "usageType": "ISP",
+                "lastReportedAt": None,
+            }
         }
         mock_get.return_value = response
 
         result = ip_reputation("8.8.8.8")
         self.assertTrue(result["success"])
         self.assertFalse(result["is_malicious"])  # score < 25
+        self.assertEqual(result["reputation"], "low-risk")
 
     @patch.dict(os.environ, {"ABUSEIPDB_API_KEY": "test-key"})
     @patch("tools.iprep_tool.requests.get")
@@ -64,15 +101,78 @@ class TestIpReputation(unittest.TestCase):
         """Boundary: score == 25 should be flagged malicious."""
         response = Mock()
         response.json.return_value = {
-            "data": {"abuseConfidenceScore": 25, "totalReports": 5,
-                     "countryCode": "RU", "isp": "Some ISP",
-                     "domain": "bad.net", "usageType": "Hosting",
-                     "lastReportedAt": None}
+            "data": {
+                "abuseConfidenceScore": 25,
+                "totalReports": 5,
+                "countryCode": "RU",
+                "isp": "Some ISP",
+                "domain": "bad.net",
+                "usageType": "Hosting",
+                "lastReportedAt": None,
+            }
         }
         mock_get.return_value = response
 
         result = ip_reputation("1.1.1.1")
         self.assertTrue(result["is_malicious"])
+        self.assertEqual(result["reputation"], "suspicious")
+
+    @patch.dict(os.environ, {"ABUSEIPDB_API_KEY": "test-key"})
+    @patch("tools.iprep_tool.requests.get")
+    def test_handles_null_fields_gracefully(self, mock_get):
+        """Ensures missing or None values from API don't cause TypeError."""
+        response = Mock()
+        # API returns None for keys instead of omitting them
+        response.json.return_value = {
+            "data": {
+                "abuseConfidenceScore": 0,
+                "isWhitelisted": None,
+                "isTor": None,
+            }
+        }
+        mock_get.return_value = response
+
+        result = ip_reputation("8.8.8.8")
+        self.assertTrue(result["success"])
+        self.assertEqual(result["reputation"], "clean")
+        self.assertFalse(result["is_malicious"])
+
+    # -------------------------------------------------------------------------
+    # Exception Handling Tests
+    # -------------------------------------------------------------------------
+
+    @patch.dict(os.environ, {"ABUSEIPDB_API_KEY": "test-key"})
+    @patch("tools.iprep_tool.requests.get")
+    def test_http_error_handling(self, mock_get):
+        mock_response = Mock()
+        mock_response.raise_for_status.side_effect = HTTPError("401 Client Error: Unauthorized")
+        mock_get.return_value = mock_response
+
+        result = ip_reputation("1.1.1.1")
+        self.assertFalse(result["success"])
+        self.assertIn("API request failed", result["error"])
+
+    @patch.dict(os.environ, {"ABUSEIPDB_API_KEY": "test-key"})
+    @patch("tools.iprep_tool.requests.get")
+    def test_timeout_handling(self, mock_get):
+        mock_get.side_effect = Timeout("Connection timed out")
+
+        result = ip_reputation("1.1.1.1")
+        self.assertFalse(result["success"])
+        self.assertIn("timed out", result["error"])
+
+    @patch.dict(os.environ, {"ABUSEIPDB_API_KEY": "test-key"})
+    @patch("tools.iprep_tool.requests.get")
+    def test_generic_request_exception_handling(self, mock_get):
+        mock_get.side_effect = RequestException("Connection refused")
+
+        result = ip_reputation("1.1.1.1")
+        self.assertFalse(result["success"])
+        self.assertIn("Could not connect", result["error"])
+
+    # -------------------------------------------------------------------------
+    # Validation Tests
+    # -------------------------------------------------------------------------
 
     def test_ipv6_address_accepted(self):
         with patch.dict(os.environ, {}, clear=True):
@@ -86,6 +186,7 @@ class TestIpReputation(unittest.TestCase):
                 result = ip_reputation(bad_ip)
                 self.assertFalse(result["success"])
                 self.assertIn("Invalid IP", result["error"])
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tools/iprep_tool.py
+++ b/tools/iprep_tool.py
@@ -1,6 +1,29 @@
 import ipaddress
 import requests
 import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+def classify_reputation(is_whitelisted: bool, abuse_score: int, is_tor: bool) -> str:
+    """Classification model to classify the reputation of the 
+    ip on the basis on is_whitelisted, abuse_score and is_tor"""
+    if is_whitelisted:
+        return "trusted"
+
+    if abuse_score >= 75:
+        return "high-risk"
+
+    if is_tor:
+        return "suspicious"
+
+    if abuse_score >= 25:
+        return "suspicious"
+
+    if abuse_score > 0:
+        return "low-risk"
+
+    return "clean"
 
 def ip_reputation(ip_address: str) -> dict:
     """
@@ -30,15 +53,26 @@ def ip_reputation(ip_address: str) -> dict:
         data = response.json().get("data", {})
 
         abuse_score = data.get("abuseConfidenceScore", 0)
+        is_whitelisted = bool(data.get("isWhitelisted" , False))
+        is_tor = bool(data.get("isTor" , False))
+        reputation = classify_reputation(is_whitelisted, abuse_score, is_tor)
+
         return {
             "success": True,
             "ip": ip,
-            "is_malicious": abuse_score >= 25,
+            "ip_version": data.get("ipVersion"),
+            "is_malicious": reputation in {"high-risk" , "suspicious"},
+            "is_whitelisted": is_whitelisted,
+            "is_public": bool(data.get("isPublic" , False)),
+            "is_tor": is_tor,
+            "reputation": reputation,
+            "num_distinct_users": data.get("numDistinctUsers" , 0),
             "abuse_confidence_score": abuse_score,
             "total_reports": data.get("totalReports", 0),
             "country": data.get("countryCode"),
             "isp": data.get("isp"),
             "domain": data.get("domain"),
+            "hostnames": data.get("hostnames"),
             "usage_type": data.get("usageType"),
             "last_reported_at": data.get("lastReportedAt"),
         }

--- a/tools/iprep_tool.py
+++ b/tools/iprep_tool.py
@@ -66,7 +66,7 @@ def ip_reputation(ip_address: str) -> dict:
             "is_public": bool(data.get("isPublic" , False)),
             "is_tor": is_tor,
             "reputation": reputation,
-            "num_distinct_users": data.get("numDistinctUsers" , 0),
+            "num_distinct_users": data.get("numDistinctUsers") or 0,
             "abuse_confidence_score": abuse_score,
             "total_reports": data.get("totalReports", 0),
             "country": data.get("countryCode"),

--- a/uv.lock
+++ b/uv.lock
@@ -76,6 +76,7 @@ dependencies = [
     { name = "packaging" },
     { name = "pip" },
     { name = "pytest" },
+    { name = "python-dotenv" },
     { name = "python-nmap" },
     { name = "python-whois" },
     { name = "reportlab" },
@@ -92,6 +93,7 @@ requires-dist = [
     { name = "packaging", specifier = ">=26.2" },
     { name = "pip", specifier = ">=26.1.2" },
     { name = "pytest", specifier = "==9.0.3" },
+    { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "python-nmap", specifier = ">=0.7.1" },
     { name = "python-whois", specifier = ">=0.9.6" },
     { name = "reportlab", specifier = ">=4.5.1" },
@@ -1399,8 +1401,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "sys_platform != 'win32'" },
-    { name = "jeepney", marker = "sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## Summary

This PR enhances the `ip_reputation` tool by introducing a human-readable reputation classification model, exposing additional AbuseIPDB metadata, and improving environment variable loading through `.env` support.

Previously, the tool determined whether an IP address was malicious solely based on the `abuseConfidenceScore` threshold (`>= 25`). While functional, this approach ignored important context provided by AbuseIPDB such as whitelisting status, Tor usage, and public infrastructure indicators.

Additionally, the tool relied entirely on environment variables being manually exported, which could lead to configuration issues during local development.

This change provides richer reputation analysis while preserving backward compatibility through the existing `is_malicious` field and improves developer experience by supporting `.env`-based configuration.

---

## Changes Implemented

### Reputation Classification

Added a dedicated reputation classification model that categorizes IPs into:

* [x] `trusted`
* [x] `high-risk`
* [x] `suspicious`
* [x] `low-risk`
* [x] `clean`

Classification logic now considers:

* Abuse confidence score
* AbuseIPDB whitelist status
* Tor exit node status

---

### Additional AbuseIPDB Metadata

Exposed the following fields in the tool output:

* [x] `ip_version`
* [x] `is_whitelisted`
* [x] `is_public`
* [x] `is_tor`
* [x] `num_distinct_users`
* [x] `hostnames`
* [x] `reputation`

Existing fields such as:

* [x] `abuse_confidence_score`
* [x] `total_reports`

remain available for transparency and compatibility.

---

### Environment Configuration Improvements

Added support for loading environment variables from a `.env` file using `python-dotenv`.

Changes include:

* [x] Added `python-dotenv` dependency
* [x] Added automatic `.env` loading during tool initialization
* [x] Improved local development experience by reducing manual environment setup requirements
* [x] Maintained existing support for standard environment variables

This ensures the AbuseIPDB API key can be loaded consistently across local development and deployment environments.

---

### Backward Compatibility

The existing `is_malicious` field has been retained.

Instead of relying directly on the abuse confidence score threshold, it is now derived from the reputation classification:

* `high-risk` → malicious
* `suspicious` → malicious
* `trusted` → not malicious
* `low-risk` → not malicious
* `clean` → not malicious

This ensures existing integrations continue to work without modification.

---

File Changes:-
* [x] Tests updated
* [x] Dependecies file updated
* [x] Tool file updated

Closes #101