### PR TITLE
fix(subdomain-takeover): anchor the AWS S3 fingerprint on documented bucket endpoints

### DIFF
--- a/tests/test_subdomain_takeover.py
+++ b/tests/test_subdomain_takeover.py
@@ -246,6 +246,53 @@ def test_both_schemes_fail_is_safe(mock_enum, mock_resolver_class, mock_get):
     assert mock_get.call_count == 2
 
 
+@patch("tools.subdomain_takeover_tool.requests.get")
+@patch("tools.subdomain_takeover_tool.dns.resolver.Resolver")
+@patch("tools.subdomain_takeover_tool.dns_enumeration")
+def test_s3_fingerprint_matches_only_s3_endpoints(mock_enum, mock_resolver_class, mock_get):
+    """Only actual S3 endpoint CNAMEs select the AWS S3 fingerprint; other amazonaws.com services are safe and unprobed."""
+    mock_enum.return_value = _enumeration_result(["static.example.com"])
+    resolver = Mock()
+    mock_resolver_class.return_value = resolver
+
+    s3_cnames = [
+        "static-example-com.s3.amazonaws.com.",
+        "static-example-com.s3.us-east-1.amazonaws.com.",
+        "static-example-com.s3-us-west-2.amazonaws.com.",
+        "static-example-com.s3.dualstack.us-east-1.amazonaws.com.",
+        "static-example-com.s3-website-us-east-1.amazonaws.com.",
+        "static-example-com.s3-website.eu-west-1.amazonaws.com.",
+        "Static-Example-Com.S3.Us-East-1.Amazonaws.Com.",
+    ]
+    non_s3_cnames = [
+        "abc123def4.execute-api.us-east-1.amazonaws.com.",  # API Gateway
+        "my-alb-1234567890.us-east-1.elb.amazonaws.com.",  # Elastic Load Balancing
+        "dualstack.my-alb-1234567890.us-west-2.elb.amazonaws.com.",  # ELB dualstack
+        "ABC123DEF4.EXECUTE-API.US-EAST-1.AMAZONAWS.COM.",  # uppercase API Gateway
+    ]
+
+    for cname, is_s3 in [(c, True) for c in s3_cnames] + [(c, False) for c in non_s3_cnames]:
+        mock_get.reset_mock()
+        resolver.resolve.return_value = [_cname_record(cname)]
+        mock_response = Mock()
+        mock_response.status_code = 404
+        mock_response.text = "NoSuchBucket"
+        mock_get.return_value = mock_response
+
+        result = subdomain_takeover("example.com")
+
+        assert result["success"] is True
+        if is_s3:
+            assert result["total_vulnerable"] == 1, f"{cname} is an actual S3 endpoint and must match"
+            assert result["vulnerable"][0]["service"] == "AWS S3"
+            assert result["vulnerable"][0]["cname"] == cname.rstrip(".")
+            assert mock_get.call_count == 1
+        else:
+            assert result["vulnerable"] == [], f"{cname} is not an S3 endpoint and must not match"
+            assert result["safe"] == ["static.example.com"]
+            mock_get.assert_not_called()
+
+
 @patch("tools.subdomain_takeover_tool.dns_enumeration")
 def test_invalid_domain(mock_enum):
     result = subdomain_takeover("bad_domain")

--- a/tests/test_subdomain_takeover.py
+++ b/tests/test_subdomain_takeover.py
@@ -250,18 +250,27 @@ def test_both_schemes_fail_is_safe(mock_enum, mock_resolver_class, mock_get):
 @patch("tools.subdomain_takeover_tool.dns.resolver.Resolver")
 @patch("tools.subdomain_takeover_tool.dns_enumeration")
 def test_s3_fingerprint_matches_only_s3_endpoints(mock_enum, mock_resolver_class, mock_get):
