### PR TITLE
Improve Nmap scan reliability and result parsing

### DIFF
--- a/mcp.json
+++ b/mcp.json
@@ -36,7 +36,8 @@
       "description": "Nmap-powered port scanner with service and version detection",
       "input": {
         "target": "string",
-        "scan_type": "string"
+        "scan_type": "string",
+        "timeout": "integer"
       },
       "requires_api_key": false,
       "requires_system_dependency": "nmap"

--- a/tests/test_port_scan.py
+++ b/tests/test_port_scan.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import Mock, MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 from tools.portscan_tool import port_scan
 
 class TestPortScan(unittest.TestCase):
@@ -31,7 +31,7 @@ class TestPortScan(unittest.TestCase):
         self.assertIn("results", result)
 
     @patch("tools.portscan_tool.nmap.PortScanner")
-    def test_scan_uses_nmap_and_application_timeouts(self, mock_cls):
+    def test_scan_uses_derived_default_timeout(self, mock_cls):
         scanner = self._make_scanner_mock()
         mock_cls.return_value = scanner
 
@@ -41,7 +41,19 @@ class TestPortScan(unittest.TestCase):
         scanner.scan.assert_called_once_with(
             hosts="example.com",
             arguments="-sV -F --host-timeout 120s",
-            timeout=130,
+            timeout=144,
+        )
+
+    @patch("tools.portscan_tool.nmap.PortScanner")
+    def test_custom_timeout_overrides_default(self, mock_cls):
+        scanner = self._make_scanner_mock()
+        mock_cls.return_value = scanner
+
+        port_scan("example.com", "service", timeout=300)
+        scanner.scan.assert_called_once_with(
+            hosts="example.com",
+            arguments="-sV -F --host-timeout 120s",
+            timeout=300,
         )
 
     @patch("tools.portscan_tool.nmap.PortScanner")
@@ -53,7 +65,7 @@ class TestPortScan(unittest.TestCase):
         scanner.scan.assert_called_once_with(
             hosts="example.com",
             arguments="-p- --host-timeout 15m",
-            timeout=950,
+            timeout=1080,
         )
 
     @patch("tools.portscan_tool.nmap.PortScanner")
@@ -65,7 +77,7 @@ class TestPortScan(unittest.TestCase):
         scanner.scan.assert_called_once_with(
             hosts="example.com",
             arguments="--script vuln -F --host-timeout 15m --script-timeout 5m",
-            timeout=950,
+            timeout=1080,
         )
 
     @patch("tools.portscan_tool.nmap.PortScanner")
@@ -224,7 +236,7 @@ class TestPortScan(unittest.TestCase):
         )
 
     @patch("tools.portscan_tool.nmap.PortScanner")
