### PR TITLE
fix(dns): resolve over UDP first and let TCP be the fallback (#144 item 3)

### DIFF
--- a/tests/test_dns_enumeration.py
+++ b/tests/test_dns_enumeration.py
@@ -102,8 +102,88 @@ class TestDnsEnumeration(unittest.TestCase):
         self.assertEqual(result["errors"]["CAA"], "NoAnswer")
         self.assertIn("subdomains_found", result)
         self.assertEqual(resolver.nameservers, ["1.1.1.1", "8.8.8.8"])
-        resolver.resolve.assert_any_call("example.com", "TXT", lifetime=5, tcp=True)
-        resolver.resolve.assert_any_call("www.example.com", "A", lifetime=3, tcp=True)
+        resolver.resolve.assert_any_call("example.com", "TXT", lifetime=5)
+        resolver.resolve.assert_any_call("www.example.com", "A", lifetime=3)
+
+    @patch("tools.dns_tool.dns.resolver.Resolver")
+    def test_udp_first_preserves_result_shape_and_content(self, mock_resolver_class):
+        import dns.resolver as real_dns
+
+        resolver = Mock()
+        mock_resolver_class.return_value = resolver
+
+        def side_effect(name, rtype, lifetime=5, tcp=False):
+            if name == "example.com" and rtype == "A":
+                return _ResolverAnswer(["192.0.2.10"], 60)
+            if name == "_sip._tcp.example.com" and rtype == "SRV":
+                record = Mock()
+                record.priority = 10
+                record.weight = 20
+                record.port = 5060
+                record.target = "sip.example.com."
+                return [record]
+            if name == "www.example.com" and rtype == "A":
+                return _ResolverAnswer(["192.0.2.20"], 30)
+            raise real_dns.NoAnswer
+
+        resolver.resolve.side_effect = side_effect
+
+        result = dns_enumeration("example.com")
+
+        self.assertEqual(
+            result,
+            {
+                "success": True,
+                "domain": "example.com",
+                "errors": {
+                    "AAAA": "NoAnswer",
+                    "MX": "NoAnswer",
+                    "NS": "NoAnswer",
+                    "TXT": "NoAnswer",
+                    "CNAME": "NoAnswer",
+                    "SOA": "NoAnswer",
+                    "CAA": "NoAnswer",
+                },
+                "records": {
+                    "A": ["192.0.2.10"],
+                    "AAAA": [],
+                    "MX": [],
+                    "NS": [],
+                    "TXT": [],
+                    "CNAME": [],
+                    "SOA": [],
+                    "CAA": [],
+                },
+                "srv_records": {
+                    "_sip._tcp": [
+                        {
+                            "priority": 10,
+                            "weight": 20,
+                            "port": 5060,
+                            "target": "sip.example.com",
+                        }
+                    ],
+                    "_ldap._tcp": [],
+                    "_xmpp-client._tcp": [],
+                    "_kerberos._tcp": [],
+                    "_autodiscover._tcp": [],
+                },
+                "srv_errors": {},
+                "subdomains_found": ["www.example.com"],
+                "subdomain_errors": {},
+                "ttl": {"A": 60},
+                "resolver": {
+                    "nameservers": ["1.1.1.1", "8.8.8.8"],
+                    "timeout": 2.0,
+                    "lifetime": 5,
+                },
+            },
+        )
+        resolver.resolve.assert_any_call("example.com", "A", lifetime=5)
+        resolver.resolve.assert_any_call(
+            "_sip._tcp.example.com", "SRV", lifetime=5
+        )
+        resolver.resolve.assert_any_call("www.example.com", "A", lifetime=3)
 
     @patch("tools.dns_tool.dns.resolver.Resolver")
     def test_dns_nxdomain_returns_failure(self, mock_resolver_class):
@@ -299,9 +379,9 @@ class TestDnsEnumeration(unittest.TestCase):
         self.assertNotIn("ftp.example.com", result["subdomains_found"])
         self.assertNotIn("www.example.com", result["subdomain_errors"])
         self.assertEqual(result["subdomains_found"].count("www.example.com"), 1)
-        resolver.resolve.assert_any_call("www.example.com", "A", lifetime=3, tcp=True)
-        resolver.resolve.assert_any_call("www.example.com", "AAAA", lifetime=3, tcp=True)
-        resolver.resolve.assert_any_call("mail.example.com", "CNAME", lifetime=3, tcp=True)
+        resolver.resolve.assert_any_call("www.example.com", "A", lifetime=3)
+        resolver.resolve.assert_any_call("www.example.com", "AAAA", lifetime=3)
+        resolver.resolve.assert_any_call("mail.example.com", "CNAME", lifetime=3)
 
     @patch("tools.dns_tool.dns.resolver.Resolver")
     def test_aaaa_found_subdomain_has_no_expected_a_error(self, mock_resolver_class):
@@ -492,7 +572,7 @@ class TestDnsEnumeration(unittest.TestCase):
         self.assertEqual(set(srv_records), expected_services)
         for service in expected_services:
             resolver.resolve.assert_any_call(
-                f"{service}.example.com", "SRV", lifetime=5, tcp=True
+                f"{service}.example.com", "SRV", lifetime=5
             )
         # A published SRV record is parsed into its fields.
         self.assertEqual(
@@ -553,7 +633,7 @@ class TestDnsEnumeration(unittest.TestCase):
                 for service in ("_sip._tcp", "_ldap._tcp", "_xmpp-client._tcp",
                                 "_kerberos._tcp", "_autodiscover._tcp"):
                     resolver.resolve.assert_any_call(
-                        f"{service}.{domain}", "SRV", lifetime=5, tcp=True
+                        f"{service}.{domain}", "SRV", lifetime=5
                     )
                     self.assertEqual(result["srv_records"][service], [])
                     self.assertEqual(result["srv_errors"][service], error.__name__)

--- a/tools/dns_tool.py
+++ b/tools/dns_tool.py
@@ -131,7 +131,7 @@ def dns_enumeration(domain: str) -> dict:
 
     for rtype in RECORD_TYPES:
         try:
-            answers = resolver.resolve(domain, rtype, lifetime=RESOLVER_LIFETIME, tcp=True)
+            answers = resolver.resolve(domain, rtype, lifetime=RESOLVER_LIFETIME)
         except dns.resolver.NXDOMAIN:
             return {"success": False, "error": f"Domain {domain} does not exist"}
         except LOOKUP_ERRORS as exc:
@@ -189,7 +189,7 @@ def dns_enumeration(domain: str) -> dict:
     for service in SRV_SERVICES:
         srv_name = f"{service}.{domain}"
         try:
-            answers = resolver.resolve(srv_name, "SRV", lifetime=RESOLVER_LIFETIME, tcp=True)
+            answers = resolver.resolve(srv_name, "SRV", lifetime=RESOLVER_LIFETIME)
         except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
             srv_records[service] = []
         except SRV_LOOKUP_ERRORS as exc:
@@ -219,7 +219,7 @@ def dns_enumeration(domain: str) -> dict:
         full = f"{sub}.{domain}"
         for rtype in SUBDOMAIN_RECORD_TYPES:
             try:
-                resolver.resolve(full, rtype, lifetime=SUBDOMAIN_LIFETIME, tcp=True)
+                resolver.resolve(full, rtype, lifetime=SUBDOMAIN_LIFETIME)
                 found_subdomains.append(full)
                 # A name that resolves on any record type is found, so an
                 # error recorded for an earlier record type no longer applies.


### PR DESCRIPTION
## Closes

Nothing on its own — this is **item 3 only** of the enhancement list, so the issue stays open for the remaining items. Refs #144

## Summary

Stops forcing TCP on DNS resolution. The three resolution paths in `dns_enumeration` now let dnspython use its normal UDP-first behaviour, with TCP still available as the fallback it already handles on truncation. Resolver lifetimes and the tool's public result shape are unchanged.

## What changed

- `tools/dns_tool.py` — dropped `tcp=True` from the three `resolver.resolve(...)` call sites: the ordinary record loop, the SRV query path, and the A/AAAA/CNAME subdomain probes. Six lines, nothing else.
- `tests/test_dns_enumeration.py` — the existing assertions **pinned the old behaviour** (`assert_any_call(..., tcp=True)`), so they had to be retargeted rather than added to. They still assert the lifetimes (`5` for records and SRV, `3` for subdomain probes) and the same mocked answers and exceptions.
- Added `test_udp_first_preserves_result_shape_and_content`, which asserts the exact call contract for all three families and pins the full returned structure — keys, per-type error strings, TTL map, resolver metadata and `subdomains_found` — so this refactor is provably behaviour-preserving apart from transport selection.

## Notes

- **TCP fallback was verified from source rather than assumed**, since it is the whole justification for the change. Against the pinned `dnspython==2.8.0`: `resolve()` defaults `tcp=False` (`dns/resolver.py:1251`), the UDP receive path raises `dns.message.Truncated` on the TC bit (`dns/query.py:872-877`), and `_Resolution.query_result` sets `retry_with_tcp` which `next_nameserver` turns into a TCP attempt against the same nameserver (`dns/resolver.py:808-813`, `761-766`).
- **Known limitation of the tests, disclosed rather than hidden.** The assertions pin exact calls, so reintroducing `tcp=True` at any one of the three sites fails the suite — verified by doing it three times. But a *partial* reintroduction hides: forcing TCP for only a non-asserted record type (say `MX`), or only a non-asserted subdomain, leaves the suite green. Call multiplicity is also unpinned, so a change that doubled every lookup would not be caught. A single sweep over `call_args_list` asserting that no call anywhere carries `tcp=` would close all three; I left it out to keep this diff to item 3, and it is probably better as its own change.
- **Sibling occurrence, out of scope here:** `tools/subdomain_takeover_tool.py:69` still passes `tcp=True` on its CNAME lookup. #154 covers that tool's error handling but not its transport. Flagging it rather than folding it in, since it belongs to that tool's issue and not to this one.
- Untouched by design: exception handling (item 1), the subdomain wordlist (item 5), timeouts, record types, and every key of the returned dictionary.

## Verification

- [x] Ran locally and confirmed it works as expected
- [x] Added/updated tests for the changed behavior
- [x] All tests pass (`pytest tests/`)
- [x] No unrelated changes included
- [x] Checked `CONTRIBUTING.md` and applied all changes
- [ ] Updated Documentation ( if required ) — not required; no user-visible behaviour or output shape changed

Beyond the suite: an independent reviewer reintroduced `tcp=True` at each of the three call sites in turn, confirmed each produced an `AssertionError` (never an import or collection error) and that the suite returned green after each restore; confirmed the mocked resolver is genuinely exercised (208 calls in the main test, matching 8 record types + 5 SRV services + 65 subdomains × 3 types) so no assertion passes vacuously; and drove the base and changed implementations over identical mocked inputs across six scenarios — full success with TTLs, NXDOMAIN, an error matrix, a TXT decode error, the CAA raw fallback, and invalid input — comparing serialized output for exact equality. Zero mismatches.

Generated by GPT-5.6 Sol (analysis), GPT-5.6 Luna (implementation, testing), Kimi K3 (review, verification), Claude Opus 5 (brief, review)
