### PR TITLE
refactor(techstack): remove security-header analysis from tech_stack_detect (#130 phase 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ It is also listed on glama mcp registry.
 | `port_scan` | Nmap-powered scanner with service/version detection and security warnings |
 | `ssl_inspect` | SSL/TLS certificate — issuer, expiry, cipher strength, SANs, TLS version |
 | `email_security_check` | Checks SPF, DKIM, and DMARC DNS records — returns a security_score, rating, and actionable recommendations for missing or weak configurations |
-| `tech_stack_detect` | Web server, CMS, JS frameworks, CDN, analytics, and security header scoring |
+| `tech_stack_detect` | Web server, CMS, JS frameworks, CDN, and analytics |
 | `cert_transparency` | Query crt.sh Certificate Transparency logs for a domain and extract certificate, subdomain, and wildcard information |
 | `asn_lookup` | Autonomous System Number (ASN) and network ownership lookup via Team Cymru WHOIS — identifies ASN, BGP prefix, organization, registry, country, and allocation date for domains or IP addresses (no API key required) |
 | `ip_reputation` | Check if an IP is flagged as malicious via AbuseIPDB (api key requied) |

--- a/mcp.json
+++ b/mcp.json
@@ -68,7 +68,7 @@
     },
     {
       "name": "tech_stack_detect",
-      "description": "Fingerprint web server, CMS, CDN, JS frameworks, and security headers",
+      "description": "Fingerprint web server, CMS, CDN, and JS frameworks",
       "input": {
         "domain": "string"
       },

--- a/tests/test_tech_stack_detect.py
+++ b/tests/test_tech_stack_detect.py
@@ -51,30 +51,23 @@ class TestTechStackDetect(unittest.TestCase):
         self.assertIn("Next.js", result["technologies"]["javascript_frameworks"])
 
     @patch("tools.techstack_tool.requests.get")
-    def test_security_header_scoring(self, mock_get):
+    def test_no_security_analysis_in_output(self, mock_get):
         headers = {
+            "server": "nginx/1.18",
             "strict-transport-security": "max-age=31536000",
             "x-frame-options": "DENY",
-            "x-content-type-options": "nosniff",
-            "content-security-policy": "default-src 'self'",
-            "referrer-policy": "strict-origin",
-            "permissions-policy": "geolocation=()",
-            "x-xss-protection": "1; mode=block",
         }
-        mock_get.return_value = self._make_response(headers=headers)
+        html = '<link rel="stylesheet" href="/wp-content/themes/theme.css">'
+        mock_get.return_value = self._make_response(html=html, headers=headers)
         result = tech_stack_detect("example.com")
 
-        self.assertEqual(result["security_headers"]["score"], "100%")
-        self.assertEqual(result["security_headers"]["rating"], "Excellent")
-        self.assertEqual(result["security_headers"]["missing"], [])
-
-    @patch("tools.techstack_tool.requests.get")
-    def test_poor_security_header_rating(self, mock_get):
-        mock_get.return_value = self._make_response(headers={})
-        result = tech_stack_detect("example.com")
-
-        self.assertEqual(result["security_headers"]["score"], "0%")
-        self.assertEqual(result["security_headers"]["rating"], "Poor")
+        self.assertNotIn("security_headers", result)
+        self.assertEqual(
+            set(result.keys()),
+            {"success", "domain", "url", "status_code", "technologies"},
+        )
+        self.assertEqual(result["technologies"]["web_server"], "nginx/1.18")
+        self.assertIn("WordPress", result["technologies"]["cms"])
 
     @patch("tools.techstack_tool.requests.get", side_effect=Exception("Connection refused"))
     def test_connection_error_caught(self, _):

--- a/tools/techstack_tool.py
+++ b/tools/techstack_tool.py
@@ -4,7 +4,7 @@ from utils.helpers import is_valid_domain, normalize_domain
 def tech_stack_detect(domain: str) -> dict:
     """
     Detect technology stack of a website.
-    Identifies web server, frameworks, CMS, CDN, analytics, and security headers.
+    Identifies web server, frameworks, CMS, CDN, and analytics.
     """
     domain = normalize_domain(domain)
     if not is_valid_domain(domain):
@@ -82,38 +82,12 @@ def tech_stack_detect(domain: str) -> dict:
         if analytics_found:
             tech["analytics"] = analytics_found
 
-        # ── Security Headers ──
-        security_headers = [
-            "strict-transport-security",
-            "content-security-policy",
-            "x-frame-options",
-            "x-content-type-options",
-            "referrer-policy",
-            "permissions-policy",
-            "x-xss-protection"
-        ]
-        present = [h for h in security_headers if h in headers]
-        missing = [h for h in security_headers if h not in headers]
-
-        security_score = int((len(present) / len(security_headers)) * 100)
-
         return {
             "success": True,
             "domain": domain,
             "url": resp.url,
             "status_code": resp.status_code,
             "technologies": tech,
-            "security_headers": {
-                "present": present,
-                "missing": missing,
-                "score": f"{security_score}%",
-                "rating": (
-                    "Excellent" if security_score >= 85 else
-                    "Good"      if security_score >= 60 else
-                    "Fair"      if security_score >= 40 else
-                    "Poor"
-                )
-            }
         }
 
     except requests.exceptions.SSLError as e:


### PR DESCRIPTION
## Summary

Phase 1 of #130: `tech_stack_detect` no longer does security-header analysis. The header list, the present/missing split and the `security_score`/`rating` computation are gone, along with the `security_headers` key in the returned dict. Everything else in the tool is byte-for-byte unchanged, including all three `except` clauses.

Scoped to Phase 1 deliberately — Phases 2–4 and the proposed output schema are left for follow-ups so this stays reviewable. Say the word if you would rather have it in one go.

## Related Issues and Pull Requests

Partially addresses #130 — this is phase 1 only; the remaining phases follow in separate PRs.

## Changes

- `tools/techstack_tool.py` — removed the `# ── Security Headers ──` block and the `"security_headers": {...}` entry; docstring now reads "...CDN, and analytics".
- `tests/test_tech_stack_detect.py` — two tests removed (below), one added.
- `README.md`, `mcp.json` — dropped the security-header mentions from the tool's description. `server.json` has no per-tool entries, so nothing to change there.

The output schema is the old one minus `security_headers`; the issue's proposed schema is **not** adopted here, matching how increments have landed in this repo before. `tools/signals/tech_stack.py` is untouched.

## Testing

`pytest tests/ -v` — the CI job's exact command. **288 passed / 15 subtests** on `main`, **287 / 15** here: −2 deleted, +1 added. No skips, no xfails, no relaxed assertions; only `tests/test_tech_stack_detect.py` was touched.

The new `test_no_security_analysis_in_output` was written **before** the change and run against unmodified `tools/techstack_tool.py`, where it fails:

```
AssertionError: 'security_headers' unexpectedly found in {..., 'security_headers':
{'present': [...], 'missing': [...], 'score': '28%', 'rating': 'Poor'}}
```

It feeds headers that *are* present, so the old code produced a non-trivial block rather than an empty one, and it pins the whole top-level key set against a pasted literal — so re-introducing the behaviour under a different key name fails it too.

**On the two deleted tests**, since that is the part worth scrutinising:

- `test_security_header_scoring` — asserted only `result["security_headers"]["score"] == "100%"`, `["rating"] == "Excellent"`, `["missing"] == []`
- `test_poor_security_header_rating` — asserted only `["score"] == "0%"`, `["rating"] == "Poor"`

Every assertion in both reads `result["security_headers"]`; neither has any residual fingerprinting assertion that could have been kept. To be precise about the authority: the issue does not mention tests at all — it says this functionality "should be removed entirely", and these tests assert exactly that functionality, so they go with it and are replaced by a test pinning its absence.

No other test asserts on the tool's `security_headers`. The other hits in `tests/` (`test_signals_extractors.py`, `test_asn_extractor.py`, `test_full_recon.py`) hand-build synthetic `signals` dicts and never call `tech_stack_detect` — and the `full_recon` tests patch both `TOOL_REGISTRY` and `extract_signals`, so the real tool and extractors never run. `tests/test_headers_tool.py` is untouched and keeps the genuine header coverage.

## Bugs Discovered

- #139 full_recon can never get security headers from headers_analyzer: it is not in the signal registry
- #140 List-valued technologies reach the LLM prompt as a Python repr, e.g. Software detected : nginx, ['WordPress']

## Follow-ups / Known Limitations

**The disclosed consequence, stated fully because it is slightly worse than it first looks.** With the security block gone, `techstack_extractor` takes its `not headers_data` path on every successful run, so `full_recon`'s `missing_security_headers` becomes permanently `[]` and renders as `Missing sec headers: 0 — none`. I verified that end to end rather than reasoning about it: no crash, the extractor's graceful absent-data path handles it, no auto-warnings.

Beyond what I said when claiming the issue: `tools/prompts/threat_analysis.py` names `(techstack)` as that signal's source in three places, and its "Insufficient data" rule keys on the techstack scan — so after this PR the prompt describes a source that produces nothing, and that rule can never fire. The underlying cause is that `headers_analyzer` was never registered, which is #139.

I have deliberately **not** migrated the signal here, because that is registry wiring rather than this refactor and it is your call. If you would rather it landed together, say so and I will fold it in.

Two smaller notes so they are not "you missed a spot": `tools/signals/test.py` still carries an old sample payload with `security_headers`, left alone as non-executed sample data that pytest does not collect; and the branch is cut from `main` rather than my fork's default, which was 20 commits behind.

Generated by Claude Opus 5 (brief, implementation, review), Kimi K3 (issue triage, verification)