### PR TITLE
Add a pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Closes
+
+<!-- e.g. Closes #12, addresses item #4 and #5 -->
+
+## Summary
+
+<!-- One or two sentences: what does this PR do and why -->
+
+## What changed
+
+<!-- Bullet list of concrete changes -->
+-
+-
+
+## Notes
+
+<!-- Anything reviewers should know: tradeoffs, follow-ups, things intentionally left out -->
+
+## Verification
+
+- [ ] Ran locally and confirmed it works as expected
+- [ ] Added/updated tests for the changed behavior
+- [ ] All tests pass (`<test command here>`)
+- [ ] No unrelated changes included
+- [ ] Checked `CONTRIBUTING.md` and applied all changes
+- [ ] Updated Documentation ( if required )

--- a/contributing.md
+++ b/contributing.md
@@ -236,6 +236,12 @@ pytest tests/ -v
 
 ---
 
+## Pull Request Template
+
+A pull request template at `.github/PULL_REQUEST_TEMPLATE.md` auto-fills the description box when you open a PR. Fill in its sections (Closes, Summary, What changed, Notes, Verification) and complete the verification checklist before requesting review.
+
+---
+
 ## PR Checklist
 
 - [ ] Tool follows the existing pattern in `tools/`


### PR DESCRIPTION
## Closes

Closes #155

## Summary

Adds `.github/PULL_REQUEST_TEMPLATE.md` so new pull requests are pre-filled with a consistent structure, using the template exactly as written in the issue. This PR is filled in with it, so you can see the rendered result.

## What changed

- Added `.github/PULL_REQUEST_TEMPLATE.md` with the sections from the issue — Closes, Summary, What changed, Notes, Verification — verbatim, no edits.
- Added a short mention of the template to `contributing.md`.

## Notes

Your acceptance criteria say `CONTRIBUTING.md`, but the file on `main` is `contributing.md` — lowercase, repo root. I added the mention there rather than creating a second file, which I flagged on the issue before starting (issuecomment-5259013746). Happy to rename it in a follow-up if you'd rather have the conventional casing; that felt like your call rather than something to slip into a template PR.

`contributing.md` is CRLF throughout and the added lines keep that, so the diff is whitespace-clean under the file's own convention.

Nothing else is touched.

## Verification

- [x] Ran locally and confirmed it works as expected
- [ ] Added/updated tests for the changed behavior — not applicable, the change is two markdown files with no code path
- [x] All tests pass (`pytest tests/` — 312 passed)
- [x] No unrelated changes included
- [x] Checked `CONTRIBUTING.md` and applied all changes
- [x] Updated Documentation ( if required )

Generated by Kimi K3 (implementation), GPT-5.6 Sol (review, verification), Claude Opus 5 (brief, review)
