### PR TITLE
feat: add Imperva/Incapsula body-signature detection + Cloudflare 403 edge-case test

### DIFF
--- a/tests/test_headers_tool.py
+++ b/tests/test_headers_tool.py
@@ -5,7 +5,7 @@ from curl_cffi.requests.headers import Headers
 from tools.headers_tool import headers_analyzer
 
 
-def _resp(status_code: int, headers: dict):
+def _resp(status_code: int, headers: dict, body: str = ""):
     """Build a mock curl_cffi response for a single hop.
 
     Wraps headers in curl_cffi's real Headers class (not a plain dict)
@@ -21,9 +21,14 @@ def _resp(status_code: int, headers: dict):
     See test_dict_headers_items_preserves_genuinely_duplicate_headers
     below for the test that specifically covers that case using a
     list of tuples instead.
+
+    body defaults to ""; most tests only care about headers; tests
+    that need real body content (Imperva's body-signature detection)
+    pass it explicitly.
     """
     m = Mock()
     m.status_code = status_code
+    m.text = body
     m.headers = Headers(headers)
     return m
 
@@ -249,6 +254,7 @@ class TestHeadersAnalyzer(unittest.TestCase):
         """
         mock_resp = Mock()
         mock_resp.status_code = 200
+        mock_resp.text = ""
         mock_resp.headers = Headers([
             ("Content-Security-Policy", "script-src 'unsafe-inline'"),
             ("Content-Security-Policy", "default-src 'self'"),
@@ -373,6 +379,16 @@ class TestHeadersAnalyzer(unittest.TestCase):
         self.assertTrue(result["headers"]["x-frame-options"]["present"])
 
     @patch("tools.headers_tool.requests.get")
+    def test_cloudflare_fronted_403_without_challenge_header_is_analyzed_normally(self, mock_get):
+        mock_get.return_value = _resp(403, {
+            "Server": "cloudflare",
+            "X-Frame-Options": "DENY",
+        })
+        result = headers_analyzer("example.com")
+        self.assertTrue(result["success"])
+        self.assertTrue(result["headers"]["x-frame-options"]["present"])
+
+    @patch("tools.headers_tool.requests.get")
     def test_akamai_block_page_is_rejected_not_analyzed(self, mock_get):
         # Real signature confirmed against marriott.com/homedepot.com/
         # costco.com: a 403 with Server: AkamaiGHost and no origin
@@ -403,6 +419,50 @@ class TestHeadersAnalyzer(unittest.TestCase):
             "Server": "AkamaiGHost",
             "X-Frame-Options": "DENY",
         })
+        result = headers_analyzer("example.com")
+        self.assertTrue(result["success"])
+        self.assertTrue(result["headers"]["x-frame-options"]["present"])
+
+    @patch("tools.headers_tool.requests.get")
+    def test_imperva_block_page_body_signature_is_rejected_not_analyzed(self, mock_get):
+        mock_get.return_value = _resp(
+            403,
+            {
+                "Content-Type": "text/html",
+                "X-Iinfo": "15-36662187-0 0NNN RT(...) q(0 -1 -1 2) r(0 -1)",
+            },
+            body=(
+                '<html><head><META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">'
+                '</head><body><iframe id="main-iframe" '
+                'src="/_Incapsula_Resource?SWJIYLWA=abc123"></iframe></body></html>'
+            ),
+        )
+        result = headers_analyzer("example.com")
+        self.assertFalse(result["success"])
+        self.assertIn("imperva", result["error"].lower())
+
+    @patch("tools.headers_tool.requests.get")
+    def test_normal_imperva_fronted_site_is_analyzed_normally(self, mock_get):
+        mock_get.return_value = _resp(
+            200,
+            {
+                "X-CDN": "Imperva",
+                "X-Iinfo": "11-25276189-25276193 PNNN RT(...) q(0 0 0 0) r(3 3)",
+                "X-Frame-Options": "SAMEORIGIN",
+            },
+            body="<html><body>Welcome to the real site</body></html>",
+        )
+        result = headers_analyzer("example.com")
+        self.assertTrue(result["success"])
+        self.assertTrue(result["headers"]["x-frame-options"]["present"])
+
+    @patch("tools.headers_tool.requests.get")
+    def test_incapsula_resource_in_body_on_2xx_response_is_not_rejected(self, mock_get):
+        mock_get.return_value = _resp(
+            200,
+            {"X-Frame-Options": "DENY"},
+            body='<html><body><script src="/_Incapsula_Resource?x=1"></script></body></html>',
+        )
         result = headers_analyzer("example.com")
         self.assertTrue(result["success"])
         self.assertTrue(result["headers"]["x-frame-options"]["present"])

--- a/tools/headers_tool.py
+++ b/tools/headers_tool.py
@@ -22,29 +22,72 @@ _SENSITIVE_PERMISSIONS_FEATURES = (
     "camera", "microphone", "geolocation", "payment", "usb",
 )
 
-_WAF_BLOCK_PAGE_SIGNATURES = (
+_WAF_BLOCK_PAGE_HEADER_SIGNATURES = (
     ("cf-mitigated", "challenge", "Cloudflare", None),
     ("server", "akamaighost", "Akamai", 400),
 )
 
+# Body-content signatures: (substring to search for in the lowercased
+# response body, provider label, minimum status code required or None).
+#
+# Needed because some providers' block pages aren't distinguishable via
+# headers alone: Imperva/Incapsula's X-Iinfo and X-CDN headers are
+# present on BOTH normal and blocked responses (confirmed: geico.com
+# shows X-Iinfo on its 200 homepage AND its 403 block page, just with a
+# different internal value each time), so headers can't tell them apart.
+# The block page's body is distinctive instead; it embeds
+# <iframe src="/_Incapsula_Resource?..."> that never appears in real
+# page content. Confirmed live against geico.com (403, plain
+# non-impersonated request), and independently corroborated by a
+# third-party anti-bot-bypass reference (scrapfly.io) and a 2020
+# GitHub issue (chromedp/chromedp#561) showing the identical HTML
+# structure, so this isn't a one-site coincidence. status_code >= 400
+# required for the same reason as Akamai's entry above: only 1 directly
+# confirmed live sample, no proof this string is exclusive to block
+# pages, so an error-class status is required as a second signal
+# rather than trusting the body substring alone.
+_WAF_BLOCK_PAGE_BODY_SIGNATURES = (
+    ("_incapsula_resource", "Imperva", 400),
+)
 
-def _detect_waf_block_page(raw_headers: dict, status_code: int) -> str | None:
-    """Return the provider name if raw_headers (and, where required,
-    status_code) look like a WAF's own block/challenge page rather
-    than real site content, else None.
+
+def _detect_waf_block_page(raw_headers: dict, status_code: int, body: str) -> str | None:
+    """Return the provider name if this response (headers and/or body)
+    looks like a WAF's own block/challenge page rather than real site
+    content, else None. Header signatures are checked first since
+    they're a cheap dict lookup; body signatures require a substring
+    search over the full response body.
     """