-    def test_osmatch_filters_incomplete_entries(self, mock_cls):
+    def test_os_scan_keeps_partial_os_matches(self, mock_cls):
         os_matches = [
             {"name": "Linux 4.19 - 5.15", "accuracy": "98"},
             {"name": "Linux 4.15", "line": "52791"},
@@ -236,8 +248,19 @@ class TestPortScan(unittest.TestCase):
 
         self.assertEqual(
             result["results"][0]["os_matches"],
-            [{"name": "Linux 4.19 - 5.15", "accuracy": "98"}],
+            [
+                {"name": "Linux 4.19 - 5.15", "accuracy": "98"},
+                {"name": "Linux 4.15"},
+            ],
         )
+
+    @patch("tools.portscan_tool.nmap.PortScanner")
+    def test_non_os_scan_omits_os_matches_even_when_present(self, mock_cls):
+        os_matches = [{"name": "Linux 4.19 - 5.15", "accuracy": "98"}]
+        mock_cls.return_value = self._make_scanner_mock(os_matches=os_matches)
+        result = port_scan("example.com", "service")
+
+        self.assertNotIn("os_matches", result["results"][0])
 
     @patch("tools.portscan_tool.nmap.PortScanner")
     def test_scan_no_hosts_found(self, mock_cls):
@@ -271,6 +294,14 @@ class TestPortScan(unittest.TestCase):
 
         self.assertFalse(result["success"])
         self.assertEqual(result["error"], "Port scan timed out")
+
+    @patch("tools.portscan_tool.nmap.PortScanner")
+    def test_invalid_timeout_returns_error(self, mock_cls):
+        result = port_scan("example.com", scan_type="basic", timeout=0)
+
+        self.assertFalse(result["success"])
+        self.assertIn("Invalid timeout", result["error"])
+        mock_cls.assert_not_called()
 
     @patch("tools.portscan_tool.nmap.PortScanner")
     def test_invalid_scan_type_returns_error(self, mock_cls):

--- a/tests/test_port_scan.py
+++ b/tests/test_port_scan.py
@@ -4,7 +4,7 @@ from tools.portscan_tool import port_scan
 
 class TestPortScan(unittest.TestCase):
 
-    def _make_scanner_mock(self, host="93.184.216.34", open_ports=None):
+    def _make_scanner_mock(self, host="93.184.216.34", open_ports=None, os_matches=None, elapsed="1.23", nmap_xml=None):
         open_ports = open_ports or {80: {"state": "open", "name": "http", "product": "nginx", "version": "1.18"}}
         scanner = MagicMock()
         scanner.all_hosts.return_value = [host]
@@ -12,6 +12,11 @@ class TestPortScan(unittest.TestCase):
         scanner[host].state.return_value = "up"
         scanner[host].all_protocols.return_value = ["tcp"]
         scanner[host]["tcp"].items.return_value = open_ports.items()
+        scanner[host].get.side_effect = lambda key, default=None: {
+            "osmatch": os_matches or []
+        }.get(key, default)
+        scanner.scanstats.return_value = {"elapsed": elapsed}
+        scanner.get_nmap_last_output.return_value = nmap_xml
         return scanner
 
     @patch("tools.portscan_tool.nmap.PortScanner")
@@ -35,8 +40,32 @@ class TestPortScan(unittest.TestCase):
         self.assertTrue(result["success"])
         scanner.scan.assert_called_once_with(
             hosts="example.com",
-            arguments="-sV -F --host-timeout 45s",
-            timeout=50,
+            arguments="-sV -F --host-timeout 120s",
+            timeout=130,
+        )
+
+    @patch("tools.portscan_tool.nmap.PortScanner")
+    def test_full_scan_uses_bounded_host_timeout(self, mock_cls):
+        scanner = self._make_scanner_mock()
+        mock_cls.return_value = scanner
+
+        port_scan("example.com", "full")
+        scanner.scan.assert_called_once_with(
+            hosts="example.com",
+            arguments="-p- --host-timeout 15m",
+            timeout=950,
+        )
+
+    @patch("tools.portscan_tool.nmap.PortScanner")
+    def test_vuln_scan_uses_script_timeout_and_bounded_host_timeout(self, mock_cls):
+        scanner = self._make_scanner_mock()
+        mock_cls.return_value = scanner
+
+        port_scan("example.com", "vuln")
+        scanner.scan.assert_called_once_with(
+            hosts="example.com",
+            arguments="--script vuln -F --host-timeout 15m --script-timeout 5m",
+            timeout=950,
         )
 
     @patch("tools.portscan_tool.nmap.PortScanner")
@@ -50,9 +79,172 @@ class TestPortScan(unittest.TestCase):
         self.assertEqual(port_entry["product"], "nginx")
 
     @patch("tools.portscan_tool.nmap.PortScanner")
+    def test_os_scan_includes_os_matches(self, mock_cls):
+        os_matches = [
+            {"name": "Linux 4.19 - 5.15", "accuracy": "98", "line": "52790", "osclass": []},
+            {"name": "Linux 4.15", "accuracy": "94", "line": "52791", "osclass": []},
+        ]
+        mock_cls.return_value = self._make_scanner_mock(os_matches=os_matches)
+        result = port_scan("scanme.nmap.org", "os")
+
+        self.assertTrue(result["success"])
+        host_result = result["results"][0]
+        self.assertIn("os_matches", host_result)
+        self.assertEqual(
+            host_result["os_matches"],
+            [
+                {"name": "Linux 4.19 - 5.15", "accuracy": "98"},
+                {"name": "Linux 4.15", "accuracy": "94"},
+            ],
+        )
+
+    @patch("tools.portscan_tool.nmap.PortScanner")
+    def test_scan_omits_os_matches_when_absent(self, mock_cls):
+        mock_cls.return_value = self._make_scanner_mock(os_matches=[])
+        result = port_scan("example.com", "basic")
+
+        self.assertNotIn("os_matches", result["results"][0])
+
+    @patch("tools.portscan_tool.nmap.PortScanner")
+    def test_scan_includes_duration(self, mock_cls):
+        mock_cls.return_value = self._make_scanner_mock(elapsed="12.34")
+        result = port_scan("example.com", "basic")
+
+        self.assertEqual(result["duration_seconds"], 12.34)
+
+    @patch("tools.portscan_tool.nmap.PortScanner")
+    def test_duration_defaults_to_none_when_scanstats_unavailable(self, mock_cls):
+        scanner = self._make_scanner_mock()
+        scanner.scanstats.side_effect = AssertionError("Do a scan before trying to get result !")
+        mock_cls.return_value = scanner
+
+        result = port_scan("example.com", "basic")
+
+        self.assertTrue(result["success"])
+        self.assertIsNone(result["duration_seconds"])
+
+    @patch("tools.portscan_tool.nmap.PortScanner")
+    def test_host_timeout_status_from_xml(self, mock_cls):
+        xml = """<?xml version="1.0"?>
+        <nmaprun>
+          <host>
+            <address addr="93.184.216.34" addrtype="ipv4"/>
+            <status state="up"/>
+          </host>
+        </nmaprun>"""
+        mock_cls.return_value = self._make_scanner_mock(nmap_xml=xml)
+        result = port_scan("93.184.216.34", "basic")
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["host_timeout_status"], {"93.184.216.34": False})
+
+    @patch("tools.portscan_tool.nmap.PortScanner")
+    def test_host_timeout_status_true_when_timedout(self, mock_cls):
+        xml = """<?xml version="1.0"?>
+        <nmaprun>
+          <host timedout="true">
+            <address addr="93.184.216.34" addrtype="ipv4"/>
+            <status state="up"/>
+          </host>
+        </nmaprun>"""
+        mock_cls.return_value = self._make_scanner_mock(nmap_xml=xml)
+        result = port_scan("93.184.216.34", "basic")
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["host_timeout_status"], {"93.184.216.34": True})
+
+    @patch("tools.portscan_tool.nmap.PortScanner")
+    def test_host_timeout_status_none_when_xml_unavailable(self, mock_cls):
+        mock_cls.return_value = self._make_scanner_mock(nmap_xml=None)
+        result = port_scan("example.com", "basic")
+
+        self.assertTrue(result["success"])
+        self.assertIsNone(result["host_timeout_status"])
+
+    @patch("tools.portscan_tool.nmap.PortScanner")
+    def test_host_timeout_status_none_when_xml_is_garbage(self, mock_cls):
+        mock_cls.return_value = self._make_scanner_mock(nmap_xml="not xml at all")
+        result = port_scan("example.com", "basic")
+
+        self.assertTrue(result["success"])
+        self.assertIsNone(result["host_timeout_status"])
+
+    @patch("tools.portscan_tool.nmap.PortScanner")
+    def test_host_timeout_status_none_when_get_last_output_raises(self, mock_cls):
+        scanner = self._make_scanner_mock()
+        scanner.get_nmap_last_output.side_effect = RuntimeError("nmap crashed")
+        mock_cls.return_value = scanner
+
+        result = port_scan("example.com", "basic")
+
+        self.assertTrue(result["success"])
+        self.assertIsNone(result["host_timeout_status"])
+
+    @patch("tools.portscan_tool.nmap.PortScanner")
+    def test_host_timeout_status_supports_ipv6(self, mock_cls):
+        xml = """<?xml version="1.0"?>
+        <nmaprun>
+          <host timedout="true">
+            <address addr="2606:4700::6810:84e5" addrtype="ipv6"/>
+            <status state="up"/>
+          </host>
+        </nmaprun>"""
+        mock_cls.return_value = self._make_scanner_mock(
+            host="2606:4700::6810:84e5", nmap_xml=xml
+        )
+        result = port_scan("2606:4700::6810:84e5", "basic")
+
+        self.assertTrue(result["success"])
+        self.assertEqual(
+            result["host_timeout_status"], {"2606:4700::6810:84e5": True}
+        )
+
+    @patch("tools.portscan_tool.nmap.PortScanner")
+    def test_host_timeout_status_supports_multiple_hosts(self, mock_cls):
+        xml = """<?xml version="1.0"?>
+        <nmaprun>
+          <host timedout="true">
+            <address addr="93.184.216.34" addrtype="ipv4"/>
+            <status state="up"/>
+          </host>
+          <host>
+            <address addr="93.184.216.35" addrtype="ipv4"/>
+            <status state="up"/>
+          </host>
+        </nmaprun>"""
+        mock_cls.return_value = self._make_scanner_mock(
+            host="93.184.216.34", nmap_xml=xml
+        )
+        result = port_scan("93.184.216.34", "basic")
+
+        self.assertTrue(result["success"])
+        self.assertEqual(
+            result["host_timeout_status"],
+            {"93.184.216.34": True, "93.184.216.35": False},
+        )
+
+    @patch("tools.portscan_tool.nmap.PortScanner")
+    def test_osmatch_filters_incomplete_entries(self, mock_cls):
+        os_matches = [
+            {"name": "Linux 4.19 - 5.15", "accuracy": "98"},
+            {"name": "Linux 4.15", "line": "52791"},
+            {"line": "52792"},
+            {},
+        ]
+        mock_cls.return_value = self._make_scanner_mock(os_matches=os_matches)
+        result = port_scan("example.com", "os")
+
+        self.assertEqual(
+            result["results"][0]["os_matches"],
+            [{"name": "Linux 4.19 - 5.15", "accuracy": "98"}],
+        )
+
+    @patch("tools.portscan_tool.nmap.PortScanner")
     def test_scan_no_hosts_found(self, mock_cls):
         scanner = MagicMock()
         scanner.all_hosts.return_value = []
