### PR TITLE
fix(signals): flatten list-valued technologies so they stop reaching the prompt as Python reprs

### DIFF
--- a/tests/test_signals_extractors.py
+++ b/tests/test_signals_extractors.py
@@ -254,13 +254,7 @@ def test_asn_extractor_skips_metadata_on_failure():
 # ── techstack_extractor ──────────────────────────────────────────────────
 
 def test_techstack_extractor_flattens_list_valued_technologies():
-    """List-valued technology entries must be flattened into individual names.
-
-    Regression test for #140: cms/analytics/javascript_frameworks are stored
-    as lists in the tech_stack_detect result. The extractor used to append
-    str(list), so the prompt line contained a literal Python repr such as
-    ``['WordPress']`` instead of the technology name.
-    """
+    """List-valued technology entries must be flattened into individual names."""
     result = {
         "success": True,
         "status_code": 200,

--- a/tests/test_signals_extractors.py
+++ b/tests/test_signals_extractors.py
@@ -8,6 +8,7 @@ ip_reputation_extractor (the AbuseIPDB-backed canonical source).
 """
 from tools.signals.asn import asn_extractor
 from tools.signals.ip_reputation import ip_reputation_extractor
+from tools.signals.tech_stack import techstack_extractor
 from tools.signals.extractor import extract_signals
 
 
@@ -248,4 +249,56 @@ def test_asn_extractor_skips_metadata_on_failure():
     assert signals["asn_org"] is None
     assert signals["asn_ip"] is None
     assert signals["asn_country"] is None
+
+
+# ── techstack_extractor ──────────────────────────────────────────────────
+
+def test_techstack_extractor_flattens_list_valued_technologies():
+    """List-valued technology entries must be flattened into individual names.
+
+    Regression test for #140: cms/analytics/javascript_frameworks are stored
+    as lists in the tech_stack_detect result. The extractor used to append
+    str(list), so the prompt line contained a literal Python repr such as
+    ``['WordPress']`` instead of the technology name.
+    """
+    result = {
+        "success": True,
+        "status_code": 200,
+        "security_headers": {"missing": []},
+        "technologies": {
+            "web_server": "nginx",
+            "cms": ["WordPress"],
+            "analytics": ["Google Analytics"],
+            "javascript_frameworks": ["React", "Vue.js"],
+        },
+    }
+    signals = _base_signals()
+    techstack_extractor(result, signals)
+
+    prompt_line = f"Software detected  : {', '.join(signals['software_detected'])}"
+    assert prompt_line == (
+        "Software detected  : nginx, WordPress, Google Analytics, React, Vue.js"
+    )
+    assert "['WordPress']" not in prompt_line
+    assert '"React"' not in prompt_line
+
+
+def test_techstack_extractor_skips_empty_and_none_technologies():
+    """Empty lists, None, 'Unknown' and 'None' values must not add entries."""
+    result = {
+        "success": True,
+        "status_code": 200,
+        "security_headers": {"missing": []},
+        "technologies": {
+            "web_server": "nginx",
+            "cms": [],
+            "analytics": None,
+            "powered_by": "Unknown",
+            "javascript_frameworks": ["React", None, "", "Unknown"],
+        },
+    }
+    signals = _base_signals()
+    techstack_extractor(result, signals)
+
+    assert signals["software_detected"] == ["nginx", "React"]
 

--- a/tools/signals/tech_stack.py
+++ b/tools/signals/tech_stack.py
@@ -8,7 +8,11 @@ def techstack_extractor(result, signals):
         return
 
     for tech in technologies.values():
-        if tech and str(tech).strip() not in ("Unknown", "None", ""):
+        if isinstance(tech, list):
+            for item in tech:
+                if item and str(item).strip() not in ("Unknown", "None", ""):
+                    signals["software_detected"].append(str(item).strip())
+        elif tech and str(tech).strip() not in ("Unknown", "None", ""):
             signals["software_detected"].append(str(tech).strip())
 
     if not result.get("success"):


### PR DESCRIPTION
## Description

Closes #140. List-valued technology entries reached the LLM prompt as raw Python reprs, so the analyst model was reading:

```
Software detected  : nginx, ['WordPress'], ['Google Analytics'], ['React', 'Vue.js']
```

`techstack_extractor` now iterates list-valued entries and appends each element individually, giving:

```
Software detected  : nginx, WordPress, Google Analytics, React, Vue.js
```

The scalar path is untouched — same `str(tech).strip()` guard, same `"Unknown"`/`"None"`/`""` skip logic — so single-valued detections behave exactly as before.

Edge cases: an empty list contributes nothing; a top-level `None` is skipped by the existing scalar guard and `None` items inside a list by the item guard. Nested lists aren't produced by `tech_stack_detect`; if one ever appeared it would be stringified rather than recursed, matching the old scalar behaviour rather than inventing new semantics.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Closes #140

## How Has This Been Tested?

`python3 -m pytest tests/ -v` → **306 passed**.

New test `test_techstack_extractor_flattens_list_valued_technologies` feeds a scalar `web_server` alongside list-valued `cms`, `analytics` and `javascript_frameworks`, builds the real prompt line, and asserts it carries no brackets or quotes.

Checked by mutation rather than by passing: reverting the change fails it with the literal bracketed string above, and restoring it passes.

I also checked the sibling extractors for the same leak — none have it; the others call `str()` on scalar fields only.

Generated by Claude Opus 5 (brief, review), Kimi K2.7 Code (implementation)
