### PR TITLE
refactor(techstack): extract the technology fingerprinting engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,9 @@ Intended for:
 ├── .github/              # GitHub Actions workflows and templates
 ├── tests/                # Unit tests
 ├── tools/                # MCP tool implementations
+  ├── fingerprint/        # Technology fingerprinting engine used by tech_stack_detect
+    ├── signatures.py     # Signature tables (CDN, CMS, JS frameworks, analytics)
+    └── engine.py         # Detection layers and the fingerprint() entry point
   ├── prompts/            # AI prompt templates
   ├── signals/            # Signal extraction framework used by full_recon
     ├── registry.py       # Registers tools and their signal extractors

--- a/tests/test_fingerprint_engine.py
+++ b/tests/test_fingerprint_engine.py
@@ -1,0 +1,77 @@
+import unittest
+
+from tools.fingerprint import fingerprint
+from tools.fingerprint.engine import headers_layer, html_layer
+from tools.fingerprint.signatures import (
+    ANALYTICS_SIGNATURES,
+    CDN_SIGNATURES,
+    CMS_SIGNATURES,
+    JS_SIGNATURES,
+)
+
+
+class TestFingerprintEngine(unittest.TestCase):
+    """Contract of the I/O-free fingerprinting seam.
+
+    fingerprint() owns the normalisation (lowercased header names, lowercased
+    body) that the tool used to do inline, so callers hand it raw response
+    headers and raw response text.
+    """
+
+    def test_fingerprint_returns_the_full_technology_map(self):
+        result = fingerprint(
+            {"Server": "nginx/1.18", "X-Powered-By": "PHP/8.1", "CF-RAY": "abc123"},
+            '<LINK HREF="/WP-CONTENT/X.CSS"><SCRIPT SRC="/_NEXT/STATIC/A.JS"></SCRIPT>'
+            '<SCRIPT SRC="HTTPS://GOOGLE-ANALYTICS.COM/GA.JS"></SCRIPT>',
+        )
+
+        self.assertEqual(
+            result,
+            {
+                "web_server": "nginx/1.18",
+                "powered_by": "PHP/8.1",
+                "cdn": ["Cloudflare"],
+                "cms": ["WordPress"],
+                "javascript_frameworks": ["Next.js"],
+                "analytics": ["Google Analytics"],
+            },
+        )
+        self.assertEqual(
+            list(result.keys()),
+            [
+                "web_server",
+                "powered_by",
+                "cdn",
+                "cms",
+                "javascript_frameworks",
+                "analytics",
+            ],
+        )
+
+    def test_fingerprint_omits_categories_that_match_nothing(self):
+        self.assertEqual(fingerprint({}, ""), {})
+        self.assertEqual(fingerprint({"Server": "nginx"}, ""), {"web_server": "nginx"})
+
+    def test_layers_are_independent(self):
+        self.assertEqual(
+            headers_layer({"Server": "nginx", "CF-Ray": "x"}),
+            {"web_server": "nginx", "cdn": ["Cloudflare"]},
+        )
+        self.assertEqual(html_layer("WP-CONTENT"), {"cms": ["WordPress"]})
+        self.assertEqual(headers_layer({}), {})
+        self.assertEqual(html_layer(""), {})
+
+    def test_signature_tables_are_intact(self):
+        self.assertEqual(len(CDN_SIGNATURES), 6)
+        self.assertEqual(len(CMS_SIGNATURES), 7)
+        self.assertEqual(len(JS_SIGNATURES), 8)
+        self.assertEqual(len(ANALYTICS_SIGNATURES), 6)
+        self.assertEqual(CDN_SIGNATURES["Cloudflare"], ["cf-ray", "cf-cache-status"])
+        self.assertEqual(
+            ANALYTICS_SIGNATURES["Google Analytics"],
+            ["google-analytics.com", "gtag(", "ga("],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_tech_stack_detect.py
+++ b/tests/test_tech_stack_detect.py
@@ -1,5 +1,8 @@
 import unittest
 from unittest.mock import Mock, MagicMock, patch, call
+
+import requests
+
 from tools.techstack_tool import tech_stack_detect
 
 class TestTechStackDetect(unittest.TestCase):
@@ -73,6 +76,243 @@ class TestTechStackDetect(unittest.TestCase):
     def test_connection_error_caught(self, _):
         result = tech_stack_detect("example.com")
         self.assertFalse(result["success"])
+
+
+# ---------------------------------------------------------------------------
+# Characterization tests.
+#
+# These pin the *current* observable behaviour of tech_stack_detect(), warts
+# included, so that moving the signature tables and match loops out of the tool
+# body can be proven byte-for-byte behaviour preserving. They are written
+# against the unmodified implementation and must stay green, unchanged, across
+# the extraction. A failure here means behaviour moved, not that the
+# expectation is wrong.
+#
+# The signature tables below are an independent restatement of the tables the
+# tool matches against; if the moved copy ever drifts, these tests fail.
+# ---------------------------------------------------------------------------
+
+CDN_HEADER_SIGNATURES = {
+    "Cloudflare": ["cf-ray", "cf-cache-status"],
+    "Fastly": ["x-fastly-request-id"],
+    "Akamai": ["x-akamai-transformed"],
+    "AWS CloudFront": ["x-amz-cf-id"],
+    "Vercel": ["x-vercel-id"],
+    "Netlify": ["x-nf-request-id"],
+}
+
+CMS_HTML_SIGNATURES = {
+    "WordPress": ["wp-content", "wp-includes", "wordpress"],
+    "Drupal": ["drupal.js", "drupal.min.js", "/sites/default/files"],
+    "Joomla": ["/media/jui/", "joomla"],
+    "Shopify": ["cdn.shopify.com", "shopify.com/s/files"],
+    "Wix": ["wix.com", "wixstatic.com"],
+    "Squarespace": ["squarespace.com", "static.squarespace.com"],
+    "Ghost": ["ghost.io", "content/themes/ghost"],
+}
+
+JS_HTML_SIGNATURES = {
+    "React": ["react.js", "react.min.js", "_react", "__react"],
+    "Vue.js": ["vue.js", "vue.min.js", "__vue__"],
+    "Angular": ["angular.js", "ng-version", "angular/core"],
+    "Next.js": ["_next/static", "__next"],
+    "Nuxt.js": ["_nuxt/", "__nuxt"],
+    "jQuery": ["jquery.js", "jquery.min.js"],
+    "Bootstrap": ["bootstrap.css", "bootstrap.min.css", "bootstrap.js"],
+    "Tailwind": ["tailwindcss", "tailwind.css"],
+}
+
+ANALYTICS_HTML_SIGNATURES = {
+    "Google Analytics": ["google-analytics.com", "gtag(", "ga("],
+    "Google Tag Manager": ["googletagmanager.com"],
+    "Hotjar": ["hotjar.com"],
+    "Mixpanel": ["mixpanel.com"],
+    "Segment": ["segment.com", "analytics.js"],
+    "Facebook Pixel": ["connect.facebook.net/en_us/fbevents"],
+}
+
+TECHNOLOGY_KEY_ORDER = [
+    "web_server",
+    "powered_by",
+    "cdn",
+    "cms",
+    "javascript_frameworks",
+    "analytics",
+]
+
+
+def make_response(html="", headers=None, url="https://example.com", status=200):
+    """Build a mock requests response.
+
+    Unlike TestTechStackDetect._make_response this honours an *empty* header
+    mapping instead of substituting defaults, which the signature sweeps need.
+    """
+    resp = Mock()
+    resp.text = html
+    resp.headers = {} if headers is None else headers
+    resp.url = url
+    resp.status_code = status
+    return resp
+
+
+class TestTechStackDetectCharacterization(unittest.TestCase):
+
+    def _detect(self, **kwargs):
+        with patch("tools.techstack_tool.requests.get") as mock_get:
+            mock_get.return_value = make_response(**kwargs)
+            return tech_stack_detect("example.com")
+
+    # ── the empty case: categories are omitted, not emptied ──
+
+    def test_empty_page_yields_empty_technologies(self):
+        result = self._detect(html="", headers={})
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["technologies"], {})
+        self.assertEqual(
+            set(result.keys()),
+            {"success", "domain", "url", "status_code", "technologies"},
+        )
+
+    # ── every entry of every signature table ──
+
+    def test_all_cdn_signature_headers_detected(self):
+        for name, header_names in CDN_HEADER_SIGNATURES.items():
+            for header_name in header_names:
+                with self.subTest(cdn=name, header=header_name):
+                    result = self._detect(html="", headers={header_name: "value"})
+                    self.assertEqual(result["technologies"], {"cdn": [name]})
+
+    def test_all_cms_signature_strings_detected(self):
+        for name, signatures in CMS_HTML_SIGNATURES.items():
+            for signature in signatures:
+                with self.subTest(cms=name, signature=signature):
+                    result = self._detect(html=signature, headers={})
+                    self.assertEqual(result["technologies"], {"cms": [name]})
+
+    def test_all_javascript_signature_strings_detected(self):
+        for name, signatures in JS_HTML_SIGNATURES.items():
+            for signature in signatures:
+                with self.subTest(framework=name, signature=signature):
+                    result = self._detect(html=signature, headers={})
+                    self.assertEqual(
+                        result["technologies"], {"javascript_frameworks": [name]}
+                    )
+
+    def test_all_analytics_signature_strings_detected(self):
+        for name, signatures in ANALYTICS_HTML_SIGNATURES.items():
+            for signature in signatures:
+                with self.subTest(analytics=name, signature=signature):
+                    result = self._detect(html=signature, headers={})
+                    self.assertEqual(result["technologies"], {"analytics": [name]})
+
+    # ── shape of a fully populated result ──
+
+    def test_technology_key_order_is_stable(self):
+        result = self._detect(
+            html='<link href="/wp-content/x.css"><script src="/_next/static/a.js">'
+                 '</script><script src="https://google-analytics.com/ga.js"></script>',
+            headers={
+                "server": "nginx/1.18",
+                "x-powered-by": "PHP/8.1",
+                "cf-ray": "abc123",
+            },
+        )
+
+        self.assertEqual(list(result["technologies"].keys()), TECHNOLOGY_KEY_ORDER)
+        self.assertEqual(
+            result["technologies"],
+            {
+                "web_server": "nginx/1.18",
+                "powered_by": "PHP/8.1",
+                "cdn": ["Cloudflare"],
+                "cms": ["WordPress"],
+                "javascript_frameworks": ["Next.js"],
+                "analytics": ["Google Analytics"],
+            },
+        )
+
+    def test_multiple_matches_within_a_category_keep_table_order(self):
+        result = self._detect(
+            html="wp-content joomla wixstatic.com",
+            headers={"cf-ray": "a", "x-vercel-id": "b", "x-nf-request-id": "c"},
+        )
+
+        self.assertEqual(result["technologies"]["cdn"], ["Cloudflare", "Vercel", "Netlify"])
+        self.assertEqual(result["technologies"]["cms"], ["WordPress", "Joomla", "Wix"])
+
+    # ── normalisation ──
+
+    def test_matching_is_case_insensitive(self):
+        upper = self._detect(
+            html='<LINK HREF="/WP-CONTENT/X.CSS"><SCRIPT SRC="/_NEXT/STATIC/A.JS">'
+                 '</SCRIPT><SCRIPT SRC="HTTPS://GOOGLE-ANALYTICS.COM/GA.JS"></SCRIPT>',
+            headers={"Server": "nginx/1.18", "X-Powered-By": "PHP/8.1", "CF-RAY": "abc123"},
+        )
+
+        self.assertEqual(
+            upper["technologies"],
+            {
+                "web_server": "nginx/1.18",
+                "powered_by": "PHP/8.1",
+                "cdn": ["Cloudflare"],
+                "cms": ["WordPress"],
+                "javascript_frameworks": ["Next.js"],
+                "analytics": ["Google Analytics"],
+            },
+        )
+
+    def test_header_values_are_not_lowercased(self):
+        result = self._detect(html="", headers={"Server": "Apache/2.4 (Ubuntu)"})
+
+        self.assertEqual(result["technologies"]["web_server"], "Apache/2.4 (Ubuntu)")
+
+    # ── known false positives: pinned deliberately, NOT fixed here ──
+
+    def test_bare_substring_false_positives_are_preserved(self):
+        # Issue #130 "Current Problems" §3 calls these out as real false
+        # positives. They are pinned here so that fixing them is a visible,
+        # separately reviewed behaviour change rather than a silent side
+        # effect of moving the tables into the fingerprinting engine.
+        saga = self._detect(html="the saga(s) of vega(1)", headers={})
+        self.assertEqual(saga["technologies"], {"analytics": ["Google Analytics"]})
+
+        # "wix.com" matches inside an unrelated word, and Segment's
+        # "analytics.js" matches any script with that filename.
+        prose = self._detect(html="phoenix.community and /js/analytics.js", headers={})
+        self.assertEqual(prose["technologies"], {"analytics": ["Segment"]})
+
+    # ── passthrough and error paths ──
+
+    def test_url_and_status_code_passthrough(self):
+        result = self._detect(
+            html="", headers={}, url="https://www.example.com/landing", status=418
+        )
+
+        self.assertEqual(result["url"], "https://www.example.com/landing")
+        self.assertEqual(result["status_code"], 418)
+        self.assertEqual(result["domain"], "example.com")
+
+    @patch(
+        "tools.techstack_tool.requests.get",
+        side_effect=requests.exceptions.SSLError("certificate verify failed"),
+    )
+    def test_ssl_error_message(self, _):
+        result = tech_stack_detect("example.com")
+
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error"], "SSL error: certificate verify failed")
+
+    @patch(
+        "tools.techstack_tool.requests.get",
+        side_effect=requests.exceptions.ConnectionError("boom"),
+    )
+    def test_connection_error_message(self, _):
+        result = tech_stack_detect("example.com")
+
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error"], "Could not connect to the domain")
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_tech_stack_detect.py
+++ b/tests/test_tech_stack_detect.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, MagicMock, patch, call
 
 import requests
 