+        scanner.scanstats.return_value = {"elapsed": "0.50"}
+        scanner.get_nmap_last_output.return_value = None
         mock_cls.return_value = scanner
 
         result = port_scan("192.0.2.1")

--- a/tools/portscan_tool.py
+++ b/tools/portscan_tool.py
@@ -1,15 +1,36 @@
+import re
 import xml.etree.ElementTree as ET
 import nmap
 
 SCAN_CONFIG = {
-    "basic": {"args": "-F --host-timeout 30s", "timeout": 35},
-    "service": {"args": "-sV -F --host-timeout 120s", "timeout": 130},
-    "os": {"args": "-O -F --host-timeout 60s", "timeout": 65},
-    "full": {"args": "-p- --host-timeout 15m", "timeout": 950},
-    "vuln": {"args": "--script vuln -F --host-timeout 15m --script-timeout 5m", "timeout": 950},
+    "basic": {"args": "-F --host-timeout 30s"},
+    "service": {"args": "-sV -F --host-timeout 120s"},
+    "os": {"args": "-O -F --host-timeout 60s"},
+    "full": {"args": "-p- --host-timeout 15m"},
+    "vuln": {"args": "--script vuln -F --host-timeout 15m --script-timeout 5m"},
 }
 
+TIMEOUT_MARGIN = 0.2
+
 PORT_SCAN_TIMEOUT_ERRORS = (TimeoutError, getattr(nmap, "PortScannerTimeout", TimeoutError))