-    for header_name, expected_value, provider, min_status in _WAF_BLOCK_PAGE_SIGNATURES:
+    for header_name, expected_value, provider, min_status in _WAF_BLOCK_PAGE_HEADER_SIGNATURES:
         if raw_headers.get(header_name, "").lower() != expected_value:
             continue
         if min_status is not None and status_code < min_status:
             continue
         return provider
+
+    body_lower = body.lower()
+    for needle, provider, min_status in _WAF_BLOCK_PAGE_BODY_SIGNATURES:
+        if needle not in body_lower:
+            continue
+        if min_status is not None and status_code < min_status:
+            continue
+        return provider
+
     return None
 
 
 def _walk_redirect_chain(url: str, max_hops: int = _MAX_REDIRECT_HOPS) -> List[Dict[str, Any]]:
     """Manually follow redirects one hop at a time, capturing each
-    response's status and headers along the way.
+    response's status, headers, and body along the way.
+
+    Body is captured (not just headers) because some WAF block pages
+    aren't distinguishable via headers alone; see
+    _WAF_BLOCK_PAGE_BODY_SIGNATURES. This adds no extra network cost:
+    resp.text is already downloaded as part of the same GET, it just
+    wasn't being read anywhere before. Body is intentionally NOT
+    included in headers_analyzer's public redirect_chain output, it's
+    only used internally for the block-page check to avoid bloating
+    the return payload with full page HTML on every call.
 
     curl_cffi's built-in allow_redirects=True (like every other HTTP
     client's auto-follow) only ever surfaces the FINAL response. If an
@@ -72,6 +115,7 @@ def _walk_redirect_chain(url: str, max_hops: int = _MAX_REDIRECT_HOPS) -> List[D
             "url": current_url,
             "status_code": resp.status_code,
             "headers": dict(resp.headers.items()),
+            "body": resp.text,
         })
 
         if resp.status_code in _REDIRECT_STATUSES:
@@ -180,7 +224,9 @@ def headers_analyzer(domain: str) -> dict:
         # were the site's real security posture would be actively
         # misleading. Checked via a small signature table so adding a
         # new provider is a one-line addition, not new branching logic.
-        blocked_by = _detect_waf_block_page(raw_headers, final_hop["status_code"])
+        blocked_by = _detect_waf_block_page(
+            raw_headers, final_hop["status_code"], final_hop["body"]
+        )
         if blocked_by:
             return {
                 "success": False,


### PR DESCRIPTION
Related to #62 (continued from #68, #131)

## Problem
Imperva/Incapsula block pages were undetected, only 1 sample existed, too small to act on.

## Fix
Probed 36 domains, found 1 new Imperva hit (geico.com). Compared browser-impersonated vs plain request to trigger its actual block page (no attack payload). Found X-Iinfo/X-CDN headers present on both normal and blocked responses, can't use headers alone like Cloudflare/Akamai. The block page's body embeds `_Incapsula_Resource`.

Extended detection to check body content, not just headers. `_walk_redirect_chain` now captures `resp.text` (already downloaded, no extra cost). Split signatures into header-based and body-based tables. Imperva requires `status_code >= 400`, same defensive pattern as Akamai.

## Validation
```bash
pytest tests/test_headers_tool.py -v --cov=tools.headers_tool
51 passed, 100% coverage
```
4 new tests: 3 for Imperva (block-page test confirmed failing pre-fix, passing post-fix), 1 confirming a Cloudflare origin's real 403 without `cf-mitigated` still analyzes normally.

## Does NOT resolve
- Sucuri: 0 samples, wrong domain category.
- AWS/CloudFront, DataDome: no confirmed block page yet.
- Imperva: only 1 live sample (third-party corroboration, not a second first-hand confirmation).