### PR TITLE
fix(subdomain-takeover): report an incomplete probe as unknown, not safe (#154 item 10)

### DIFF
--- a/tests/test_subdomain_takeover.py
+++ b/tests/test_subdomain_takeover.py
@@ -64,6 +64,7 @@ def test_vulnerable_subdomain_is_flagged(mock_enum, mock_resolver_class, mock_ge
     assert result["vulnerable"][0]["severity"] == "HIGH"
     assert "reason" in result["vulnerable"][0]
     assert result["safe"] == ["www.example.com"]
+    assert result.get("unknown") == []
     mock_get.assert_called_once()
 
 
@@ -89,6 +90,7 @@ def test_fingerprint_match_without_indicator_is_safe(mock_enum, mock_resolver_cl
     assert result["vulnerable"] == []
     assert result["total_vulnerable"] == 0
     assert result["safe"] == ["blog.example.com"]
+    assert result.get("unknown") == []
 
 
 @patch("tools.subdomain_takeover_tool.requests.get")
@@ -164,6 +166,7 @@ def test_aggregate_counts(mock_enum, mock_resolver_class, mock_get):
     assert result["vulnerable"][0]["subdomain"] == "dev.example.com"
     assert result["vulnerable"][0]["service"] == "GitHub Pages"
     assert result["safe"] == ["blog.example.com", "www.example.com"]
+    assert result.get("unknown") == []
 
 
 @patch("tools.subdomain_takeover_tool.requests.get")
@@ -189,6 +192,7 @@ def test_azure_vulnerable_matches_body(mock_enum, mock_resolver_class, mock_get)
     assert result["total_vulnerable"] == 1
     assert result["vulnerable"][0]["subdomain"] == "app.example.com"
     assert result["vulnerable"][0]["service"] == "Azure"
+    assert result.get("unknown") == []
     # HTTPS is attempted first and succeeded, so exactly one request is made to https://.
     assert mock_get.call_count == 1
     first_url = urlparse(mock_get.call_args_list[0].args[0])
@@ -237,8 +241,8 @@ def test_https_failure_falls_back_to_http(mock_enum, mock_resolver_class, mock_g
 @patch("tools.subdomain_takeover_tool.requests.get")
 @patch("tools.subdomain_takeover_tool.dns.resolver.Resolver")
 @patch("tools.subdomain_takeover_tool.dns_enumeration")
-def test_both_schemes_fail_is_safe(mock_enum, mock_resolver_class, mock_get):
-    """Neither HTTPS nor HTTP connects => not confirmed => safe."""
+def test_both_schemes_fail_is_unknown(mock_enum, mock_resolver_class, mock_get):
+    """Neither HTTPS nor HTTP connects => the probe outcome is unknown."""
     import requests as real_requests
 
     mock_enum.return_value = _enumeration_result(["app.example.com"])
@@ -253,8 +257,69 @@ def test_both_schemes_fail_is_safe(mock_enum, mock_resolver_class, mock_get):
 
     assert result["success"] is True
     assert result["total_vulnerable"] == 0
-    assert result["safe"] == ["app.example.com"]
+    assert result["safe"] == []
+    assert result["unknown"][0]["subdomain"] == "app.example.com"
+    assert result["unknown"][0]["reason"] == "Unable to complete HTTP probe over HTTPS or HTTP"
+    assert [error["scheme"] for error in result["unknown"][0]["probe_errors"]] == [
+        "https",
+        "http",
+    ]
+    assert all("ConnectionError: unreachable" in error["error"] for error in result["unknown"][0]["probe_errors"])
     assert mock_get.call_count == 2
+
+
+@patch("tools.subdomain_takeover_tool.requests.get")
+@patch("tools.subdomain_takeover_tool.dns.resolver.Resolver")
+@patch("tools.subdomain_takeover_tool.dns_enumeration")
+def test_mixed_probe_outcomes_are_disjoint_and_total(mock_enum, mock_resolver_class, mock_get):
+    """Every probed subdomain lands in exactly one of vulnerable, safe, or unknown."""
+    import requests as real_requests
+
+    subdomains = [
+        "vulnerable.example.com",
+        "safe.example.com",
+        "unknown.example.com",
+    ]
+    mock_enum.return_value = _enumeration_result(subdomains)
+
+    resolver = Mock()
+    resolver.resolve.side_effect = lambda name, rtype, **kwargs: [
+        _cname_record("vulnerable.ghost.io." if name.startswith("vulnerable") else "safe.ghost.io.")
+    ]
+    mock_resolver_class.return_value = resolver
+
+    def http_side_effect(url, **kwargs):
+        host = (urlparse(url).hostname or "").lower()
+        if host.startswith("unknown"):
+            raise real_requests.exceptions.Timeout("probe timed out")
+        response = Mock()
+        response.status_code = 200
+        response.text = (
+            "404 Domain Not Found"
+            if host.startswith("vulnerable")
+            else "Welcome to a live site"
+        )
+        return response
+
+    mock_get.side_effect = http_side_effect
+
+    result = subdomain_takeover("example.com")
+
+    assert result.get("unknown") is not None
+    bucket_subdomains = {
+        "vulnerable": {item["subdomain"] for item in result["vulnerable"]},
+        "safe": set(result["safe"]),
+        "unknown": {item["subdomain"] for item in result.get("unknown", [])},
+    }
+    assert set.union(*bucket_subdomains.values()) == set(subdomains)
+    assert sum(len(bucket) for bucket in bucket_subdomains.values()) == len(subdomains)
+    for left_name, left_bucket in bucket_subdomains.items():
+        for right_name, right_bucket in bucket_subdomains.items():
+            if left_name != right_name:
+                assert left_bucket.isdisjoint(right_bucket)
+    assert bucket_subdomains["vulnerable"] == {"vulnerable.example.com"}
+    assert bucket_subdomains["safe"] == {"safe.example.com"}
+    assert bucket_subdomains["unknown"] == {"unknown.example.com"}
 
 
 @patch("tools.subdomain_takeover_tool.requests.get")

--- a/tools/subdomain_takeover_tool.py
+++ b/tools/subdomain_takeover_tool.py
@@ -6,6 +6,8 @@ fingerprints (GitHub Pages, Heroku, S3, Azure, Ghost, Shopify, Fastly), and
 confirms the takeover with an HTTP request checking for the service's
 takeover-indicating response.
 """
+from dataclasses import dataclass
+from enum import Enum
 import re
 
 import dns.resolver
@@ -57,6 +59,24 @@ _REQUEST_HEADERS = {
 _REQUEST_TIMEOUT = 10
 
 
+class _ProbeStatus(str, Enum):
+    CONFIRMED = "confirmed"
+    NO_INDICATOR = "no_indicator"
+    UNABLE_TO_PROBE = "unable_to_probe"
+
+
+@dataclass(frozen=True)
+class _ProbeResult:
+    response: requests.Response | None
+    errors: tuple[dict[str, str], ...] = ()
+
+
+@dataclass(frozen=True)
+class _TakeoverResult:
+    status: _ProbeStatus
+    probe_errors: tuple[dict[str, str], ...] = ()
+
+
 def _make_resolver() -> dns.resolver.Resolver:
     resolver = dns.resolver.Resolver(configure=False)
     resolver.nameservers = PUBLIC_RESOLVERS
@@ -84,35 +104,44 @@ def _match_fingerprint(cname: str) -> dict | None:
     return None
 
 
-def _probe(subdomain: str):
+def _probe(subdomain: str) -> _ProbeResult:
     """Fetch the subdomain over HTTPS first, falling back to HTTP.
 
     Many hosted services only serve (or redirect to) HTTPS, so try that first
     and fall back to plain HTTP only when the HTTPS connection itself fails.
-    Returns the response, or None if neither scheme connects.
+    Returns the response and any errors if neither scheme connects.
     """
+    errors = []
     for scheme in ("https", "http"):
         try:
-            return requests.get(
+            response = requests.get(
                 f"{scheme}://{subdomain}",
                 headers=_REQUEST_HEADERS,
                 timeout=_REQUEST_TIMEOUT,
             )
-        except requests.exceptions.RequestException:
+            return _ProbeResult(response=response)
+        except requests.exceptions.RequestException as exc:
+            errors.append({
+                "scheme": scheme,
+                "error": f"{type(exc).__name__}: {exc}",
+            })
             continue
-    return None
+    return _ProbeResult(response=None, errors=tuple(errors))
 
 
-def _confirms_takeover(subdomain: str, fingerprint: dict) -> bool:
-    """HTTP-probe the subdomain and check for the takeover-indicating response."""
-    response = _probe(subdomain)
-    if response is None:
-        return False
+def _confirms_takeover(subdomain: str, fingerprint: dict) -> _TakeoverResult:
+    """Return the tri-state takeover result and probe failure evidence."""
+    probe = _probe(subdomain)
+    if probe.response is None:
+        return _TakeoverResult(_ProbeStatus.UNABLE_TO_PROBE, probe.errors)
 
     indicator = fingerprint["indicator"]
     if "status" in indicator:
-        return response.status_code == indicator["status"]
-    return indicator["body"].lower() in response.text.lower()
+        confirmed = probe.response.status_code == indicator["status"]
+    else:
+        confirmed = indicator["body"].lower() in probe.response.text.lower()
+    status = _ProbeStatus.CONFIRMED if confirmed else _ProbeStatus.NO_INDICATOR
+    return _TakeoverResult(status)
 
 
 def subdomain_takeover(domain: str) -> dict:
@@ -138,6 +167,7 @@ def subdomain_takeover(domain: str) -> dict:
 
     vulnerable = []
     safe = []
+    unknown = []
 
     for subdomain in subdomains:
         cname = _resolve_cname(subdomain, resolver)
@@ -150,7 +180,8 @@ def subdomain_takeover(domain: str) -> dict:
             safe.append(subdomain)
             continue
 
-        if _confirms_takeover(subdomain, fingerprint):
+        probe_result = _confirms_takeover(subdomain, fingerprint)
+        if probe_result.status is _ProbeStatus.CONFIRMED:
             vulnerable.append({
                 "subdomain": subdomain,
                 "cname": cname,
@@ -158,8 +189,14 @@ def subdomain_takeover(domain: str) -> dict:
                 "reason": f"CNAME points to unclaimed {fingerprint['service']} service",
                 "severity": "HIGH",
             })
-        else:
+        elif probe_result.status is _ProbeStatus.NO_INDICATOR:
             safe.append(subdomain)
+        else:
+            unknown.append({
+                "subdomain": subdomain,
+                "reason": "Unable to complete HTTP probe over HTTPS or HTTP",
+                "probe_errors": list(probe_result.probe_errors),
+            })
 
     return {
         "success": True,
@@ -167,5 +204,6 @@ def subdomain_takeover(domain: str) -> dict:
         "subdomains_checked": len(subdomains),
         "vulnerable": vulnerable,
         "safe": safe,
+        "unknown": unknown,
         "total_vulnerable": len(vulnerable),
     }


### PR DESCRIPTION
## Closes

Nothing on its own — this is **item 10**, plus only the probe-failure half of **item 3**, so the issue stays open for the DNS and unsupported-service halves and everything else on the list. Refs #154

## Summary

A subdomain-takeover probe that never completed was being reported as `safe`. In a security tool that is the dangerous direction of wrong: "could not check" and "checked, nothing found" collapsed to the same answer. Probe failures now land in a separate `unknown` bucket, carrying the per-scheme errors that explain why.

## What changed

- `tools/subdomain_takeover_tool.py`
  - `_probe()` still tries HTTPS then HTTP, but now returns the failure evidence instead of discarding it — per-scheme exception type and message.
  - `_confirms_takeover()` returns a tri-state (`confirmed` / `no_indicator` / `unable_to_probe`) instead of a bare bool, so the caller can tell the two false cases apart.
  - The caller routes only `unable_to_probe` to the new bucket. `confirmed` → `vulnerable` and `no_indicator` → `safe` behave exactly as before.
- `tests/test_subdomain_takeover.py` — the existing test **asserted the defect** (`safe == ["app.example.com"]` while both schemes raised `ConnectionError`), so it was retargeted rather than added to. New coverage: both schemes failing, a completed probe with no indicator, a completed probe with an indicator, and a mixed run asserting the three buckets are disjoint and total.

## Notes

- **This changes the return contract, and I would rather say so plainly than have you find it.** `unknown` is a new top-level key, and subdomains that used to inflate `safe` no longer appear there. Concretely: `len(vulnerable) + len(safe) == subdomains_checked` **no longer holds**, and any consumer treating `len(safe)` as "all clear" would now be reading a smaller number for the right reason. `subdomains_checked` still counts everything. If you would rather keep the old invariant and expose the state differently — a per-entry status instead of a third list, say — I am happy to reshape it.
- **The same "could not check → reported safe" pattern still exists one stage earlier, and this PR does not fix it.** `_resolve_cname()` swallows `Exception`, so a DNS timeout or SERVFAIL on an individual subdomain collapses to "no CNAME" and lands in `safe`. That is the DNS half of item 3 and it needs the specific-exception work from item 1, so I have deliberately left it alone rather than half-doing two items in one diff.
- Known test-coverage gap, disclosed: no test asserts `subdomains_checked` in a run that produces `unknown` entries, so a regression that undercounted it would stay green. The production value is correct (`len(subdomains)`); it is one assertion short of being pinned.
- `unknown` records carry `subdomain`, `reason` and `probe_errors`. They deliberately omit the matched `cname`/`service` — say the word if you would find those useful for triage and I will add them.

## Verification

- [x] Ran locally and confirmed it works as expected
- [x] Added/updated tests for the changed behavior
- [x] All tests pass (`pytest tests/`)
- [x] No unrelated changes included
- [x] Checked `CONTRIBUTING.md` and applied all changes
- [ ] Updated Documentation ( if required ) — flagging instead: the return-shape change above is the documentation-relevant part, and I would rather you decide where it belongs than guess

Beyond the suite, an independent reviewer checked the direction that would actually matter if this went wrong. It drove the pre-change and post-change implementations side by side over a 42-scenario matrix — all seven fingerprints × three body casings × HTTPS-succeeds and HTTPS-fails-then-HTTP-succeeds — comparing full `vulnerable` records and `total_vulnerable`: **zero mismatches**, so no input that was flagged vulnerable before is anything other than vulnerable now. It verified the three buckets partition the input set exactly, using its own driver rather than the PR's tests; confirmed the invalid-domain and enumeration-failure responses are byte-identical to before; reintroduced each of the four collapse points singly and confirmed each turns the suite red with an `AssertionError`; and re-ran the whole test file with `socket.socket` and `socket.create_connection` replaced by raisers to prove no test touches the network.

Generated by GPT-5.6 Sol (analysis), GPT-5.6 Luna (implementation, testing), Kimi K3 (review, verification), Claude Opus 5 (brief, review)
