### PR TITLE
docs(whois): add WHOIS tool documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ It is also listed on glama mcp registry.
 
 ## Tools Available
 
+See the [tools documentation index](docs/tools/README.md) for detailed
+reference pages and the current registration inventory.
+
 ### Included in `full_recon`
 
 | Tool | Description |

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ reference pages and the current registration inventory.
 
 | Tool | Description |
 |---|---|
-| [`whois_lookup`](docs/tools/whois_lookup.md) | Domain registration data — owner, registrar, creation date, expiry, name servers |
+| [`whois_lookup`](docs/tools/whois_lookup.md) | Domain registration data — registrant organization, registrar, creation date, expiry, name servers |
 | `dns_enumeration` | A, AAAA, MX, NS, TXT, CNAME, SOA, CAA, and common SRV records (SIP, LDAP, XMPP, Kerberos, Autodiscover) + common subdomain brute-forcing |
 | `port_scan` | Nmap-powered scanner with service/version detection and security warnings |
 | `ssl_inspect` | SSL/TLS certificate — issuer, expiry, cipher strength, SANs, TLS version |

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ It is also listed on glama mcp registry.
 
 | Tool | Description |
 |---|---|
-| `whois_lookup` | Domain registration data — owner, registrar, creation date, expiry, name servers |
+| [`whois_lookup`](docs/tools/whois_lookup.md) | Domain registration data — owner, registrar, creation date, expiry, name servers |
 | `dns_enumeration` | A, AAAA, MX, NS, TXT, CNAME, SOA, CAA, and common SRV records (SIP, LDAP, XMPP, Kerberos, Autodiscover) + common subdomain brute-forcing |
 | `port_scan` | Nmap-powered scanner with service/version detection and security warnings |
 | `ssl_inspect` | SSL/TLS certificate — issuer, expiry, cipher strength, SANs, TLS version |

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -1,0 +1,32 @@
+# AynOps tools
+
+This index lists the tools currently registered by the MCP server. Dedicated
+pages are being added incrementally; `whois_lookup` is documented in this
+slice, and the remaining pages are planned follow-ups.
+
+## Included in `full_recon`
+
+| Tool | Description | Documentation |
+|---|---|---|
+| [`whois_lookup`](whois_lookup.md) | Domain registration data — owner, registrar, creation date, expiry, and name servers | Available |
+| `dns_enumeration` | Enumerates DNS records and common subdomains | Pending |
+| `port_scan` | Nmap-powered port scanner with service and version detection | Pending |
+| `ssl_inspect` | Inspects SSL/TLS certificates, cipher strength, SANs, and TLS version | Pending |
+| `email_security_check` | Checks SPF, DKIM, and DMARC configuration | Pending |
+| `tech_stack_detect` | Detects web servers, CMSs, JavaScript frameworks, CDNs, and analytics | Pending |
+| `cert_transparency` | Queries Certificate Transparency logs and extracts certificate and subdomain information | Pending |
+| `asn_lookup` | Looks up ASN and network ownership information through Team Cymru WHOIS | Pending |
+| `ip_reputation` | Checks whether an IP is flagged as malicious through AbuseIPDB | Pending |
+| `headers_analyzer` | Analyzes HTTP security headers and reports misconfigurations | Pending |
+| `full_recon` | Combines results from the core reconnaissance tools into a single report | Pending |
+
+## Standalone tools
+
+| Tool | Description | Documentation |
+|---|---|---|
+| `cve_lookup` | Searches the NVD for known CVEs by software and version | Pending |
+| `cloud_exposure_check` | Checks for publicly accessible cloud storage buckets | Pending |
+| `trace_redirects` | Traces an HTTP redirect chain and flags suspicious hops | Pending |
+| `robots_txt_inspect` | Fetches and parses `robots.txt` for hidden directories and sitemaps | Pending |
+| `subdomain_takeover` | Checks discovered subdomains for takeover indicators | Pending |
+| `hibp_check` | Checks whether an email or domain appears in Have I Been Pwned breach data | Pending |

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -8,7 +8,7 @@ slice, and the remaining pages are planned follow-ups.
 
 | Tool | Description | Documentation |
 |---|---|---|
-| [`whois_lookup`](whois_lookup.md) | Domain registration data — owner, registrar, creation date, expiry, and name servers | Available |
+| [`whois_lookup`](whois_lookup.md) | Domain registration data — registrant organization, registrar, creation date, expiry, and name servers | Available |
 | `dns_enumeration` | Enumerates DNS records and common subdomains | Pending |
 | `port_scan` | Nmap-powered port scanner with service and version detection | Pending |
 | `ssl_inspect` | Inspects SSL/TLS certificates, cipher strength, SANs, and TLS version | Pending |