+
+_DURATION_UNITS = {"s": 1, "m": 60, "h": 3600}
+
+
+def _host_timeout_seconds(args: str) -> int:
+    match = re.search(r"--host-timeout\s*[=]?\s*(\d+)\s*([smh])?", args)
+    if not match:
+        return 0
+    value = int(match.group(1))
+    unit = match.group(2) or "s"
+    return value * _DURATION_UNITS[unit]
+
+
+def _default_timeout(args: str) -> int:
+    host_timeout = _host_timeout_seconds(args)
+    if host_timeout <= 0:
+        raise ValueError(f"No parseable --host-timeout in args: {args!r}")
+    return int(host_timeout * (1 + TIMEOUT_MARGIN))
 
 
 def _extract_host_timeout_status(nmap_output: bytes) -> dict:
@@ -37,7 +58,7 @@ def _extract_host_timeout_status(nmap_output: bytes) -> dict:
     return result
 
 
-def port_scan(target: str, scan_type: str = "basic") -> dict:
+def port_scan(target: str, scan_type: str = "basic", timeout: int | None = None) -> dict:
     """
     Perform Nmap port scan on a target IP or domain.
 
@@ -47,6 +68,9 @@ def port_scan(target: str, scan_type: str = "basic") -> dict:
     - "os"      : OS detection, needs admin (-O -F)
     - "full"    : All 65535 ports, slow (-p-)
     - "vuln"    : Basic vulnerability scripts (--script vuln -F)
+
+    timeout overrides the application-level timeout in seconds. When omitted,
+    it defaults to the scan's --host-timeout plus a margin (TIMEOUT_MARGIN).
     """
     if scan_type not in SCAN_CONFIG:
         return {
@@ -58,14 +82,21 @@ def port_scan(target: str, scan_type: str = "basic") -> dict:
             "valid_scan_types": list(SCAN_CONFIG.keys()),
         }
 
+    if timeout is not None and timeout < 1:
+        return {
+            "success": False,
+            "error": f"Invalid timeout '{timeout}'. Must be a positive number of seconds.",
+        }
+
     try:
         scanner = nmap.PortScanner()
 
         config = SCAN_CONFIG[scan_type]
+        effective_timeout = timeout if timeout is not None else _default_timeout(config["args"])
         scanner.scan(
             hosts=target,
             arguments=config["args"],
-            timeout=config["timeout"],
+            timeout=effective_timeout,
         )
 
         results = []
@@ -78,11 +109,11 @@ def port_scan(target: str, scan_type: str = "basic") -> dict:
             }
 
             os_matches = scanner[host].get("osmatch", [])
