### PR TITLE
Expanded the COMMON_SUBDOMAIN wordlist for enhancement of the subdomain coverage.

### DIFF
--- a/tools/dns_tool.py
+++ b/tools/dns_tool.py
@@ -13,7 +13,14 @@ SUBDOMAIN_LIFETIME = 3
 RECORD_TYPES = ["A", "AAAA", "MX", "NS", "TXT", "CNAME", "SOA", "CAA"]
 
 # Common subdomains tried during brute-force discovery; adjust to taste.
-COMMON_SUBDOMAINS = ["www", "mail", "ftp", "admin", "api", "dev", "staging", "vpn", "remote", "portal"]
+COMMON_SUBDOMAINS = [
+    "www", "mail", "ftp", "admin", "api", "dev", "staging", "vpn", "remote", "portal",
+    "webmail", "smtp", "pop", "imap", "autodiscover", "autoconfig", "mx", "ns1", "ns2", "cpanel","whm", 
+    "blog", "store", "app", "shop", "mobile", "test", "demo", "beta", "testing","sandbox","local",
+    "cdn", "edge", "static", "caching", "proxy", "origin", "media", "assets", "images", "docs", "help","support","status",
+    "git", "jenkins", "jira", "wiki","pipeline","sso", "auth", "login", "gateway","secure", "files", "upload", "backup",
+    "db", "monitor", "dashboard","cloud", 'chat', "forum", "cluster", "aws","metadata","management"
+]
 
 # A subdomain counts as found if any of these record types resolves for it.
 SUBDOMAIN_RECORD_TYPES = ("A", "AAAA", "CNAME")

--- a/tools/dns_tool.py
+++ b/tools/dns_tool.py
@@ -17,9 +17,9 @@ COMMON_SUBDOMAINS = [
     "www", "mail", "ftp", "admin", "api", "dev", "staging", "vpn", "remote", "portal",
     "webmail", "smtp", "pop", "imap", "autodiscover", "autoconfig", "mx", "ns1", "ns2", "cpanel","whm", 
     "blog", "store", "app", "shop", "mobile", "test", "demo", "beta", "testing","sandbox","local",
-    "cdn", "edge", "static", "caching", "proxy", "origin", "media", "assets", "images", "docs", "help","support","status",
+    "cdn", "edge", "static", "proxy", "origin", "media", "assets", "images", "docs", "help","support","status",
     "git", "jenkins", "jira", "wiki","pipeline","sso", "auth", "login", "gateway","secure", "files", "upload", "backup",
-    "db", "monitor", "dashboard","cloud", 'chat', "forum", "cluster", "aws","metadata","management"
+    "db", "monitor", "dashboard","cloud", "chat", "forum", "cluster", "aws","management"
 ]
 
 # A subdomain counts as found if any of these record types resolves for it.


### PR DESCRIPTION
Supporting configurable or expanded built-in wordlists to significantly increase our discovery coverage without adding complexity. this has done to scale the default list to at least 50 entries to optimize subdomain enumeration.