--- a/docs/tools/whois_lookup.md
+++ b/docs/tools/whois_lookup.md
@@ -23,9 +23,9 @@ The MCP tool exposes one required input:
 There are no optional parameters. The server strips surrounding whitespace,
 converts the value to lowercase, and removes trailing dots before validation.
 Validation requires at least one dot, labels of at most 63 characters, a total
-length of at most 253 characters, and a final label containing at least two
-ASCII letters. Each non-final label may contain letters, digits, and internal
-hyphens, but may not start or end with a hyphen.
+length of at most 253 characters, and a final label consisting entirely of at
+least two ASCII letters. Each non-final label may contain letters, digits, and
+internal hyphens, but may not start or end with a hyphen.
 
 ## Example MCP request
 
@@ -79,7 +79,7 @@ On success, the response contains `success: true` and the following fields:
 | `success` | boolean | `true` for a completed WHOIS lookup. |
 | `domain` | string, list of strings, or null | The `domain_name` value returned by the WHOIS library. A single parsed value remains a string; multiple values are returned as a list. |
 | `registrar` | string or null | Registrar returned by the WHOIS response. |
-| `registrar_url` | string or null | Registrar URL, when supplied. |
+| `registrar_url` | string, list of strings, or null | Registrar URL, when supplied. A single parsed value is a string; repeated upstream values are returned as a list. |
 | `whois_server` | string or null | WHOIS server returned by the response. |
 | `creation_date` | string, list of strings, or null | Creation date. Date objects are converted to strings; multiple values are returned as a list. |
 | `expiration_date` | string, list of strings, or null | Expiration date, with the same conversion and list behavior as `creation_date`. |

--- a/docs/tools/whois_lookup.md
+++ b/docs/tools/whois_lookup.md
@@ -6,13 +6,13 @@
 returns the fields that the upstream WHOIS response provides. It does not
 require an API key.
 
-## Common uses
+## Purpose and common use cases
 
 Use this tool to inspect registration metadata such as the registrar, registry
 dates, name servers, registration status, and the organization associated with
 a domain. WHOIS responses vary by registry, so some fields may be unavailable.
 
-## Input
+## Parameters
 
 The MCP tool exposes one required input:
 
@@ -20,12 +20,14 @@ The MCP tool exposes one required input:
 |---|---|---|---|
 | `domain` | string | Yes | A fully qualified domain name to query. IP addresses, `localhost`, bare labels, and malformed domain names are rejected. |
 
-There are no optional parameters. The server strips surrounding whitespace,
-converts the value to lowercase, and removes trailing dots before validation.
 Validation requires at least one dot, labels of at most 63 characters, a total
 length of at most 253 characters, and a final label consisting entirely of at
 least two ASCII letters. Each non-final label may contain letters, digits, and
 internal hyphens, but may not start or end with a hyphen.
+
+## Optional parameters
+
+None.
 
 ## Example MCP request
 
@@ -37,7 +39,7 @@ internal hyphens, but may not start or end with a hyphen.
   "params": {
     "name": "whois_lookup",
     "arguments": {
-      "domain": " Example.COM. "
+      "domain": "example.com"
     }
   }
 }