+from tools.fingerprint import fingerprint
 from tools.techstack_tool import tech_stack_detect
 
 class TestTechStackDetect(unittest.TestCase):
@@ -71,6 +72,40 @@ class TestTechStackDetect(unittest.TestCase):
         )
         self.assertEqual(result["technologies"]["web_server"], "nginx/1.18")
         self.assertIn("WordPress", result["technologies"]["cms"])
+
+    @patch("tools.techstack_tool.requests.get")
+    def test_fingerprints_response_state_at_fetch_time(self, mock_get):
+        initial_headers = {"server": "nginx/1.18"}
+        initial_text = "plain response body"
+        expected = fingerprint(initial_headers, initial_text)
+
+        class ResponseWithReadMutation:
+            def __init__(self):
+                self.headers = dict(initial_headers)
+                self.text = initial_text
+                self._status_code = 200
+
+            @property
+            def url(self):
+                self.headers["cf-ray"] = "injected-by-url-read"
+                self.text += " /wp-content/"
+                return "https://example.com"
+
+            @property
+            def status_code(self):
+                return self._status_code
+
+        mock_get.return_value = ResponseWithReadMutation()
+
+        result = tech_stack_detect("example.com")
+
+        # Derive the expectation from the response state handed to the fetch,
+        # rather than hard-coding what this mutating response happens to yield.
+        self.assertEqual(
+            result["technologies"],
+            expected,
+            "fingerprint must use headers/text as fetched, before assembly reads",
+        )
 
     @patch("tools.techstack_tool.requests.get", side_effect=Exception("Connection refused"))
     def test_connection_error_caught(self, _):

