### PR TITLE
fix(signals): register headers_analyzer so full_recon can report missing security headers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,7 +154,7 @@ TOOL_REGISTRY = [
 
 - `wave`: waves run in order (1 -> 2 -> 3), tools within a wave run in parallel. Pick by category, not just by whether the tool needs `domain`:
   - **Wave 1**, lightweight API and infrastructure record lookups (`whois`, `dns`, `ssl`, `email_security`, `asn`).
-  - **Wave 2**, aggressive port/tech scans and throttled log aggregators (`ports`, `techstack`, `ct_logs`; crt.sh rate-limits).
+  - **Wave 2**, aggressive port/tech scans and throttled log aggregators (`ports`, `techstack`, `headers`, `ct_logs`; crt.sh rate-limits).
   - **Wave 3**, tools that depend on Wave 1/2 output (`ip_reputation`, which needs an IP resolved by `asn`/`dns`).
 - `should_run` / `skip_reason`: use when the tool can't run without another tool's successful output, e.g. `ip_reputation` needs an IP address, so it only runs if `asn`/`dns` resolved one. If `should_run` returns `False`, `fn` is never called and the tool is recorded as skipped with `skip_reason` instead of a result.
 

--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ It is also listed on glama mcp registry.
 | `cert_transparency` | Query crt.sh Certificate Transparency logs for a domain and extract certificate, subdomain, and wildcard information |
 | `asn_lookup` | Autonomous System Number (ASN) and network ownership lookup via Team Cymru WHOIS — identifies ASN, BGP prefix, organization, registry, country, and allocation date for domains or IP addresses (no API key required) |
 | `ip_reputation` | Check if an IP is flagged as malicious via AbuseIPDB (api key requied) |
+| `headers_analyzer` | Analyzes HTTP security headers — checks HSTS, CSP, X-Frame-Options, and more with severity ratings and misconfiguration details |
 | `full_recon` | Runs all core tools in parallel and returns combined result |
 
 ### Standalone Tools
 
 | Tool | Description |
 |---|---|
-| `headers_analyzer` | Analyzes HTTP security headers — checks HSTS, CSP, X-Frame-Options, and more with severity ratings and misconfiguration details |
 | `cve_lookup` | Search NVD for known CVEs by software name and version (no API key required) |
 | `cloud_exposure_check` | Checks for publicly accessible AWS S3, Azure Blob Storage, and Google Cloud Storage buckets using common bucket naming patterns derived from the target domain |
 | `trace_redirects` | Traces the full HTTP redirect chain hop by hop — flags TLS downgrades, private-IP leaks, redirect loops, cross-domain hops, and overly long chains |

--- a/tests/test_asn_extractor.py
+++ b/tests/test_asn_extractor.py
@@ -64,6 +64,7 @@ def test_extract_signals_includes_asn_fields():
         },
         "ports": {"success": False},
         "techstack": {"success": False},
+        "headers": {"success": False},
         "ct_logs": {"success": False},
         "ip_reputation": {"success": False},
     }