@@ -70,7 +72,7 @@ or return more than one value for a field.
 }
 ```
 
-## Response fields
+## Response field descriptions
 
 On success, the response contains `success: true` and the following fields:
 
@@ -111,14 +113,19 @@ failures are returned using the underlying exception message.
 
 ## Notes and limitations
 
-- No API key is required, but the lookup needs network access to the relevant
-  WHOIS service.
+- Before validation, the server strips surrounding whitespace, converts the
+  value to lowercase, and removes trailing dots.
+- The lookup needs network access to the relevant WHOIS service.
 - Field availability and formatting vary between registries and registrars;
   missing values are returned as `null`.
 - A field with one parsed value is a scalar string, while repeated values are
   returned as a list of strings.
 - The validator accepts domain names only; IP address lookups are not part of
   this tool's input contract.
+
+## API key requirements
+
+None required.
 
 ## Related tools
 

--- a/docs/tools/whois_lookup.md
+++ b/docs/tools/whois_lookup.md
@@ -1,0 +1,127 @@
+# `whois_lookup`
+
+## Overview
+
+`whois_lookup` queries domain-registration data through the WHOIS service and
+returns the fields that the upstream WHOIS response provides. It does not
+require an API key.
+
+## Common uses
+
+Use this tool to inspect registration metadata such as the registrar, registry
+dates, name servers, registration status, and the organization associated with
+a domain. WHOIS responses vary by registry, so some fields may be unavailable.
+
+## Input
+
+The MCP tool exposes one required input:
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `domain` | string | Yes | A fully qualified domain name to query. IP addresses, `localhost`, bare labels, and malformed domain names are rejected. |
+
+There are no optional parameters. The server strips surrounding whitespace,
+converts the value to lowercase, and removes trailing dots before validation.
+Validation requires at least one dot, labels of at most 63 characters, a total
+length of at most 253 characters, and a final label containing at least two
+ASCII letters. Each non-final label may contain letters, digits, and internal
+hyphens, but may not start or end with a hyphen.
+
+## Example MCP request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "whois_lookup",
+    "arguments": {
+      "domain": " Example.COM. "
+    }
+  }
+}
+```
+
+## Example successful response
+
+The values below are illustrative; registries and registrars can omit fields
+or return more than one value for a field.
+
+```json
+{
+  "success": true,
+  "domain": "example.com",
+  "registrar": "Example Registrar LLC",
+  "registrar_url": "https://registrar.example",
+  "whois_server": "whois.example",
+  "creation_date": "2010-01-01 00:00:00",
+  "expiration_date": "2030-01-01 00:00:00",
+  "updated_date": "2023-06-15 00:00:00",
+  "name_servers": [
+    "ns1.example.com",
+    "ns2.example.com"
+  ],
+  "status": "clientTransferProhibited",
+  "emails": "admin@example.com",
+  "dnssec": "unsigned",
+  "country": "US",
+  "org": "Example Organization"
+}
+```
+
+## Response fields
+
+On success, the response contains `success: true` and the following fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `success` | boolean | `true` for a completed WHOIS lookup. |
+| `domain` | string, list of strings, or null | The `domain_name` value returned by the WHOIS library. A single parsed value remains a string; multiple values are returned as a list. |
+| `registrar` | string or null | Registrar returned by the WHOIS response. |
+| `registrar_url` | string or null | Registrar URL, when supplied. |
+| `whois_server` | string or null | WHOIS server returned by the response. |
+| `creation_date` | string, list of strings, or null | Creation date. Date objects are converted to strings; multiple values are returned as a list. |
+| `expiration_date` | string, list of strings, or null | Expiration date, with the same conversion and list behavior as `creation_date`. |
+| `updated_date` | string, list of strings, or null | Last-updated date, with the same conversion and list behavior as `creation_date`. |
+| `name_servers` | string, list of strings, or null | Name-server values. A single value is a string; multiple values are a list. |
+| `status` | string, list of strings, or null | Registration status values. A single value is a string; multiple values are a list. |
+| `emails` | string, list of strings, or null | Contact email values. A single value is a string; multiple values are a list. |
+| `dnssec` | string, list of strings, or null | DNSSEC status, when supplied. A single parsed value is a string; repeated values are a list. |
+| `country` | string, list of strings, or null | Registrant country, when supplied. A single parsed value is a string; repeated values are a list. |
+| `org` | string, list of strings, or null | Registrant organization, when supplied. A single parsed value is a string; repeated values are a list. |
+
+The successful `domain` field comes from the WHOIS response and is not a copy
+of the normalized input. The date fields are stringified for JSON output; the
+exact date text and format depend on the registry response.
+
+## Errors and timeouts
+
+Failure responses contain `success: false` and an `error` string instead of
+the successful fields:
+
+| Situation | Response |
+|---|---|
+| Input fails normalization or validation | `{"success": false, "error": "Invalid domain format"}` |
+| The WHOIS request raises a socket timeout or `TimeoutError` | `{"success": false, "error": "WHOIS lookup timed out after 10 seconds"}` |
+| Any other exception | `{"success": false, "error": "<exception message>"}` |
+
+The WHOIS request is made with a 10-second timeout. Other service or parser
+failures are returned using the underlying exception message.
+
+## Notes and limitations
+
+- No API key is required, but the lookup needs network access to the relevant
+  WHOIS service.
+- Field availability and formatting vary between registries and registrars;
+  missing values are returned as `null`.
+- A field with one parsed value is a scalar string, while repeated values are
+  returned as a list of strings.
+- The validator accepts domain names only; IP address lookups are not part of
+  this tool's input contract.
+
+## Related tools
+
+`dns_enumeration`, `asn_lookup`, and `full_recon` provide related DNS,
+network-ownership, and combined-reconnaissance views. See the [tools index](README.md)
+for the current registration inventory and documentation status.

--- a/tests/test_whois_lookup.py
+++ b/tests/test_whois_lookup.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 import socket
 import unittest