--- a/tests/test_tech_stack_detect.py
+++ b/tests/test_tech_stack_detect.py
@@ -107,6 +107,49 @@ class TestTechStackDetect(unittest.TestCase):
             "fingerprint must use headers/text as fetched, before assembly reads",
         )
 
+    @patch("tools.techstack_tool.requests.get")
+    def test_fingerprints_headers_snapshot_before_text_read(self, mock_get):
+        # The response double's `text` getter mutates the headers mapping when
+        # read. The caller must snapshot the headers before touching `text`,
+        # so the fingerprint reflects the response state at fetch time.
+        initial_headers = {"server": "nginx/1.18", "x-powered-by": "PHP/8.1"}
+        initial_text = "plain response body"
+        expected = fingerprint(initial_headers, initial_text)
+
+        class TextReadMutatesHeaders:
+            def __init__(self, mutate):
+                self.headers = dict(initial_headers)
+                self.url = "https://example.com"
+                self.status_code = 200
+                self._mutate = mutate
+
+            @property
+            def text(self):
+                self._mutate(self.headers)
+                return initial_text
+
+        # Reading `text` ADDS a header.
+        mock_get.return_value = TextReadMutatesHeaders(
+            lambda headers: headers.update({"cf-ray": "injected-by-text-read"})
+        )
+        result = tech_stack_detect("example.com")
+        self.assertEqual(
+            result["technologies"],
+            expected,
+            "header added by the text read must not leak into the fingerprint",
+        )
+
+        # Reading `text` DELETES a header.
+        mock_get.return_value = TextReadMutatesHeaders(
+            lambda headers: headers.pop("x-powered-by")
+        )
+        result = tech_stack_detect("example.com")
+        self.assertEqual(
+            result["technologies"],
+            expected,
+            "header deleted by the text read must not leak into the fingerprint",
+        )
+
     @patch("tools.techstack_tool.requests.get", side_effect=Exception("Connection refused"))
     def test_connection_error_caught(self, _):
         result = tech_stack_detect("example.com")