-            if os_matches:
+            if scan_type == "os" and os_matches:
                 host_data["os_matches"] = [
-                    {"name": m["name"], "accuracy": m["accuracy"]}
+                    {k: m.get(k) for k in ("name", "accuracy") if m.get(k)}
                     for m in os_matches
-                    if m.get("name") and m.get("accuracy")
+                    if m.get("name") or m.get("accuracy")
                 ]
 
             for proto in scanner[host].all_protocols():

--- a/tools/portscan_tool.py
+++ b/tools/portscan_tool.py
@@ -1,14 +1,41 @@
+import xml.etree.ElementTree as ET
 import nmap
 
 SCAN_CONFIG = {
     "basic": {"args": "-F --host-timeout 30s", "timeout": 35},
-    "service": {"args": "-sV -F --host-timeout 45s", "timeout": 50},
-    "os": {"args": "-O -F --host-timeout 45s", "timeout": 50},
-    "full": {"args": "-p- --host-timeout 5m", "timeout": 310},
-    "vuln": {"args": "--script vuln -F --host-timeout 90s", "timeout": 100},
+    "service": {"args": "-sV -F --host-timeout 120s", "timeout": 130},
+    "os": {"args": "-O -F --host-timeout 60s", "timeout": 65},
+    "full": {"args": "-p- --host-timeout 15m", "timeout": 950},
+    "vuln": {"args": "--script vuln -F --host-timeout 15m --script-timeout 5m", "timeout": 950},
 }
 
 PORT_SCAN_TIMEOUT_ERRORS = (TimeoutError, getattr(nmap, "PortScannerTimeout", TimeoutError))
+
+
+def _extract_host_timeout_status(nmap_output: bytes) -> dict:
+    """
+    Parse raw nmap XML to extract timedout status per host.
+    Returns {host_ip: True/False} for each <host> element.
+    Returns empty dict on parse failure.
+
+    Hosts are keyed by IPv4 address when present, falling back to
+    IPv6 — matching how python-nmap keys entries in all_hosts().
+    """
+    try:
+        dom = ET.fromstring(nmap_output)
+    except ET.ParseError:
+        return {}
+    result = {}
+    for host_el in dom.findall("host"):
+        addr_el = host_el.find("address[@addrtype='ipv4']")
+        if addr_el is None:
+            addr_el = host_el.find("address[@addrtype='ipv6']")
+        if addr_el is not None:
+            addr = addr_el.get("addr")
+            if addr:
+                result[addr] = host_el.get("timedout") == "true"
+    return result
+
 
 def port_scan(target: str, scan_type: str = "basic") -> dict:
     """
@@ -50,6 +77,14 @@ def port_scan(target: str, scan_type: str = "basic") -> dict:
                 "protocols": {}
             }
 
+            os_matches = scanner[host].get("osmatch", [])
+            if os_matches:
+                host_data["os_matches"] = [
+                    {"name": m["name"], "accuracy": m["accuracy"]}
+                    for m in os_matches
+                    if m.get("name") and m.get("accuracy")
+                ]
+
             for proto in scanner[host].all_protocols():
                 ports = []
                 for port, data in scanner[host][proto].items():
@@ -70,12 +105,30 @@ def port_scan(target: str, scan_type: str = "basic") -> dict:
 
             results.append(host_data)
 
+        duration = None
+        try:
+            raw = scanner.scanstats().get("elapsed")
+            if raw is not None:
+                duration = float(raw)
+        except Exception:
+            pass
+
+        host_timeout_status = {}
+        try:
+            raw_xml = scanner.get_nmap_last_output()
+            if raw_xml:
+                host_timeout_status = _extract_host_timeout_status(raw_xml)
+        except Exception:
+            pass
+
         return {
             "success": True,
             "target": target,
             "scan_type": scan_type,
             "hosts_found": len(results),
-            "results": results
+            "duration_seconds": duration,
+            "results": results,
+            "host_timeout_status": host_timeout_status or None,
         }
 
     except PORT_SCAN_TIMEOUT_ERRORS:


### PR DESCRIPTION
Closes #136

## Changes

- Relaxed `--host-timeout`/`timeout` for `service`, `os`, `full`, and `vuln` (with `--script-timeout 5m` on `vuln`), so long scans no longer terminate early.
- `os` scans now return `os_matches` (`{name, accuracy}`); results also include `duration_seconds` and `host_timeout_status` (keyed by IP) to distinguish complete scans from partial ones.

## Tests

Expanded `tests/test_port_scan.py` covering the new configs and parsin logic, all pass.