### PR TITLE
chore(subdomain-takeover): trim the S3 endpoint comments to strategy and rationale

### DIFF
--- a/tools/subdomain_takeover_tool.py
+++ b/tools/subdomain_takeover_tool.py
@@ -14,24 +14,15 @@ import requests
 from tools.dns_tool import PUBLIC_RESOLVERS, dns_enumeration
 from utils.helpers import is_valid_domain, normalize_domain
 
-# Region codes are matched by shape - an area prefix, alphabetic segments and a
-# trailing number - which covers commercial, GovCloud, China and ISO regions
-# (us-east-1, us-gov-west-1, cn-north-1, us-iso-east-1) without freezing a list
-# that AWS keeps extending. Matching them by shape is also what separates a
-# bucket host from the sibling s3-* endpoint families that are not buckets
-# (s3-control, s3-accesspoint, s3-object-lambda, s3-outposts, s3express-*,
-# s3tables), whose service label can never be read as a region.
+# Match region labels by shape rather than a fixed list so newly added AWS
+# regions stay covered. Keeping service-specific labels out of this slot
+# prevents non-bucket AWS endpoints from being interpreted as bucket regions.
 _AWS_REGION = r"[a-z]{2}(?:-[a-z]+)+-\d+"
 
-# The documented S3 bucket endpoint hosts, i.e. the ones a dangling CNAME can
-# leave answering NoSuchBucket. Under amazonaws.com: bucket.s3.<region>,
-# bucket.s3-<region> (legacy dash), bucket.s3 (legacy global),
-# s3.dualstack.<region>, s3-fips[.dualstack].<region>, the Transfer
-# Acceleration s3-accelerate[.dualstack] endpoints, and the
-# s3-website[.-]<region> website endpoints. The China partition documents the
-# regional, legacy dash, legacy global, dual-stack and s3-website.<region>
-# forms under amazonaws.com.cn. Anchoring on these keeps every other AWS
-# service (API Gateway, ELB, ...) from being matched as S3.
+# Restrict the fingerprint to documented S3 bucket endpoint families that can
+# return NoSuchBucket for an unclaimed bucket. Anchoring the hostname prevents
+# unrelated AWS services from being treated as S3.
+# References:
 # https://docs.aws.amazon.com/general/latest/gr/s3.html
 # https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html
 # https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteEndpoints.html


### PR DESCRIPTION
## Closes

Relates to #159 — follow-up requested in review, closes nothing.

## Summary

Shortens the inline comments around the S3 endpoint regex so they carry the matching strategy and the rationale rather than enumerating endpoint-specific behaviour the regression tests already pin. No behaviour change.

## What changed

- `tools/subdomain_takeover_tool.py`: the region comment now states why region labels are matched by shape (new AWS regions stay covered without freezing a list) and why service-specific labels must stay out of that slot, instead of listing the individual region and `s3-*` family examples.
- `tools/subdomain_takeover_tool.py`: the endpoint comment now states the rule being applied — restrict to documented S3 bucket endpoint families that can answer `NoSuchBucket`, and anchor the hostname so unrelated AWS services are not treated as S3 — instead of inventorying each accepted form per partition. The AWS documentation URLs are kept, now under an explicit `References:` label.
- Net 7 insertions, 16 deletions, one file. No executable line changed.

## Notes

- Motivation: your review on #159 — https://github.com/AynOps/AynOps/pull/159#pullrequestreview-4942976019
- Comments only: the parsed AST and the non-comment token stream are identical before and after, so the fingerprint's behaviour cannot have changed by this commit.
- Deliberately kept rather than trimmed: why the pattern is anchored on documented bucket endpoint forms at all, and why non-bucket AWS endpoint families must not match. Those are the parts a reader cannot recover from the test names, so they stayed even though they are the longest surviving lines. If you would rather they went too, say so and I will cut them.
- No tests were added or changed: nothing behavioural changed, and the existing S3 matrix in `tests/test_subdomain_takeover.py` already drives both the accepted S3 endpoints and the rejected non-S3 ones.

## Verification

- [x] Ran locally and confirmed it works as expected
- [ ] Added/updated tests for the changed behavior
- [x] All tests pass (`pytest tests/ -v`)
- [x] No unrelated changes included
- [x] Checked `CONTRIBUTING.md` and applied all changes
- [ ] Updated Documentation ( if required )

`pytest tests/test_subdomain_takeover.py` locally: 11 passed. Full `pytest tests/ -v` green on CI against this branch's head `ed415088c7f3a74001c46601b134abbdafc913bd`.

The two unchecked boxes are unchecked on purpose. No test was added because no behaviour changed — a test asserting comment text would pin formatting, not behaviour. No documentation update was required: `CONTRIBUTING.md`'s documentation steps cover adding a tool to the README and `mcp.json`, and this touches neither.

Generated by Claude Opus 5 (brief, review), GPT-5.6-Luna (implementation), GPT-5.6-Sol (verification)