--- a/tests/test_tech_stack_detect.py
+++ b/tests/test_tech_stack_detect.py
@@ -313,6 +313,24 @@ class TestTechStackDetectCharacterization(unittest.TestCase):
         self.assertFalse(result["success"])
         self.assertEqual(result["error"], "Could not connect to the domain")
 
+    # ── the seam ──
+
+    @patch("tools.techstack_tool.fingerprint")
+    @patch("tools.techstack_tool.requests.get")
+    def test_detection_is_delegated_to_the_fingerprint_engine(
+        self, mock_get, mock_fingerprint
+    ):
+        headers = {"Server": "nginx/1.18"}
+        html = "<html>/wp-content/</html>"
+        mock_get.return_value = make_response(html=html, headers=headers)
+        mock_fingerprint.return_value = {"sentinel": True}
+
+        result = tech_stack_detect("example.com")
+
+        # raw headers and raw text: normalisation belongs to the engine
+        mock_fingerprint.assert_called_once_with(headers, html)
+        self.assertEqual(result["technologies"], {"sentinel": True})
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_tech_stack_detect.py
+++ b/tests/test_tech_stack_detect.py
@@ -6,6 +6,30 @@ import requests
 from tools.fingerprint import fingerprint
 from tools.techstack_tool import tech_stack_detect
 