--- a/tests/test_full_recon.py
+++ b/tests/test_full_recon.py
@@ -220,7 +220,7 @@ def test_full_recon_skips_and_failures(mock_is_valid, mock_registry, mock_extrac
     skipped_fn.assert_not_called()
 
 # ==========================================
-# TESTS FOR THE SECURITY-HEADER SIGNAL (issue #139)
+# TESTS FOR THE SECURITY-HEADER SIGNAL
 # ==========================================
 
 def _stub_fn(name):

--- a/tests/test_full_recon.py
+++ b/tests/test_full_recon.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 
 # Import the functions to test. Adjust 'tools.fullrecon_tool' to match your actual module layout.
 from tools.fullrecon_tool import _format_signals_block, full_recon
+from tools.signals.registry import TOOL_REGISTRY
 
 
 # ==========================================
@@ -217,3 +218,59 @@ def test_full_recon_skips_and_failures(mock_is_valid, mock_registry, mock_extrac
     
     # Ensure skipped target functions never entered execution path
     skipped_fn.assert_not_called()
+
+# ==========================================
+# TESTS FOR THE SECURITY-HEADER SIGNAL (issue #139)
+# ==========================================
+
+def _stub_fn(name):
+    """A registered tool replaced by a no-network failure result."""
+    def _fn(*_args, **_kwargs):
+        return {"success": False, "error": f"{name} not exercised by this test"}
+    return _fn
+
+
+def _registry_with_only_headers_live():
+    """The real TOOL_REGISTRY with every tool but headers_analyzer stubbed.
+
+    Keeps full_recon's real wave scheduling, real registry entries and the
+    real extractor wiring, while making the run offline.
+    """
+    entries = []
+    for tool in TOOL_REGISTRY:
+        entry = dict(tool)
+        if entry["name"] != "headers":
+            entry["fn"] = _stub_fn(entry["name"])
+        entries.append(entry)
+    return entries
+
+
+def test_full_recon_gets_missing_security_headers_from_headers_analyzer():
+    """full_recon must surface headers_analyzer's findings in the signal
+    and in the block handed to the threat-analysis prompt."""
+    hop = {
+        "url": "https://example.com/",
+        "status_code": 200,
+        "headers": {
+            "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+            "X-Content-Type-Options": "nosniff",
+        },
+        "body": "",
+    }
+
+    with patch("tools.headers_tool._walk_redirect_chain", return_value=[hop]), \
+            patch("tools.fullrecon_tool.TOOL_REGISTRY", _registry_with_only_headers_live()):
+        result = full_recon("example.com")
+
+    signals = result["pre_extracted_signals"]
+    assert signals["missing_security_headers"] == [
+        "content-security-policy",
+        "x-frame-options",
+        "referrer-policy",
+        "permissions-policy",
+    ]
+    assert (
+        "Missing sec headers: 4 — content-security-policy, x-frame-options, "
+        "referrer-policy, permissions-policy"
+    ) in result["signals_block"]
+    assert result["tool_coverage"].get("headers") == "success"

--- a/tests/test_full_recon.py
+++ b/tests/test_full_recon.py
@@ -274,3 +274,42 @@ def test_full_recon_gets_missing_security_headers_from_headers_analyzer():
         "referrer-policy, permissions-policy"
     ) in result["signals_block"]
     assert result["tool_coverage"].get("headers") == "success"
+
+
+def _full_recon_over_one_hop(status_code):
+    """Run full_recon with headers_analyzer served one canned, header-less
+    response and every other tool stubbed out."""
+    hop = {
+        "url": "https://example.com/",
+        "status_code": status_code,
+        "headers": {},
+        "body": "",
+    }
+
+    with patch("tools.headers_tool._walk_redirect_chain", return_value=[hop]), \
+            patch("tools.fullrecon_tool.TOOL_REGISTRY", _registry_with_only_headers_live()):
+        return full_recon("example.com")
+
+
+def test_full_recon_reports_no_hardening_gap_from_a_4xx_page():
+    """Headers read off a 4xx error page describe that page, not the site, so
+    full_recon must report neither missing headers nor a warning."""
+    result = _full_recon_over_one_hop(403)
+
+    signals = result["pre_extracted_signals"]
+    assert signals["missing_security_headers"] == []
+    assert signals["auto_warnings"] == []
+    assert "Missing sec headers: 0 — none" in result["signals_block"]
+    assert "AUTO-WARNINGS" not in result["signals_block"]
+
+
+def test_full_recon_reports_no_hardening_gap_from_a_5xx_page():
+    """A 5xx response never reached page content, so full_recon must report
+    neither missing headers nor a warning."""
+    result = _full_recon_over_one_hop(503)
+
+    signals = result["pre_extracted_signals"]
+    assert signals["missing_security_headers"] == []
+    assert signals["auto_warnings"] == []
+    assert "Missing sec headers: 0 — none" in result["signals_block"]
+    assert "AUTO-WARNINGS" not in result["signals_block"]

--- a/tests/test_signals_extractors.py
+++ b/tests/test_signals_extractors.py
@@ -391,6 +391,26 @@ def test_extract_signals_reports_no_missing_headers_when_all_present():
     assert signals["missing_security_headers"] == []
 
 
+def test_extract_signals_ignores_headers_from_a_4xx_final_hop():
+    """A 4xx response is an error page, not the site, so its absent headers
+    must not become a finding or a warning."""
+    results = _registry_results(headers=_headers_result({}, status_code=403))
+    signals = extract_signals(results)
+
+    assert signals["missing_security_headers"] == []
+    assert signals["auto_warnings"] == []
+
+
+def test_extract_signals_ignores_headers_from_a_5xx_final_hop():
+    """A 5xx response never reached page content, so its absent headers must
+    not become a finding or a warning."""
+    results = _registry_results(headers=_headers_result({}, status_code=503))
+    signals = extract_signals(results)
+
+    assert signals["missing_security_headers"] == []
+    assert signals["auto_warnings"] == []
+
+
 def test_techstack_success_does_not_clear_the_headers_signal():
     """tech_stack_detect no longer analyses headers, so its extractor must
     not overwrite what headers_analyzer found (extractors run in registry

--- a/tests/test_signals_extractors.py
+++ b/tests/test_signals_extractors.py
@@ -6,10 +6,14 @@ especially important for the ip_abuse_score signal, which was silently
 always 0 between PR #84 and the fix that moved the assignment into
 ip_reputation_extractor (the AbuseIPDB-backed canonical source).
 """
+from unittest.mock import patch
+
+from tools.headers_tool import headers_analyzer
 from tools.signals.asn import asn_extractor
 from tools.signals.ip_reputation import ip_reputation_extractor
 from tools.signals.tech_stack import techstack_extractor
 from tools.signals.extractor import extract_signals
+from tools.signals.registry import TOOL_REGISTRY
 
 
 def _base_signals():
@@ -296,3 +300,180 @@ def test_techstack_extractor_skips_empty_and_none_technologies():
 
     assert signals["software_detected"] == ["nginx", "React"]
 
+
+
+# ── headers signal (issue #139) ──────────────────────────────────────────
+#
+# full_recon's `missing_security_headers` signal must come from
+# headers_analyzer, the tool that owns header analysis. These tests drive
+# the real TOOL_REGISTRY and the real headers_analyzer (only the HTTP hop
+# is canned), so they fail if the tool is unregistered, registered under a
+# different name, wired to the wrong function, or given an extractor that
+# does not populate the signal.
+
+_RAW_HEADERS_ALL_PRESENT = {
+    "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+    "Content-Security-Policy": "default-src 'self'",
+    "X-Frame-Options": "DENY",
+    "X-Content-Type-Options": "nosniff",
+    "Referrer-Policy": "no-referrer",
+    "Permissions-Policy": "camera=(), microphone=()",
+}
+
+
+def _registry_entry(name):
+    """Return the TOOL_REGISTRY entry called `name`, asserting it exists."""
+    entry = next((t for t in TOOL_REGISTRY if t.get("name") == name), None)
+    assert entry is not None, (
+        f"no {name!r} entry in TOOL_REGISTRY — registered tools: "
+        f"{[t.get('name') for t in TOOL_REGISTRY]}"
+    )
+    return entry
+
+
+def _headers_result(raw_headers, status_code=200):
+    """Run the real headers_analyzer over one canned HTTP response."""
+    hop = {
+        "url": "https://example.com/",
+        "status_code": status_code,
+        "headers": dict(raw_headers),
+        "body": "",
+    }
+    with patch("tools.headers_tool._walk_redirect_chain", return_value=[hop]):
+        return headers_analyzer("example.com")
+
+
+def _raw_headers_without(*omitted):
+    """The fully hardened header set minus the named headers."""
+    dropped = {h.lower() for h in omitted}
+    return {k: v for k, v in _RAW_HEADERS_ALL_PRESENT.items() if k.lower() not in dropped}
+
+
+def _registry_results(**overrides):
+    """A full_recon-shaped results dict: every registered tool failed,
+    except the ones overridden here."""
+    results = {t["name"]: {"success": False, "error": "not run in this test"}
+               for t in TOOL_REGISTRY}
+    results.update(overrides)
+    return results
+
+
+def test_headers_analyzer_is_registered_for_full_recon():
+    """full_recon can only collect security headers if headers_analyzer is
+    in the signal registry with an extractor."""
+    entry = _registry_entry("headers")
+    assert entry["fn"] is headers_analyzer
+    assert callable(entry.get("extractor")), "headers entry has no extractor"
+    assert entry["args"]("example.com", {}) == ("example.com",)
+    assert entry["wave"] == 2
+
+
+def test_extract_signals_populates_missing_headers_from_headers_analyzer():
+    """The signal must carry exactly the headers headers_analyzer reports absent."""
+    results = _registry_results(
+        headers=_headers_result(
+            _raw_headers_without("Content-Security-Policy", "X-Frame-Options")
+        )
+    )
+    signals = extract_signals(results)
+
+    assert signals["missing_security_headers"] == [
+        "content-security-policy",
+        "x-frame-options",
+    ]
+
+
+def test_extract_signals_reports_no_missing_headers_when_all_present():
+    """A fully hardened site must not be reported as missing headers."""
+    results = _registry_results(headers=_headers_result(_RAW_HEADERS_ALL_PRESENT))
+    signals = extract_signals(results)
+
+    assert signals["missing_security_headers"] == []
+
+
+def test_techstack_success_does_not_clear_the_headers_signal():
+    """tech_stack_detect no longer analyses headers, so its extractor must
+    not overwrite what headers_analyzer found (extractors run in registry
+    order, so a stale techstack write silently wins)."""
+    results = _registry_results(
+        headers=_headers_result(_raw_headers_without("Content-Security-Policy")),
+        techstack={
+            "success": True,
+            "domain": "example.com",
+            "url": "https://example.com",
+            "status_code": 200,
+            "technologies": {"web_server": "nginx"},
+        },
+    )
+    signals = extract_signals(results)
+
+    assert signals["missing_security_headers"] == ["content-security-policy"]
+    assert signals["software_detected"] == ["nginx"]
+
+
+def test_headers_extractor_ignores_failed_runs():
+    """A failed headers_analyzer run must leave the signal at its default,
+    so the prompt's 'Insufficient data' rule can still apply."""
+    extractor = _registry_entry("headers")["extractor"]
+    signals = _base_signals()
+    extractor({"success": False, "error": "Connection failed"}, signals)
+
+    assert signals["missing_security_headers"] == []
+    assert signals["auto_warnings"] == []
+
+
+def test_headers_extractor_ignores_malformed_results():
+    """A success without a usable headers analysis must not crash or invent data."""
+    extractor = _registry_entry("headers")["extractor"]
+    signals = _base_signals()
+    extractor({"success": True, "domain": "example.com"}, signals)
+
+    assert signals["missing_security_headers"] == []
+    assert signals["auto_warnings"] == []
+
+
+def test_headers_extractor_warns_hard_on_four_or_more_missing():
+    """Four or more absent headers is the 'significant hardening gap' tier."""
+    extractor = _registry_entry("headers")["extractor"]
+    signals = _base_signals()
+    extractor(
+        _headers_result(
+            _raw_headers_without(
+                "Content-Security-Policy",
+                "X-Frame-Options",
+                "Referrer-Policy",
+                "Permissions-Policy",
+            )
+        ),
+        signals,
+    )
+
+    assert len(signals["missing_security_headers"]) == 4
+    assert len(signals["auto_warnings"]) == 1
+    assert "4 security headers missing" in signals["auto_warnings"][0]
+    assert "significant hardening gap" in signals["auto_warnings"][0]
+
+
+def test_headers_extractor_warns_softly_on_two_missing():
+    """Two or three absent headers is the plain-listing tier."""
+    extractor = _registry_entry("headers")["extractor"]
+    signals = _base_signals()
+    extractor(
+        _headers_result(_raw_headers_without("Content-Security-Policy", "Referrer-Policy")),
+        signals,
+    )
+
+    assert len(signals["auto_warnings"]) == 1
+    assert signals["auto_warnings"][0] == (
+        "2 security headers missing: content-security-policy, referrer-policy"
+    )
+
+
+def test_headers_extractor_does_not_warn_on_a_single_missing_header():
+    """One absent header is reported in the signal but is not a warning."""
+    extractor = _registry_entry("headers")["extractor"]
+    signals = _base_signals()
+    extractor(_headers_result(_raw_headers_without("Permissions-Policy")), signals)
+
+    assert signals["missing_security_headers"] == ["permissions-policy"]
+    assert signals["auto_warnings"] == []

--- a/tests/test_signals_extractors.py
+++ b/tests/test_signals_extractors.py
@@ -193,6 +193,7 @@ def test_extract_signals_populates_ip_abuse_score_from_ip_reputation():
         },
         "ports": {"success": False},
         "techstack": {"success": False},