-    """Only actual S3 endpoint CNAMEs select the AWS S3 fingerprint; other amazonaws.com services are safe and unprobed."""
+    """Only actual S3 bucket endpoint CNAMEs select the AWS S3 fingerprint; other AWS endpoints are safe and unprobed."""
     mock_enum.return_value = _enumeration_result(["static.example.com"])
     resolver = Mock()
     mock_resolver_class.return_value = resolver
 
     s3_cnames = [
-        "static-example-com.s3.amazonaws.com.",
-        "static-example-com.s3.us-east-1.amazonaws.com.",
-        "static-example-com.s3-us-west-2.amazonaws.com.",
-        "static-example-com.s3.dualstack.us-east-1.amazonaws.com.",
-        "static-example-com.s3-website-us-east-1.amazonaws.com.",
-        "static-example-com.s3-website.eu-west-1.amazonaws.com.",
+        "static-example-com.s3.amazonaws.com.",  # legacy global
+        "static-example-com.s3.us-east-1.amazonaws.com.",  # virtual-hosted regional
+        "static-example-com.s3-us-west-2.amazonaws.com.",  # legacy dash region
+        "static-example-com.s3.dualstack.us-east-1.amazonaws.com.",  # dual-stack
+        "static-example-com.s3-fips.us-east-1.amazonaws.com.",  # FIPS
+        "static-example-com.s3-fips.dualstack.us-east-1.amazonaws.com.",  # FIPS dual-stack
+        "static-example-com.s3-accelerate.amazonaws.com.",  # Transfer Acceleration
+        "static-example-com.s3-accelerate.dualstack.amazonaws.com.",  # Acceleration dual-stack
+        "static-example-com.s3-website-us-east-1.amazonaws.com.",  # website, dash form
+        "static-example-com.s3-website.eu-west-1.amazonaws.com.",  # website, dot form
+        "static-example-com.s3.us-gov-west-1.amazonaws.com.",  # GovCloud
+        "static-example-com.s3.cn-north-1.amazonaws.com.cn.",  # China regional
+        "static-example-com.s3-cn-northwest-1.amazonaws.com.cn.",  # China legacy dash
+        "static-example-com.s3.amazonaws.com.cn.",  # China legacy global
+        "static-example-com.s3-website.cn-north-1.amazonaws.com.cn.",  # China website
         "Static-Example-Com.S3.Us-East-1.Amazonaws.Com.",
     ]
     non_s3_cnames = [
@@ -269,8 +278,17 @@ def test_s3_fingerprint_matches_only_s3_endpoints(mock_enum, mock_resolver_class
         "my-alb-1234567890.us-east-1.elb.amazonaws.com.",  # Elastic Load Balancing
         "dualstack.my-alb-1234567890.us-west-2.elb.amazonaws.com.",  # ELB dualstack
         "ABC123DEF4.EXECUTE-API.US-EAST-1.AMAZONAWS.COM.",  # uppercase API Gateway
+        "123456789012.s3-control.us-east-1.amazonaws.com.",  # S3 Control
+        "my-ap-123456789012.s3-accesspoint.us-east-1.amazonaws.com.",  # access point
+        "my-olap-123456789012.s3-object-lambda.us-east-1.amazonaws.com.",  # Object Lambda
+        "my-ap-123456789012.s3-outposts.us-east-1.amazonaws.com.",  # S3 on Outposts
+        "bucket-base--use1-az5--x-s3.s3express-use1-az5.us-east-1.amazonaws.com.",  # S3 Express zonal
+        "s3express-control.us-east-1.amazonaws.com.",  # S3 Express control
+        "static-example-com.s3.not-a-real-region.amazonaws.com.",  # fabricated region token
+        "static-example-com.s3-website.dualstack.us-east-1.amazonaws.com.",  # website has no dual-stack form
     ]
 
+    failures = []
     for cname, is_s3 in [(c, True) for c in s3_cnames] + [(c, False) for c in non_s3_cnames]:
         mock_get.reset_mock()
         resolver.resolve.return_value = [_cname_record(cname)]
@@ -283,14 +301,24 @@ def test_s3_fingerprint_matches_only_s3_endpoints(mock_enum, mock_resolver_class
 
         assert result["success"] is True
         if is_s3:
-            assert result["total_vulnerable"] == 1, f"{cname} is an actual S3 endpoint and must match"
-            assert result["vulnerable"][0]["service"] == "AWS S3"
-            assert result["vulnerable"][0]["cname"] == cname.rstrip(".")
-            assert mock_get.call_count == 1
+            matched = (
+                result["total_vulnerable"] == 1
+                and result["vulnerable"][0]["service"] == "AWS S3"
+                and result["vulnerable"][0]["cname"] == cname.rstrip(".")
+                and mock_get.call_count == 1
+            )
+            if not matched:
+                failures.append(f"actual S3 bucket endpoint must match and be probed: {cname}")
         else:
-            assert result["vulnerable"] == [], f"{cname} is not an S3 endpoint and must not match"
-            assert result["safe"] == ["static.example.com"]
-            mock_get.assert_not_called()
+            ignored = (
+                result["vulnerable"] == []
+                and result["safe"] == ["static.example.com"]
+                and mock_get.call_count == 0
+            )
+            if not ignored:
+                failures.append(f"non-bucket endpoint must not match or be probed: {cname}")
+
+    assert failures == [], "wrong AWS S3 fingerprint selection:\n" + "\n".join(failures)
 
 
 @patch("tools.subdomain_takeover_tool.dns_enumeration")

--- a/tests/test_subdomain_takeover.py
+++ b/tests/test_subdomain_takeover.py
@@ -270,6 +270,8 @@ def test_s3_fingerprint_matches_only_s3_endpoints(mock_enum, mock_resolver_class
         "static-example-com.s3.cn-north-1.amazonaws.com.cn.",  # China regional
         "static-example-com.s3-cn-northwest-1.amazonaws.com.cn.",  # China legacy dash
         "static-example-com.s3.amazonaws.com.cn.",  # China legacy global
+        "static-example-com.s3.dualstack.cn-north-1.amazonaws.com.cn.",  # China dual-stack
+        "static-example-com.s3.dualstack.cn-northwest-1.amazonaws.com.cn.",  # China dual-stack
         "static-example-com.s3-website.cn-north-1.amazonaws.com.cn.",  # China website
         "Static-Example-Com.S3.Us-East-1.Amazonaws.Com.",
     ]
@@ -286,6 +288,12 @@ def test_s3_fingerprint_matches_only_s3_endpoints(mock_enum, mock_resolver_class
         "s3express-control.us-east-1.amazonaws.com.",  # S3 Express control
         "static-example-com.s3.not-a-real-region.amazonaws.com.",  # fabricated region token
         "static-example-com.s3-website.dualstack.us-east-1.amazonaws.com.",  # website has no dual-stack form
+        "static-example-com.s3-fips.cn-north-1.amazonaws.com.cn.",  # China has no FIPS form
+        "static-example-com.s3-accelerate.amazonaws.com.cn.",  # China has no accelerate form
+        "static-example-com.s3-website-cn-north-1.amazonaws.com.cn.",  # China website is dot-separated only
+        "static-example-com.s3.us-east-1.amazonaws.com.evil.com.",  # lookalike suffix, not an AWS host
+        "static-example-com.s3.amazonaws.com.cn.evil.com.",  # lookalike suffix, not an AWS host
+        "nots3.amazonaws.com.",  # s3 substring inside a label, not an s3 label
     ]
 
     failures = []

--- a/tools/subdomain_takeover_tool.py
+++ b/tools/subdomain_takeover_tool.py
@@ -29,21 +29,22 @@ _AWS_REGION = r"[a-z]{2}(?:-[a-z]+)+-\d+"
 # s3.dualstack.<region>, s3-fips[.dualstack].<region>, the Transfer
 # Acceleration s3-accelerate[.dualstack] endpoints, and the
 # s3-website[.-]<region> website endpoints. The China partition documents the
-# regional, legacy dash, legacy global and s3-website.<region> forms under
-# amazonaws.com.cn. Anchoring on these keeps every other AWS service (API
-# Gateway, ELB, ...) from being matched as S3.
+# regional, legacy dash, legacy global, dual-stack and s3-website.<region>
+# forms under amazonaws.com.cn. Anchoring on these keeps every other AWS
+# service (API Gateway, ELB, ...) from being matched as S3.
 # https://docs.aws.amazon.com/general/latest/gr/s3.html
 # https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html
 # https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteEndpoints.html
 # https://docs.aws.amazon.com/AmazonS3/latest/userguide/transfer-acceleration-getting-started.html
 # https://docs.amazonaws.cn/en_us/AmazonS3/latest/userguide/VirtualHosting.html
 # https://docs.amazonaws.cn/en_us/AmazonS3/latest/userguide/static-website-hosting-china.html
+# https://github.com/boto/botocore/blob/develop/botocore/data/endpoints.json
 _S3_ENDPOINT_RE = re.compile(
     rf"(?:^|\.)(?:s3(?:[.-]{_AWS_REGION}|\.dualstack\.{_AWS_REGION})?"
     rf"|s3-fips(?:\.dualstack)?\.{_AWS_REGION}"
     rf"|s3-accelerate(?:\.dualstack)?"
     rf"|s3-website[.-]{_AWS_REGION})\.amazonaws\.com$"
-    rf"|(?:^|\.)(?:s3(?:[.-]{_AWS_REGION})?"
+    rf"|(?:^|\.)(?:s3(?:[.-]{_AWS_REGION}|\.dualstack\.{_AWS_REGION})?"
     rf"|s3-website\.{_AWS_REGION})\.amazonaws\.com\.cn$"
 )
 

--- a/tools/subdomain_takeover_tool.py
+++ b/tools/subdomain_takeover_tool.py
@@ -14,17 +14,37 @@ import requests
 from tools.dns_tool import PUBLIC_RESOLVERS, dns_enumeration
 from utils.helpers import is_valid_domain, normalize_domain
 
-# Actual S3 endpoint hosts end in an s3 service label under amazonaws.com:
-# bucket.s3.<region>, bucket.s3-<region> (legacy dash), bucket.s3 (legacy
-# global), s3.dualstack.<region>, and the s3-website[.-]<region> website
-# endpoints (https://docs.aws.amazon.com/general/latest/gr/s3.html,
-# https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteEndpoints.html,
-# https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html).
-# Anchoring on that label keeps other amazonaws.com services (API Gateway,
-# ELB, ...) from being matched as S3.
+# Region codes are matched by shape - an area prefix, alphabetic segments and a
+# trailing number - which covers commercial, GovCloud, China and ISO regions
+# (us-east-1, us-gov-west-1, cn-north-1, us-iso-east-1) without freezing a list
+# that AWS keeps extending. Matching them by shape is also what separates a
+# bucket host from the sibling s3-* endpoint families that are not buckets
+# (s3-control, s3-accesspoint, s3-object-lambda, s3-outposts, s3express-*,
+# s3tables), whose service label can never be read as a region.
+_AWS_REGION = r"[a-z]{2}(?:-[a-z]+)+-\d+"
+
+# The documented S3 bucket endpoint hosts, i.e. the ones a dangling CNAME can
+# leave answering NoSuchBucket. Under amazonaws.com: bucket.s3.<region>,
+# bucket.s3-<region> (legacy dash), bucket.s3 (legacy global),
+# s3.dualstack.<region>, s3-fips[.dualstack].<region>, the Transfer
+# Acceleration s3-accelerate[.dualstack] endpoints, and the
+# s3-website[.-]<region> website endpoints. The China partition documents the
+# regional, legacy dash, legacy global and s3-website.<region> forms under
+# amazonaws.com.cn. Anchoring on these keeps every other AWS service (API
+# Gateway, ELB, ...) from being matched as S3.
+# https://docs.aws.amazon.com/general/latest/gr/s3.html
+# https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html
+# https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteEndpoints.html
+# https://docs.aws.amazon.com/AmazonS3/latest/userguide/transfer-acceleration-getting-started.html
+# https://docs.amazonaws.cn/en_us/AmazonS3/latest/userguide/VirtualHosting.html
+# https://docs.amazonaws.cn/en_us/AmazonS3/latest/userguide/static-website-hosting-china.html
 _S3_ENDPOINT_RE = re.compile(
-    r"(?:^|\.)s3(?:-website)?(?:[.-]dualstack)?[.-][a-z0-9-]+\.amazonaws\.com$"
-    r"|(?:^|\.)s3\.amazonaws\.com$"
+    rf"(?:^|\.)(?:s3(?:[.-]{_AWS_REGION}|\.dualstack\.{_AWS_REGION})?"
+    rf"|s3-fips(?:\.dualstack)?\.{_AWS_REGION}"
+    rf"|s3-accelerate(?:\.dualstack)?"
+    rf"|s3-website[.-]{_AWS_REGION})\.amazonaws\.com$"
+    rf"|(?:^|\.)(?:s3(?:[.-]{_AWS_REGION})?"
+    rf"|s3-website\.{_AWS_REGION})\.amazonaws\.com\.cn$"
 )
 
 # (cname_contains or cname_pattern, service, takeover indicator)

--- a/tools/subdomain_takeover_tool.py
+++ b/tools/subdomain_takeover_tool.py
@@ -6,18 +6,33 @@ fingerprints (GitHub Pages, Heroku, S3, Azure, Ghost, Shopify, Fastly), and
 confirms the takeover with an HTTP request checking for the service's
 takeover-indicating response.
 """
+import re
+
 import dns.resolver
 import requests
 
 from tools.dns_tool import PUBLIC_RESOLVERS, dns_enumeration
 from utils.helpers import is_valid_domain, normalize_domain
 
-# (cname_contains, service, takeover indicator)
+# Actual S3 endpoint hosts end in an s3 service label under amazonaws.com:
+# bucket.s3.<region>, bucket.s3-<region> (legacy dash), bucket.s3 (legacy
+# global), s3.dualstack.<region>, and the s3-website[.-]<region> website
+# endpoints (https://docs.aws.amazon.com/general/latest/gr/s3.html,
+# https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteEndpoints.html,
+# https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html).
+# Anchoring on that label keeps other amazonaws.com services (API Gateway,
+# ELB, ...) from being matched as S3.
+_S3_ENDPOINT_RE = re.compile(
+    r"(?:^|\.)s3(?:-website)?(?:[.-]dualstack)?[.-][a-z0-9-]+\.amazonaws\.com$"
+    r"|(?:^|\.)s3\.amazonaws\.com$"
+)
+
+# (cname_contains or cname_pattern, service, takeover indicator)
 # indicator key "status" matches on the HTTP status code, "body" on response text.
 VULNERABLE_FINGERPRINTS = [
     {"cname_contains": "github.io", "service": "GitHub Pages", "indicator": {"body": "There isn't a GitHub Pages site here."}},
     {"cname_contains": "herokuapp.com", "service": "Heroku", "indicator": {"body": "No such app"}},
-    {"cname_contains": "amazonaws.com", "service": "AWS S3", "indicator": {"body": "NoSuchBucket"}},
+    {"cname_pattern": _S3_ENDPOINT_RE, "service": "AWS S3", "indicator": {"body": "NoSuchBucket"}},
     {"cname_contains": "azurewebsites.net", "service": "Azure", "indicator": {"body": "404 Web Site not found"}},
     {"cname_contains": "ghost.io", "service": "Ghost", "indicator": {"body": "404 Domain Not Found"}},
     {"cname_contains": "myshopify.com", "service": "Shopify", "indicator": {"body": "Sorry, this shop"}},
@@ -46,9 +61,13 @@ def _resolve_cname(subdomain: str, resolver) -> str | None:
 
 
 def _match_fingerprint(cname: str) -> dict | None:
-    cname = cname.lower()
+    cname = cname.lower().rstrip(".")
     for fingerprint in VULNERABLE_FINGERPRINTS:
-        if fingerprint["cname_contains"] in cname:
+        pattern = fingerprint.get("cname_pattern")
+        if pattern is not None:
+            if pattern.search(cname):
+                return fingerprint
+        elif fingerprint["cname_contains"] in cname:
             return fingerprint
     return None
 


### PR DESCRIPTION
## Closes

Partially addresses #154 (item 4)

## Summary

The AWS S3 takeover fingerprint matched any CNAME containing `amazonaws.com`, so API Gateway, ELB and other AWS services were fingerprinted as S3. It now matches only the documented S3 *bucket* endpoint hosts — the ones a dangling CNAME can actually leave answering `NoSuchBucket`.

## What changed

- `tools/subdomain_takeover_tool.py`: the S3 entry's `cname_contains: "amazonaws.com"` becomes a `cname_pattern` regex covering the documented bucket endpoint families — under `amazonaws.com`: virtual-hosted regional, legacy dash, legacy global, dual-stack, FIPS (± dual-stack), Transfer Acceleration (± dual-stack), and both website forms; under `amazonaws.com.cn`: regional, legacy dash, legacy global, dual-stack, and website. Sources are linked in the code comment.
- Regions are matched by shape (`us-east-1`, `us-gov-west-1`, `cn-north-1`, `us-iso-east-1`) rather than an enumeration, so the fingerprint does not go stale as AWS adds regions.
- The pattern is anchored on a label boundary and on the end of the host, so `s3` inside a longer label (`nots3.amazonaws.com`) and lookalike suffixes (`...s3.us-east-1.amazonaws.com.evil.com`) do not match.
- `_match_fingerprint` accepts `cname_pattern` alongside the existing `cname_contains` and strips the trailing dot before matching. Every other fingerprint is untouched, and the resolved CNAME reported in the result keeps its original casing.
- `tests/test_subdomain_takeover.py`: one test asserting selection over 18 hosts that must match and 18 that must not — non-S3 AWS services (API Gateway, ELB), the sibling `s3-*` endpoints that are not buckets (`s3-control`, `s3-accesspoint`, `s3-object-lambda`, `s3-outposts`, `s3express-*`), fabricated region tokens, endpoint forms AWS does not document for a given partition, and the label/suffix evasions above.

## Notes

- The sibling `s3-*` endpoints are excluded deliberately: they are not buckets and never answer `NoSuchBucket`, so matching them would reproduce the same false positive in a narrower shape.
- The China partition documents fewer forms than the commercial one (no FIPS, no Transfer Acceleration, website is dot-separated only). Those are rejected rather than accepted for symmetry, and the tests pin that.
- Shape-matched regions mean a syntactically valid but nonexistent region still matches; the narrowing here comes from anchoring on endpoint families, not from validating region names.
- Scope is item 4 only — the other items in #154 are untouched.

## Verification

- [x] Ran locally and confirmed it works as expected
- [x] Added/updated tests for the changed behavior
- [x] All tests pass (`pytest tests/ -v`)
- [x] No unrelated changes included
- [x] Checked `CONTRIBUTING.md` and applied all changes
- [x] Updated Documentation ( if required ) — none required

The full suite ran on a GitHub runner against this branch head (run `31689494665`), whose log records the checked-out SHA as `409a8c6d6caa3c8aa2891ca4edbd77e76d1d0961`: **313 passed, 15 subtests passed**. The new node `tests/test_subdomain_takeover.py::test_s3_fingerprint_matches_only_s3_endpoints` passes, driving all 36 hosts through the tool's real resolution path.

Generated by GPT-5.6 Sol (brief, review), Kimi K3 (implementation, verification), Claude Opus 5 (implementation, verification, testing, fork CI)