+
+class ItemsDrainedHeaders:
+    """Headers mapping that drains correctly only via ``.items()``.
+
+    ``dict(mapping)`` drains through ``keys()`` + ``__getitem__``; this
+    double raises on ``__getitem__``. A caller that snapshots headers with
+    ``dict(resp.headers)`` therefore fails before the body is ever read,
+    while the base's ``{k.lower(): v for k, v in resp.headers.items()}``
+    drain succeeds.
+    """
+
+    def __init__(self, data):
+        self._data = dict(data)
+
+    def items(self):
+        return list(self._data.items())
+
+    def keys(self):
+        return list(self._data.keys())
+
+    def __getitem__(self, key):
+        raise KeyError(key)
+
+
 class TestTechStackDetect(unittest.TestCase):
 
     def _make_response(self, html="", headers=None, url="https://example.com", status=200):
@@ -149,6 +173,58 @@ class TestTechStackDetect(unittest.TestCase):
             expected,
             "header deleted by the text read must not leak into the fingerprint",
         )
+
+    @patch("tools.techstack_tool.requests.get")
+    def test_snapshot_uses_items_drain_before_mutating_text_read(self, mock_get):
+        # The headers mapping only drains via .items(); the text getter then
+        # mutates the mapping. The caller must build the normalised snapshot
+        # with an .items() drain BEFORE touching `text`, exactly as the base
+        # implementation did.
+        initial_headers = {"server": "nginx/1.18", "x-powered-by": "PHP/8.1"}
+        initial_text = "plain response body"
+        expected = fingerprint(initial_headers, initial_text)
+
+        class TextReadMutatesItemsDrainedHeaders:
+            def __init__(self):
+                self.headers = ItemsDrainedHeaders(initial_headers)
+                self.url = "https://example.com"
+                self.status_code = 200
+
+            @property
+            def text(self):
+                self.headers._data["cf-ray"] = "injected-by-text-read"
+                return initial_text
+
+        mock_get.return_value = TextReadMutatesItemsDrainedHeaders()
+        result = tech_stack_detect("example.com")
+
+        self.assertTrue(result["success"])
+        self.assertEqual(
+            result["technologies"],
+            expected,
+            "header added by the text read must not leak into the fingerprint",
+        )
+
+    @patch("tools.techstack_tool.requests.get")
+    def test_text_read_error_is_reported_not_snapshot_error(self, mock_get):
+        # The headers mapping only drains via .items(); the text getter
+        # raises. Base snapshots the headers first and then surfaces the
+        # text-read error; the caller must not fail earlier on the snapshot.
+        class TextReadRaises:
+            def __init__(self):
+                self.headers = ItemsDrainedHeaders({"server": "nginx/1.18"})
+                self.url = "https://example.com"
+                self.status_code = 200
+
+            @property
+            def text(self):
+                raise RuntimeError("body decode exploded")
+
+        mock_get.return_value = TextReadRaises()
+        result = tech_stack_detect("example.com")
+
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error"], "body decode exploded")
 
     @patch("tools.techstack_tool.requests.get", side_effect=Exception("Connection refused"))
     def test_connection_error_caught(self, _):
@@ -405,8 +481,9 @@ class TestTechStackDetectCharacterization(unittest.TestCase):
 
         result = tech_stack_detect("example.com")
 
-        # raw headers and raw text: normalisation belongs to the engine
-        mock_fingerprint.assert_called_once_with(headers, html)
+        # normalised headers and raw text: the caller owns the header-name
+        # snapshot/normalisation, the engine owns the body normalisation
+        mock_fingerprint.assert_called_once_with({"server": "nginx/1.18"}, html)
         self.assertEqual(result["technologies"], {"sentinel": True})
 
 

--- a/tools/fingerprint/__init__.py
+++ b/tools/fingerprint/__init__.py
@@ -1,0 +1,5 @@
+"""Technology fingerprinting engine used by the tech_stack_detect tool."""
+
+from tools.fingerprint.engine import fingerprint
+
+__all__ = ["fingerprint"]