+        "headers": {"success": False},
         "ct_logs": {"success": False},
         "ip_reputation": {
             "success": True,
@@ -220,6 +221,7 @@ def test_extract_signals_leaves_ip_abuse_score_at_zero_when_ip_reputation_missin
         },
         "ports": {"success": False},
         "techstack": {"success": False},
+        "headers": {"success": False},
         "ct_logs": {"success": False},
         "ip_reputation": {"success": False, "error": "API down"},
     }
@@ -262,7 +264,6 @@ def test_techstack_extractor_flattens_list_valued_technologies():
     result = {
         "success": True,
         "status_code": 200,
-        "security_headers": {"missing": []},
         "technologies": {
             "web_server": "nginx",
             "cms": ["WordPress"],
@@ -286,7 +287,6 @@ def test_techstack_extractor_skips_empty_and_none_technologies():
     result = {
         "success": True,
         "status_code": 200,
-        "security_headers": {"missing": []},
         "technologies": {
             "web_server": "nginx",
             "cms": [],
@@ -476,4 +476,25 @@ def test_headers_extractor_does_not_warn_on_a_single_missing_header():
     extractor(_headers_result(_raw_headers_without("Permissions-Policy")), signals)
 
     assert signals["missing_security_headers"] == ["permissions-policy"]
+    assert signals["auto_warnings"] == []
+
+
+def test_techstack_extractor_does_not_touch_the_headers_signal():
+    """tech_stack_detect no longer returns security_headers, so its
+    extractor must not write missing_security_headers at all — whatever
+    order the registry runs the extractors in."""
+    signals = _base_signals()
+    signals["missing_security_headers"] = ["content-security-policy"]
+    techstack_extractor(
+        {
+            "success": True,
+            "domain": "example.com",
+            "url": "https://example.com",
+            "status_code": 200,
+            "technologies": {"web_server": "nginx"},
+        },
+        signals,
+    )
+
+    assert signals["missing_security_headers"] == ["content-security-policy"]
     assert signals["auto_warnings"] == []

--- a/tests/test_signals_extractors.py
+++ b/tests/test_signals_extractors.py
@@ -302,14 +302,7 @@ def test_techstack_extractor_skips_empty_and_none_technologies():
 
 
 
-# ── headers signal (issue #139) ──────────────────────────────────────────
-#
-# full_recon's `missing_security_headers` signal must come from
-# headers_analyzer, the tool that owns header analysis. These tests drive
-# the real TOOL_REGISTRY and the real headers_analyzer (only the HTTP hop
-# is canned), so they fail if the tool is unregistered, registered under a
-# different name, wired to the wrong function, or given an extractor that
-# does not populate the signal.
+# ── headers_extractor ────────────────────────────────────────────────────
 
 _RAW_HEADERS_ALL_PRESENT = {
     "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
@@ -412,9 +405,7 @@ def test_extract_signals_ignores_headers_from_a_5xx_final_hop():
 
 
 def test_techstack_success_does_not_clear_the_headers_signal():
-    """tech_stack_detect no longer analyses headers, so its extractor must
-    not overwrite what headers_analyzer found (extractors run in registry
-    order, so a stale techstack write silently wins)."""
+    """A successful techstack run must leave headers_analyzer's signal intact."""
     results = _registry_results(
         headers=_headers_result(_raw_headers_without("Content-Security-Policy")),
         techstack={

--- a/tests/test_signals_extractors.py
+++ b/tests/test_signals_extractors.py
@@ -324,16 +324,25 @@ def _registry_entry(name):
     return entry
 
 
-def _headers_result(raw_headers, status_code=200):
-    """Run the real headers_analyzer over one canned HTTP response."""
-    hop = {
-        "url": "https://example.com/",
+def _headers_result_over(hops):
+    """Run the real headers_analyzer over a canned redirect chain."""
+    with patch("tools.headers_tool._walk_redirect_chain", return_value=hops):
+        return headers_analyzer("example.com")
+
+
+def _hop(url, status_code, raw_headers):
+    """One canned HTTP response, shaped as _walk_redirect_chain returns it."""
+    return {
+        "url": url,
         "status_code": status_code,
         "headers": dict(raw_headers),
         "body": "",
     }
-    with patch("tools.headers_tool._walk_redirect_chain", return_value=[hop]):
-        return headers_analyzer("example.com")
+
+
+def _headers_result(raw_headers, status_code=200):
+    """Run the real headers_analyzer over one canned HTTP response."""
+    return _headers_result_over([_hop("https://example.com/", status_code, raw_headers)])
 
 
 def _raw_headers_without(*omitted):
@@ -382,6 +391,20 @@ def test_extract_signals_reports_no_missing_headers_when_all_present():
     signals = extract_signals(results)
 
     assert signals["missing_security_headers"] == []
+
+
+def test_extract_signals_reads_the_headers_of_the_final_redirect_hop():
+    """A chain that resolves to a 2xx page did reach the site, so the page's
+    absent headers must still reach the signal."""
+    results = _registry_results(
+        headers=_headers_result_over([
+            _hop("https://example.com/", 301, {"Location": "https://www.example.com/"}),
+            _hop("https://www.example.com/", 200, _raw_headers_without("Content-Security-Policy")),
+        ])
+    )
+    signals = extract_signals(results)
+
+    assert signals["missing_security_headers"] == ["content-security-policy"]
 
 
 def test_extract_signals_ignores_headers_from_a_4xx_final_hop():

--- a/tests/test_threat_analysis_prompt.py
+++ b/tests/test_threat_analysis_prompt.py
@@ -1,0 +1,29 @@
+"""Tests for the evidence-quality rules in the threat-analysis prompt.
+
+The rules tell the model how to classify a signal the extractors handed it,
+so they have to describe the same cutoff the extractors apply. A rule that
+drifts from the code changes how findings are reported with nothing else in
+the tree noticing.
+"""
+from tools.prompts.threat_analysis import THREAT_ANALYSIS_PROMPT
+
+
+def _headers_evidence_rule():
+    """The single evidence-quality bullet governing the headers scan."""
+    rules = [
+        line for line in THREAT_ANALYSIS_PROMPT.splitlines()
+        if line.startswith("• IF the headers scan")
+    ]
+    assert len(rules) == 1, f"expected one headers evidence rule, found {len(rules)}"
+    return rules[0]
+
+
+def test_headers_evidence_rule_covers_every_case_the_extractor_suppresses():
+    """headers_extractor writes no signal for a failed, blocked or non-2xx
+    run, so the prompt must classify all three as insufficient data."""
+    rule = _headers_evidence_rule()
+
+    assert "failed" in rule
+    assert "bot-detection/WAF challenge" in rule
+    assert "4xx/5xx" in rule
+    assert '"Insufficient data"' in rule

--- a/tools/prompts/threat_analysis.py
+++ b/tools/prompts/threat_analysis.py
@@ -8,12 +8,12 @@ YOUR JOB IS CORRELATION, NOT ENUMERATION.
 Do NOT summarise each tool individually.
 Instead, weave findings across tools into a single coherent threat picture.
 Look especially for combinations that amplify risk — examples:
-  • Missing security headers (techstack) + exposed web services = increased browser attack surface
+  • Missing security headers (headers) + exposed web services = increased browser attack surface
   • Open port 443 (ports) + SSL cert expiring in < 30 days (ssl) = imminent HTTPS outage
   • Missing DMARC/SPF/DKIM (email_security) + public-facing mail server = trivial spoofing
   • High ASN abuse score (asn) + IP flagged by reputation (ip_reputation) = hosting provider
     actively used for attacks; consider moving infra
-  • Many CT-log subdomains (ct_logs) + missing security headers (techstack) = broad attack surface with weak baseline hardening
+  • Many CT-log subdomains (ct_logs) + missing security headers (headers) = broad attack surface with weak baseline hardening
 
 Follow this exact output structure — no prose outside it:
 
@@ -81,7 +81,7 @@ signals_block ( Add signals_block from the tool output )
 
 EVIDENCE QUALITY RULES — follow these strictly:
 • Never report a vulnerability solely because data is missing from a tool.
-• IF the techstack scan failed, returned an HTTP status of 4xx/5xx, or no security headers were collected, classify security headers as "Insufficient data" rather than "Missing". Do not penalize the domain for blocked or failed requests.
+• IF the headers scan failed, was blocked by a bot-detection/WAF challenge, or collected no security headers, classify security headers as "Insufficient data" rather than "Missing". Do not penalize the domain for blocked or failed requests.
 • Use this language:
     - "Confirmed" — tool returned explicit evidence
     - "Likely" — strong indirect evidence from correlated tools

--- a/tools/prompts/threat_analysis.py
+++ b/tools/prompts/threat_analysis.py
@@ -81,7 +81,7 @@ signals_block ( Add signals_block from the tool output )
 
 EVIDENCE QUALITY RULES — follow these strictly:
 • Never report a vulnerability solely because data is missing from a tool.
-• IF the headers scan failed, was blocked by a bot-detection/WAF challenge, or collected no security headers, classify security headers as "Insufficient data" rather than "Missing". Do not penalize the domain for blocked or failed requests.
+• IF the headers scan failed, was blocked by a bot-detection/WAF challenge, returned an HTTP status of 4xx/5xx, or collected no security headers, classify security headers as "Insufficient data" rather than "Missing". Do not penalize the domain for blocked or failed requests.
 • Use this language:
     - "Confirmed" — tool returned explicit evidence
     - "Likely" — strong indirect evidence from correlated tools

--- a/tools/signals/headers.py
+++ b/tools/signals/headers.py
@@ -1,0 +1,34 @@
+def headers_extractor(result, signals):
+    """Populate the security-header signal from a headers_analyzer result.
+
+    headers_analyzer reports every checked header as
+    ``{"present": bool, "value": ..., "issue": ..., "severity": ...}``;
+    the ones it marks absent are what `missing_security_headers` means.
+    Information-disclosure headers (``server``, ``x_powered_by``, …) only
+    appear when they ARE present, so they never enter the missing list.
+    """
+    if not result.get("success"):
+        return
+
+    headers = result.get("headers")
+
+    if not isinstance(headers, dict):
+        return
+
+    missing = [
+        name
+        for name, analysis in headers.items()
+        if isinstance(analysis, dict) and not analysis.get("present")
+    ]
+
+    signals["missing_security_headers"] = missing
+
+    if len(missing) >= 4:
+        signals["auto_warnings"].append(
+            f"{len(missing)} security headers missing ({', '.join(missing)}) — significant hardening gap"
+        )
+
+    elif len(missing) >= 2:
+        signals["auto_warnings"].append(
+            f"{len(missing)} security headers missing: {', '.join(missing)}"
+        )

--- a/tools/signals/headers.py
+++ b/tools/signals/headers.py
@@ -1,3 +1,28 @@
+def _final_hop_status(result):
+    """The status code of the response headers_analyzer analysed, or None.
+
+    headers_analyzer does not surface the status at the top level; the last
+    entry of ``redirect_chain`` is the hop whose headers became the
+    analysis.
+    """
+    chain = result.get("redirect_chain")
+
+    if not isinstance(chain, list) or not chain:
+        return None
+
+    final_hop = chain[-1]
+
+    if not isinstance(final_hop, dict):
+        return None
+
+    status = final_hop.get("status_code")
+
+    if isinstance(status, bool) or not isinstance(status, int):
+        return None
+
+    return status
+
+
 def headers_extractor(result, signals):
     """Populate the security-header signal from a headers_analyzer result.
 
@@ -6,8 +31,20 @@ def headers_extractor(result, signals):
     the ones it marks absent are what `missing_security_headers` means.
     Information-disclosure headers (``server``, ``x_powered_by``, …) only
     appear when they ARE present, so they never enter the missing list.
+
+    A result that did not reach real page content is insufficient data, not
+    a hardening finding: headers_analyzer happily analyses whatever the
+    final hop returned, and an error, maintenance or bot-block page carries
+    its own (usually bare) headers, which say nothing about the site. Unless
+    the analysed hop answered 2xx, the signal is left at its default so the
+    prompt's "Insufficient data" rule applies instead.
     """
     if not result.get("success"):
+        return
+
+    status = _final_hop_status(result)
+
+    if status is None or not 200 <= status < 300:
         return
 
     headers = result.get("headers")

--- a/tools/signals/headers.py
+++ b/tools/signals/headers.py
@@ -1,29 +1,4 @@
-def _final_hop_status(result):
-    """The status code of the response headers_analyzer analysed, or None.
-
-    headers_analyzer does not surface the status at the top level; the last
-    entry of ``redirect_chain`` is the hop whose headers became the
-    analysis.
-    """
-    chain = result.get("redirect_chain")
-
-    if not isinstance(chain, list) or not chain:
-        return None
-
-    final_hop = chain[-1]
-
-    if not isinstance(final_hop, dict):
-        return None
-
-    status = final_hop.get("status_code")
-
-    if isinstance(status, bool) or not isinstance(status, int):
-        return None
-
-    return status
-
-
-def headers_extractor(result, signals):
+def headers_extractor(result, signals) -> None:
     """Populate the security-header signal from a headers_analyzer result.
 
     headers_analyzer reports every checked header as
@@ -42,9 +17,16 @@ def headers_extractor(result, signals):
     if not result.get("success"):
         return
 
-    status = _final_hop_status(result)
-
-    if status is None or not 200 <= status < 300:
+    chain = result.get("redirect_chain")
+    if not isinstance(chain, list) or not chain:
+        return
+    final_hop = chain[-1]
+    if not isinstance(final_hop, dict):
+        return
+    status = final_hop.get("status_code")
+    if isinstance(status, bool) or not isinstance(status, int):
+        return
+    if not 200 <= status < 300:
         return
 
     headers = result.get("headers")

--- a/tools/signals/registry.py
+++ b/tools/signals/registry.py
@@ -7,6 +7,7 @@ from tools.asn_tool import asn_lookup
 from tools.crt_sh_tool import cert_transparency
 from tools.iprep_tool import ip_reputation
 from tools.email_security_tool import email_security_check
+from tools.headers_tool import headers_analyzer
 
 from tools.signals.whois import whois_extractor
 from tools.signals.dns import dns_extractor
@@ -17,6 +18,7 @@ from tools.signals.asn import asn_extractor
 from tools.signals.crtsh import crt_extractor
 from tools.signals.ip_reputation import ip_reputation_extractor
 from tools.signals.email_security import email_security_extractor
+from tools.signals.headers import headers_extractor
 from tools.signals.ip_reputation import extract_ip
 
 TOOL_REGISTRY = [
@@ -73,6 +75,13 @@ TOOL_REGISTRY = [
         "wave": 2,
         "args": lambda domain, results: (domain,),
         "extractor": techstack_extractor,
+    },
+    {
+        "name": "headers",
+        "fn": headers_analyzer,
+        "wave": 2,
+        "args": lambda domain, results: (domain,),
+        "extractor": headers_extractor,
     },
     {
         "name": "ct_logs",

--- a/tools/signals/tech_stack.py
+++ b/tools/signals/tech_stack.py
@@ -14,28 +14,3 @@ def techstack_extractor(result, signals):
                     signals["software_detected"].append(str(item).strip())
         elif tech and str(tech).strip() not in ("Unknown", "None", ""):
             signals["software_detected"].append(str(tech).strip())
-
-    if not result.get("success"):
-        return
-
-    status_code = result.get("status_code")
-    headers_data = result.get("security_headers")
-
-    if status_code >= 400 or not headers_data:
-        signals["missing_security_headers"] = []
-        return
-
-    missing = headers_data.get("missing")
-
-    signals["missing_security_headers"] = missing
-
-    if len(missing) >= 4:
-        signals["auto_warnings"].append(
-            f"{len(missing)} security headers missing ({', '.join(missing)}) — significant hardening gap"
-        )
-        
-    elif len(missing) >= 2:
-        signals["auto_warnings"].append(
-            f"{len(missing)} security headers missing: {', '.join(missing)}"
-        )
-    


### PR DESCRIPTION
## Closes

Fixes #139

Relates to #130 — not closed here; this only removes the dead half its merged phase 1 (#141) left behind.

## Summary

`headers_analyzer` was never in `TOOL_REGISTRY`, so once #141 removed header analysis from `tech_stack_detect` nothing could populate `missing_security_headers` and `full_recon` reported "0 — none" for every domain. This registers `headers` as a wave-2 tool with its own signal extractor.

## What changed

- New `tools/signals/headers.py`: `headers_extractor` builds `missing_security_headers` from `headers_analyzer`'s per-header `present` flags, and keeps the two existing auto-warning tiers (>= 4 missing → "significant hardening gap", >= 2 → plain listing).
- The signal is only populated when the hop that was actually analysed answered 2xx. `headers_analyzer` analyses whatever the final redirect hop served, and an error or block page's own bare headers say nothing about the site — that is insufficient data, not a hardening finding. Failed, empty-chain and malformed results leave the signal at its default.
- `tools/signals/registry.py`: `headers` registered in wave 2, next to `techstack`.
- `tools/signals/tech_stack.py`: dropped the block still reading `result["security_headers"]` / `result["status_code"]`, keys `tech_stack_detect` stopped returning in #141.
- `tools/prompts/threat_analysis.py`: the header signal is attributed to `(headers)` instead of `(techstack)`, and the "Insufficient data" rule now also covers a bot/WAF-blocked scan and a scan that collected no headers.
- `README.md` / `CONTRIBUTING.md`: `headers_analyzer` moved to the tools `full_recon` runs, and `headers` added to the wave-2 list.

## Notes

- The 2xx cutoff is narrower than it looks: `headers_analyzer` already returns `success: False` for a chain ending on a redirect and for a detected WAF/bot page, so in practice it suppresses the signal on 4xx/5xx only.
- Names in the signal are `headers_analyzer`'s own lowercase HTTP header names (`content-security-policy`, `x-frame-options`, …), so they appear in that spelling in the auto-warning text too.

## Verification

- [x] Ran locally and confirmed it works as expected — focused runs of the extractor across the status boundary (199/200/299/300/304/403/500, plus empty and malformed redirect chains) and of `full_recon` with only the HTTP hop canned.
- [x] Added/updated tests for the changed behavior — `tests/test_signals_extractors.py`, `tests/test_full_recon.py`, and a new `tests/test_threat_analysis_prompt.py` pinning the prompt's evidence rule to the extractor's cutoff.
- [x] All tests pass (`pytest tests/ -v`) — 329 passed, 15 subtests passed, in Actions run 31688507644 on our fork Nitjsefnie-OSC/AynOps. That run's log records `checked-out SHA: ccb4e1a32dbd1d32c634037539293caece23c11d`, this branch's head; the run's own `head_sha` is the fork's default branch, not the tree tested.
- [x] No unrelated changes included
- [x] Checked `CONTRIBUTING.md` and applied all changes — its wave-2 tool list now includes `headers`.
- [x] Updated Documentation ( if required ) — `README.md` tool tables.

Generated by GPT-5.6 Sol (brief, review), Claude Opus 5 (implementation, verification, testing, fork CI)