+from pathlib import Path
 from tools.whois_tool import whois_lookup
 
 class TestWhoisLookup(unittest.TestCase):
@@ -77,6 +78,28 @@ class TestWhoisLookup(unittest.TestCase):
         self.assertTrue(result["success"])
         self.assertIsNone(result["expiration_date"])
         self.assertIsNone(result["creation_date"])
+
+    @patch("tools.whois_tool.whois.whois")
+    def test_whois_summary_surfaces_describe_returned_organization(self, mock_whois):
+        mock_whois.return_value = self._mock_whois_result()
+        result = whois_lookup("example.com")
+
+        self.assertIn("org", result)
+        self.assertNotIn("owner", result)
+
+        repo_root = Path(__file__).resolve().parents[1]
+        summary_paths = (
+            repo_root / "README.md",
+            repo_root / "docs/tools/README.md",
+        )
+        for summary_path in summary_paths:
+            summary = next(
+                line
+                for line in summary_path.read_text().splitlines()
+                if "whois_lookup" in line and "whois_lookup.md" in line
+            )
+            self.assertIn("registrant organization", summary.lower())
+            self.assertNotIn("owner", summary.lower())
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_whois_lookup.py
+++ b/tests/test_whois_lookup.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock, patch
 import socket
 import unittest
-from pathlib import Path
 from tools.whois_tool import whois_lookup
 
 class TestWhoisLookup(unittest.TestCase):
@@ -78,28 +77,6 @@ class TestWhoisLookup(unittest.TestCase):
         self.assertTrue(result["success"])
         self.assertIsNone(result["expiration_date"])
         self.assertIsNone(result["creation_date"])
-
-    @patch("tools.whois_tool.whois.whois")
-    def test_whois_summary_surfaces_describe_returned_organization(self, mock_whois):
-        mock_whois.return_value = self._mock_whois_result()
-        result = whois_lookup("example.com")
-
-        self.assertIn("org", result)
-        self.assertNotIn("owner", result)
-
-        repo_root = Path(__file__).resolve().parents[1]
-        summary_paths = (
-            repo_root / "README.md",
-            repo_root / "docs/tools/README.md",
-        )
-        for summary_path in summary_paths:
-            summary = next(
-                line
-                for line in summary_path.read_text(encoding="utf-8").splitlines()
-                if "whois_lookup" in line and "whois_lookup.md" in line
-            )
-            self.assertIn("registrant organization", summary.lower())
-            self.assertNotIn("owner", summary.lower())
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_whois_lookup.py
+++ b/tests/test_whois_lookup.py
@@ -95,7 +95,7 @@ class TestWhoisLookup(unittest.TestCase):
         for summary_path in summary_paths:
             summary = next(
                 line
-                for line in summary_path.read_text().splitlines()
+                for line in summary_path.read_text(encoding="utf-8").splitlines()
                 if "whois_lookup" in line and "whois_lookup.md" in line
             )
             self.assertIn("registrant organization", summary.lower())


### PR DESCRIPTION
## Closes

Relates to #143

## Summary

Documents the current `whois_lookup` contract and introduces a complete tools index so users can find the new reference while the remaining issue scope stays open.

## What changed

- Added `docs/tools/whois_lookup.md` with input normalization and validation, an MCP request example, response fields and value shapes, timeout and error outcomes, limitations, and related tools.
- Added `docs/tools/README.md`, grouping and enumerating all 17 tools currently registered by the server.
- Linked the existing `whois_lookup` row in the root README to its dedicated page.

## Notes

- This is the first documentation slice related to #143; dedicated pages for the remaining tools are intentionally outside this PR.
- No runtime code, dependencies, or test behavior changed.

## Verification

- [x] Ran locally and confirmed it works as expected
  - Focused WHOIS regression tests: `python3 -m pytest tests/test_whois_lookup.py -q` (`7 passed`).
  - Relative-link checks resolved all four checked links, and the inventory check matched all 17 registered tools.
- [ ] Added/updated tests for the changed behavior (documentation-only change; no runtime behavior changed)
- [x] All tests pass (`pytest` via fork wrapper run `32688816381`)
  - The run had one successful `test` job with exact provenance `38042e7abe717aa8d8e9dfe5a46c861ab4441d85` and reported `366 passed, 85 subtests passed`.
- [x] No unrelated changes included
  - Independent review approved exact SHA `38042e7abe717aa8d8e9dfe5a46c861ab4441d85` for shipping.
- [x] Checked `CONTRIBUTING.md` and applied all changes
- [x] Updated Documentation ( if required )

Generated by GPT-5.6 Luna (implementation, testing, verification), GPT-5.6 Sol (brief, review, verification)