--- a/tools/fingerprint/engine.py
+++ b/tools/fingerprint/engine.py
@@ -1,0 +1,88 @@
+"""Technology fingerprinting engine.
+
+Pure and I/O-free: it is handed an already-fetched response's headers and body
+and returns the technologies it recognises. Fetching, error handling and
+response assembly stay with the calling tool.
+
+Detection is organised as independent layers, each contributing its own keys to
+one shared result map. Adding a layer (cookies, <meta name="generator">, asset
+URLs) means adding a table to signatures.py, a layer function here, and one
+line in fingerprint().
+"""
+
+from tools.fingerprint.signatures import (
+    ANALYTICS_SIGNATURES,
+    CDN_SIGNATURES,
+    CMS_SIGNATURES,
+    JS_SIGNATURES,
+)
+
+
+def _matching(signatures: dict, predicate) -> list:
+    """Names from a signature table whose markers satisfy ``predicate``.
+
+    Table order is preserved, which is what makes the tool's output order
+    stable.
+    """
+    return [
+        name for name, markers in signatures.items()
+        if any(predicate(marker) for marker in markers)
+    ]
+
+
+def headers_layer(raw_headers) -> dict:
+    """Technologies identifiable from response headers alone.
+
+    ``raw_headers`` is any mapping of header name to value; names are compared
+    case-insensitively, values are passed through unchanged.
+    """
+    headers = {k.lower(): v for k, v in raw_headers.items()}
+    found = {}
+
+    if "server" in headers:
+        found["web_server"] = headers["server"]
+
+    if "x-powered-by" in headers:
+        found["powered_by"] = headers["x-powered-by"]
+
+    cdns = _matching(CDN_SIGNATURES, lambda header: header in headers)
+    if cdns:
+        found["cdn"] = cdns
+
+    return found
+
+
+def html_layer(raw_text: str) -> dict:
+    """Technologies identifiable from the response body alone.
+
+    Markers are matched as plain substrings against a lowercased copy of the
+    body, so the body may be passed in as received.
+    """
+    html = raw_text.lower()
+    found = {}
+
+    cms = _matching(CMS_SIGNATURES, lambda sig: sig in html)
+    if cms:
+        found["cms"] = cms
+
+    frameworks = _matching(JS_SIGNATURES, lambda sig: sig in html)
+    if frameworks:
+        found["javascript_frameworks"] = frameworks
+
+    analytics = _matching(ANALYTICS_SIGNATURES, lambda sig: sig in html)
+    if analytics:
+        found["analytics"] = analytics
+
+    return found
+
+
+def fingerprint(raw_headers, raw_text: str) -> dict:
+    """Identify the technologies behind one HTTP response.
+
+    Takes the raw headers mapping and raw body text; each layer normalises what
+    it needs. Categories that match nothing are omitted rather than reported
+    empty, so an unrecognised page yields ``{}``.
+    """
+    technologies = headers_layer(raw_headers)
+    technologies.update(html_layer(raw_text))
+    return technologies

--- a/tools/fingerprint/signatures.py
+++ b/tools/fingerprint/signatures.py
@@ -1,0 +1,57 @@
+"""Signature tables for the technology fingerprinting engine.
+
+Data only, no logic. Every table maps a technology name to the list of markers
+that identify it; a technology matches when *any* of its markers matches.
+
+CDN_SIGNATURES is matched against response *header names* (presence only, the
+value is ignored). The remaining tables are matched as plain substrings against
+the lowercased response body.
+
+Dict order is part of the tool's output contract: matches are reported in the
+order the technologies appear here.
+"""
+
+# Matched against header names, lowercased. Presence only.
+CDN_SIGNATURES = {
+    "Cloudflare":     ["cf-ray", "cf-cache-status"],
+    "Fastly":         ["x-fastly-request-id"],
+    "Akamai":         ["x-akamai-transformed"],
+    "AWS CloudFront": ["x-amz-cf-id"],
+    "Vercel":         ["x-vercel-id"],
+    "Netlify":        ["x-nf-request-id"],
+}
+
+# Matched as substrings of the lowercased response body.
+CMS_SIGNATURES = {
+    "WordPress":   ["wp-content", "wp-includes", "wordpress"],
+    "Drupal":      ["drupal.js", "drupal.min.js", "/sites/default/files"],
+    "Joomla":      ["/media/jui/", "joomla"],
+    "Shopify":     ["cdn.shopify.com", "shopify.com/s/files"],
+    "Wix":         ["wix.com", "wixstatic.com"],
+    "Squarespace": ["squarespace.com", "static.squarespace.com"],
+    "Ghost":       ["ghost.io", "content/themes/ghost"],
+}
+
+JS_SIGNATURES = {
+    "React":     ["react.js", "react.min.js", "_react", "__react"],
+    "Vue.js":    ["vue.js", "vue.min.js", "__vue__"],
+    "Angular":   ["angular.js", "ng-version", "angular/core"],
+    "Next.js":   ["_next/static", "__next"],
+    "Nuxt.js":   ["_nuxt/", "__nuxt"],
+    "jQuery":    ["jquery.js", "jquery.min.js"],
+    "Bootstrap": ["bootstrap.css", "bootstrap.min.css", "bootstrap.js"],
+    "Tailwind":  ["tailwindcss", "tailwind.css"],
+}
+
+# Some of these are bare substrings that also match unrelated text - "ga(",
+# for instance, matches the word "saga(". Known, and tracked in issue #130
+# ("Current Problems"); tightening them is a behaviour change and deliberately
+# not part of the extraction that created this module.
+ANALYTICS_SIGNATURES = {
+    "Google Analytics":   ["google-analytics.com", "gtag(", "ga("],
+    "Google Tag Manager": ["googletagmanager.com"],
+    "Hotjar":             ["hotjar.com"],
+    "Mixpanel":           ["mixpanel.com"],
+    "Segment":            ["segment.com", "analytics.js"],
+    "Facebook Pixel":     ["connect.facebook.net/en_us/fbevents"],
+}

--- a/tools/techstack_tool.py
+++ b/tools/techstack_tool.py
@@ -15,7 +15,7 @@ def tech_stack_detect(domain: str) -> dict:
         url = f"https://{domain}"
         resp = requests.get(url, timeout=10, allow_redirects=True,
                             headers={"User-Agent": "Mozilla/5.0 (compatible; SecurityScanner/1.0)"})
-        technologies = fingerprint(resp.headers, resp.text)
+        technologies = fingerprint(dict(resp.headers), resp.text)
 
         return {
             "success": True,

--- a/tools/techstack_tool.py
+++ b/tools/techstack_tool.py
@@ -15,7 +15,8 @@ def tech_stack_detect(domain: str) -> dict:
         url = f"https://{domain}"
         resp = requests.get(url, timeout=10, allow_redirects=True,
                             headers={"User-Agent": "Mozilla/5.0 (compatible; SecurityScanner/1.0)"})
-        technologies = fingerprint(dict(resp.headers), resp.text)
+        headers = {k.lower(): v for k, v in resp.headers.items()}
+        technologies = fingerprint(headers, resp.text)
 
         return {
             "success": True,

--- a/tools/techstack_tool.py
+++ b/tools/techstack_tool.py
@@ -1,4 +1,5 @@
 import requests
+from tools.fingerprint import fingerprint
 from utils.helpers import is_valid_domain, normalize_domain
 
 def tech_stack_detect(domain: str) -> dict:
@@ -15,79 +16,12 @@ def tech_stack_detect(domain: str) -> dict:
         resp = requests.get(url, timeout=10, allow_redirects=True,
                             headers={"User-Agent": "Mozilla/5.0 (compatible; SecurityScanner/1.0)"})
 
-        headers = {k.lower(): v for k, v in resp.headers.items()}
-        html    = resp.text.lower()
-        tech    = {}
-
-        # ── Web Server ──
-        if "server" in headers:
-            tech["web_server"] = headers["server"]
-
-        # ── Powered By ──
-        if "x-powered-by" in headers:
-            tech["powered_by"] = headers["x-powered-by"]
-
-        # ── CDN Detection ──
-        cdn_signatures = {
-            "Cloudflare":   ["cf-ray", "cf-cache-status"],
-            "Fastly":       ["x-fastly-request-id"],
-            "Akamai":       ["x-akamai-transformed"],
-            "AWS CloudFront": ["x-amz-cf-id"],
-            "Vercel":       ["x-vercel-id"],
-            "Netlify":      ["x-nf-request-id"],
-        }
-        cdns = [name for name, hdrs in cdn_signatures.items() if any(h in headers for h in hdrs)]
-        if cdns:
-            tech["cdn"] = cdns
-
-        # ── CMS Detection ──
-        cms_signatures = {
-            "WordPress":  ["wp-content", "wp-includes", "wordpress"],
-            "Drupal":     ["drupal.js", "drupal.min.js", "/sites/default/files"],
-            "Joomla":     ["/media/jui/", "joomla"],
-            "Shopify":    ["cdn.shopify.com", "shopify.com/s/files"],
-            "Wix":        ["wix.com", "wixstatic.com"],
-            "Squarespace":["squarespace.com", "static.squarespace.com"],
-            "Ghost":      ["ghost.io", "content/themes/ghost"],
-        }
-        cms_found = [name for name, sigs in cms_signatures.items() if any(s in html for s in sigs)]
-        if cms_found:
-            tech["cms"] = cms_found
-
-        # ── JavaScript Frameworks ──
-        js_signatures = {
-            "React":      ["react.js", "react.min.js", "_react", "__react"],
-            "Vue.js":     ["vue.js", "vue.min.js", "__vue__"],
-            "Angular":    ["angular.js", "ng-version", "angular/core"],
-            "Next.js":    ["_next/static", "__next"],
-            "Nuxt.js":    ["_nuxt/", "__nuxt"],
-            "jQuery":     ["jquery.js", "jquery.min.js"],
-            "Bootstrap":  ["bootstrap.css", "bootstrap.min.css", "bootstrap.js"],
-            "Tailwind":   ["tailwindcss", "tailwind.css"],
-        }
-        js_found = [name for name, sigs in js_signatures.items() if any(s in html for s in sigs)]
-        if js_found:
-            tech["javascript_frameworks"] = js_found
-
-        # ── Analytics ──
-        analytics_signatures = {
-            "Google Analytics":   ["google-analytics.com", "gtag(", "ga("],
-            "Google Tag Manager": ["googletagmanager.com"],
-            "Hotjar":             ["hotjar.com"],
-            "Mixpanel":           ["mixpanel.com"],
-            "Segment":            ["segment.com", "analytics.js"],
-            "Facebook Pixel":     ["connect.facebook.net/en_us/fbevents"],
-        }
-        analytics_found = [name for name, sigs in analytics_signatures.items() if any(s in html for s in sigs)]
-        if analytics_found:
-            tech["analytics"] = analytics_found
-
         return {
             "success": True,
             "domain": domain,
             "url": resp.url,
             "status_code": resp.status_code,
-            "technologies": tech,
+            "technologies": fingerprint(resp.headers, resp.text),
         }
 
     except requests.exceptions.SSLError as e:

--- a/tools/techstack_tool.py
+++ b/tools/techstack_tool.py
@@ -15,13 +15,14 @@ def tech_stack_detect(domain: str) -> dict:
         url = f"https://{domain}"
         resp = requests.get(url, timeout=10, allow_redirects=True,
                             headers={"User-Agent": "Mozilla/5.0 (compatible; SecurityScanner/1.0)"})
+        technologies = fingerprint(resp.headers, resp.text)
 
         return {
             "success": True,
             "domain": domain,
             "url": resp.url,
             "status_code": resp.status_code,
-            "technologies": fingerprint(resp.headers, resp.text),
+            "technologies": technologies,
         }
 
     except requests.exceptions.SSLError as e:


### PR DESCRIPTION
## Closes

Nothing on its own. This is groundwork for issue 130 rather than its completion — Phase 1 landed in #141, and this adds the engine seam Phases 2–4 need without changing any detection behaviour. Refs #130

## Summary

Extracts the technology-fingerprinting logic out of `tech_stack_detect` into a dedicated `tools/fingerprint/` engine, with the signature tables separated from the matching code. Output is unchanged for every response a real `requests` session can produce; the value here is structural, so the detection work in later phases has somewhere to land.

## What changed

- New `tools/fingerprint/signatures.py` holds the four signature tables — 27 technologies, 53 markers — as data, carried over unmodified from their inline definitions.
- New `tools/fingerprint/engine.py` exposes `fingerprint(raw_headers, raw_text)`, split into a `headers_layer` and an `html_layer`. Those are two of the layers issue 130 names under Phase 2, now separable, so cookie, meta-generator and asset layers can be added without reopening the tool module.
- `tools/techstack_tool.py` drops to fetch, delegate, assemble. `tech_stack_detect(domain) -> dict` and its output shape are untouched, so `server.py` and `tools/signals/registry.py` need no adjustment.
- `tests/test_tech_stack_detect.py` gains characterisation tests written **before** the move: all 53 markers individually, technology key order, within-category table order, case handling, the preserved false positives, and the error branches.
- `tests/test_fingerprint_engine.py` covers the new seam directly, including layer independence and table integrity.
- README gains a short note on the new module.

## Notes

- **Byte-for-byte equivalence was the acceptance bar, and three of the five commits exist only to hold it.** The caller now drains and normalises the response headers through `.items()` *before* `resp.text` is read, so the engine receives exactly what the old inline code computed. That ordering is load-bearing in a non-obvious way: reading the body can drain a streamed response, and the original code interleaved the header and body reads.
- **Known false positives are preserved rather than quietly repaired.** The Google Analytics marker is still the bare string `ga(`, so a page containing `saga(` still matches. Issue 130 lists false positives among the problems to solve, but fixing them inside a behaviour-preserving refactor would bury the change in a diff that claims to change nothing — they belong to the phase that addresses detection quality.
- **One redundancy I would rather flag than hide:** the caller normalises header keys and `headers_layer` normalises them again. For anything a real `requests.Session` returns this is a no-op, because headers arrive as a `CaseInsensitiveDict` of plain strings. It is only observable with a hand-built double whose key object returns a different value from a second `.lower()` call. Happy to collapse the second normalisation if you would rather not carry it.
- Phases 2–4 — the cookies, meta-tag and asset layers, confidence scoring, and the proposed output schema — are untouched here, as are the HTTP fallback, body-size limit and redirect-loop handling listed under Additional Improvements.

## Verification

- [x] Ran locally and confirmed it works as expected
- [x] Added/updated tests for the changed behavior
- [x] All tests pass (`pytest tests/`)
- [x] No unrelated changes included
- [x] Checked `CONTRIBUTING.md` and applied all changes
- [x] Updated Documentation ( if required )

Beyond the suite: an independent reviewer ran a differential against the pre-refactor implementation over 20 paired responses served from a local raw-socket HTTP server — redirect chains, chunked transfer, `stream=True`, gzip/deflate/brotli, charset mismatches and undeclared charsets, invalid UTF-8, repeated and case-varied headers, empty and 2 MiB bodies, non-2xx, and real HEAD/204/304 — comparing the full observation including technology key and list order. All 20 compared equal. The signature tables were separately compared entry-by-entry against the base by AST, confirming all 27 technologies and 53 markers identical and in the same order.

Generated by Claude Opus 5 (implementation, testing, review), Kimi K3 (implementation, review), GPT-5.6 Luna (implementation), GPT-5.6 Sol (review, verification)
