### PR TITLE
feat(dns): run independent lookups concurrently

### DIFF
--- a/tests/test_dns_enumeration.py
+++ b/tests/test_dns_enumeration.py
@@ -178,6 +178,79 @@ class TestDnsEnumeration(unittest.TestCase):
             {"success": False, "error": "Domain example.com does not exist"},
         )
 
+    @patch("tools.dns_tool.dns.resolver.Resolver")
+    def test_later_nxdomain_returns_before_blocked_unrelated_work_is_released(
+        self, mock_resolver_class
+    ):
+        import dns.resolver as real_dns
+
+        resolver = Mock()
+        mock_resolver_class.return_value = resolver
+        first_record_noanswer = threading.Event()
+        later_record_nxdomain = threading.Event()
+        unrelated_started = threading.Event()
+        unrelated_gate = threading.Event()
+        enumeration_finished = threading.Event()
+        result = {}
+        failure = {}
+
+        def side_effect(name, rtype, lifetime=5, tcp=False):
+            if name == "example.com" and rtype == dns_tool.RECORD_TYPES[0]:
+                first_record_noanswer.set()
+                raise real_dns.NoAnswer
+            if name == "example.com" and rtype == dns_tool.RECORD_TYPES[1]:
+                later_record_nxdomain.set()
+                raise real_dns.NXDOMAIN
+            unrelated_started.set()
+            if not unrelated_gate.wait(timeout=10):
+                raise AssertionError("unrelated lookup gate was not released")
+            raise real_dns.NoAnswer
+
+        resolver.resolve.side_effect = side_effect
+
+        def enumerate_domain():
+            try:
+                result.update(dns_enumeration("example.com"))
+            except Exception as exc:
+                failure["exception"] = exc
+            finally:
+                enumeration_finished.set()
+
+        worker = threading.Thread(target=enumerate_domain)
+        worker.start()
+        try:
+            self.assertTrue(
+                first_record_noanswer.wait(timeout=5),
+                "the initial A lookup did not produce NoAnswer",
+            )
+            self.assertTrue(
+                later_record_nxdomain.wait(timeout=5),
+                "the later target-record lookup did not produce NXDOMAIN",
+            )
+            self.assertTrue(
+                unrelated_started.wait(timeout=5),
+                "unrelated lookup work was not scheduled before NXDOMAIN",
+            )
+            self.assertFalse(
+                unrelated_gate.is_set(),
+                "unrelated lookup work was released before the failure returned",
+            )
+            self.assertTrue(
+                enumeration_finished.wait(timeout=2),
+                "the later NXDOMAIN result waited for unrelated lookup work",
+            )
+        finally:
+            unrelated_gate.set()
+            worker.join(timeout=10)
+
+        self.assertFalse(worker.is_alive(), "DNS enumeration did not shut down")
+        if "exception" in failure:
+            raise failure["exception"]
+        self.assertEqual(
+            result,
+            {"success": False, "error": "Domain example.com does not exist"},
+        )
+
     def test_invalid_domain(self):
         result = dns_enumeration("bad_domain")
         self.assertFalse(result["success"])

--- a/tests/test_dns_enumeration.py
+++ b/tests/test_dns_enumeration.py
@@ -178,6 +178,7 @@ class TestDnsEnumeration(unittest.TestCase):
             {"success": False, "error": "Domain example.com does not exist"},
         )
 
+    @patch("tools.dns_tool.MAX_CONCURRENT_LOOKUPS", 2)
     @patch("tools.dns_tool.dns.resolver.Resolver")
     def test_later_nxdomain_returns_before_blocked_unrelated_work_is_released(
         self, mock_resolver_class
@@ -187,23 +188,60 @@ class TestDnsEnumeration(unittest.TestCase):
         resolver = Mock()
         mock_resolver_class.return_value = resolver
         first_record_noanswer = threading.Event()
+        aaaa_started = threading.Event()
         later_record_nxdomain = threading.Event()
         unrelated_started = threading.Event()
         unrelated_gate = threading.Event()
+        unrelated_finished = threading.Event()
+        topology_ready = threading.Event()
+        queued_started = threading.Event()
+        queued_gate = threading.Event()
+        sentinel_started = threading.Event()
+        sentinel_gate = threading.Event()
+        blockers_finished = threading.Event()
+        blockers_lock = threading.Lock()
+        active_blockers = 0
         enumeration_finished = threading.Event()
         result = {}
         failure = {}
+        sentinel_name = "aws.example.com"
+
+        def wait_for_gate(gate, label):
+            nonlocal active_blockers
+            with blockers_lock:
+                active_blockers += 1
+                blockers_finished.clear()
+            try:
+                if not gate.wait(timeout=10):
+                    raise AssertionError(f"{label} gate was not released")
+            finally:
+                with blockers_lock:
+                    active_blockers -= 1
+                    if active_blockers == 0:
+                        blockers_finished.set()
 
         def side_effect(name, rtype, lifetime=5, tcp=False):
             if name == "example.com" and rtype == dns_tool.RECORD_TYPES[0]:
                 first_record_noanswer.set()
                 raise real_dns.NoAnswer
             if name == "example.com" and rtype == dns_tool.RECORD_TYPES[1]:
+                aaaa_started.set()
+                wait_for_gate(topology_ready, "AAAA topology")
                 later_record_nxdomain.set()
                 raise real_dns.NXDOMAIN
-            unrelated_started.set()
-            if not unrelated_gate.wait(timeout=10):
-                raise AssertionError("unrelated lookup gate was not released")
+            if name == sentinel_name:
+                sentinel_started.set()
+                wait_for_gate(sentinel_gate, "sentinel")
+                raise real_dns.NoAnswer
+            if name == "_sip._tcp.example.com" and rtype == "SRV":
+                unrelated_started.set()
+                try:
+                    wait_for_gate(unrelated_gate, "unrelated lookup")
+                finally:
+                    unrelated_finished.set()
+                raise real_dns.NoAnswer
+            queued_started.set()
+            wait_for_gate(queued_gate, "queued lookup")
             raise real_dns.NoAnswer
 
         resolver.resolve.side_effect = side_effect
@@ -224,12 +262,21 @@ class TestDnsEnumeration(unittest.TestCase):
                 "the initial A lookup did not produce NoAnswer",
             )
             self.assertTrue(
-                later_record_nxdomain.wait(timeout=5),
-                "the later target-record lookup did not produce NXDOMAIN",
+                aaaa_started.wait(timeout=5),
+                "the later AAAA lookup did not start",
             )
             self.assertTrue(
                 unrelated_started.wait(timeout=5),
-                "unrelated lookup work was not scheduled before NXDOMAIN",
+                "the unrelated SRV lookup did not occupy the second worker",
+            )
+            self.assertFalse(
+                queued_started.is_set(),
+                "queued lookup work started before both workers were occupied",
+            )
+            topology_ready.set()
+            self.assertTrue(
+                later_record_nxdomain.wait(timeout=5),
+                "the later target-record lookup did not produce NXDOMAIN",
             )
             self.assertFalse(
                 unrelated_gate.is_set(),
@@ -240,15 +287,30 @@ class TestDnsEnumeration(unittest.TestCase):
                 "the later NXDOMAIN result waited for unrelated lookup work",
             )
         finally:
+            topology_ready.set()
             unrelated_gate.set()
+            queued_gate.set()
+            sentinel_gate.set()
             worker.join(timeout=10)
 
         self.assertFalse(worker.is_alive(), "DNS enumeration did not shut down")
+        self.assertTrue(
+            unrelated_finished.wait(timeout=10),
+            "the running unrelated lookup did not terminate",
+        )
+        self.assertTrue(
+            blockers_finished.wait(timeout=10),
+            "a running lookup blocker did not terminate",
+        )
         if "exception" in failure:
             raise failure["exception"]
         self.assertEqual(
             result,
             {"success": False, "error": "Domain example.com does not exist"},
+        )
+        self.assertFalse(
+            sentinel_started.wait(timeout=2),
+            "the far-late queued lookup started after blockers were released",
         )
 
     def test_invalid_domain(self):

--- a/tests/test_dns_enumeration.py
+++ b/tests/test_dns_enumeration.py
@@ -1,3 +1,4 @@
+import threading
 import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock, patch
@@ -56,6 +57,67 @@ class TestDnsEnumeration(unittest.TestCase):
         answer.__iter__.return_value = iter(records)
         answer.rrset.ttl = ttl
         return answer
+
+    @patch("tools.dns_tool.dns.resolver.Resolver")
+    def test_independent_lookup_categories_can_overlap(self, mock_resolver_class):
+        import dns.resolver as real_dns
+
+        resolver = Mock()
+        mock_resolver_class.return_value = resolver
+        lookup_gate = threading.Event()
+        all_categories_started = threading.Event()
+        calls = []
+        calls_lock = threading.Lock()
+        result = {}
+        failure = {}
+
+        def side_effect(name, rtype, lifetime=5, tcp=False):
+            with calls_lock:
+                calls.append((name, rtype))
+                if len(calls) == 3:
+                    all_categories_started.set()
+            if not lookup_gate.wait(timeout=10):
+                raise AssertionError("lookup synchronization gate was not released")
+            raise real_dns.NoAnswer
+
+        resolver.resolve.side_effect = side_effect
+
+        def enumerate_domain():
+            try:
+                result.update(dns_enumeration("example.com"))
+            except Exception as exc:
+                failure["exception"] = exc
+
+        with patch.multiple(
+            "tools.dns_tool",
+            RECORD_TYPES=["A"],
+            SRV_SERVICES=["_sip._tcp"],
+            COMMON_SUBDOMAINS=["www"],
+            SUBDOMAIN_RECORD_TYPES=("A",),
+        ):
+            worker = threading.Thread(target=enumerate_domain)
+            worker.start()
+            try:
+                self.assertTrue(
+                    all_categories_started.wait(timeout=5),
+                    "record, SRV, and subdomain lookups did not overlap",
+                )
+            finally:
+                lookup_gate.set()
+                worker.join(timeout=10)
+
+        self.assertFalse(worker.is_alive(), "DNS enumeration did not shut down")
+        if "exception" in failure:
+            raise failure["exception"]
+        self.assertEqual(
+            set(calls[:3]),
+            {
+                ("example.com", "A"),
+                ("_sip._tcp.example.com", "SRV"),
+                ("www.example.com", "A"),
+            },
+        )
+        self.assertTrue(result["success"])
 
     def test_invalid_domain(self):
         result = dns_enumeration("bad_domain")

--- a/tests/test_dns_enumeration.py
+++ b/tests/test_dns_enumeration.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, Mock, patch
 import dns.rdata
 import dns.rdataclass
 import dns.rdatatype
+from tools import dns_tool
 from tools.dns_tool import dns_enumeration
 
 
@@ -59,22 +60,32 @@ class TestDnsEnumeration(unittest.TestCase):
         return answer
 
     @patch("tools.dns_tool.dns.resolver.Resolver")
-    def test_independent_lookup_categories_can_overlap(self, mock_resolver_class):
+    def test_production_queue_does_not_starve_lookup_category(
+        self, mock_resolver_class
+    ):
         import dns.resolver as real_dns
 
         resolver = Mock()
         mock_resolver_class.return_value = resolver
         lookup_gate = threading.Event()
         all_categories_started = threading.Event()
-        calls = []
+        categories = set()
         calls_lock = threading.Lock()
         result = {}
         failure = {}
 
         def side_effect(name, rtype, lifetime=5, tcp=False):
+            if name == "example.com" and rtype == dns_tool.RECORD_TYPES[0]:
+                raise real_dns.NoAnswer
             with calls_lock:
-                calls.append((name, rtype))
-                if len(calls) == 3:
+                categories.add(
+                    "record"
+                    if name == "example.com"
+                    else "srv"
+                    if rtype == "SRV"
+                    else "subdomain"
+                )
+                if len(categories) == 3:
                     all_categories_started.set()
             if not lookup_gate.wait(timeout=10):
                 raise AssertionError("lookup synchronization gate was not released")
@@ -88,36 +99,84 @@ class TestDnsEnumeration(unittest.TestCase):
             except Exception as exc:
                 failure["exception"] = exc
 
-        with patch.multiple(
-            "tools.dns_tool",
-            RECORD_TYPES=["A"],
-            SRV_SERVICES=["_sip._tcp"],
-            COMMON_SUBDOMAINS=["www"],
-            SUBDOMAIN_RECORD_TYPES=("A",),
-        ):
-            worker = threading.Thread(target=enumerate_domain)
-            worker.start()
-            try:
-                self.assertTrue(
-                    all_categories_started.wait(timeout=5),
-                    "record, SRV, and subdomain lookups did not overlap",
-                )
-            finally:
-                lookup_gate.set()
-                worker.join(timeout=10)
+        worker = threading.Thread(target=enumerate_domain)
+        worker.start()
+        try:
+            self.assertTrue(
+                all_categories_started.wait(timeout=5),
+                "a lookup category was starved under production queue depths",
+            )
+            with calls_lock:
+                self.assertEqual(categories, {"record", "srv", "subdomain"})
+        finally:
+            lookup_gate.set()
+            worker.join(timeout=10)
 
         self.assertFalse(worker.is_alive(), "DNS enumeration did not shut down")
         if "exception" in failure:
             raise failure["exception"]
-        self.assertEqual(
-            set(calls[:3]),
-            {
-                ("example.com", "A"),
-                ("_sip._tcp.example.com", "SRV"),
-                ("www.example.com", "A"),
-            },
-        )
         self.assertTrue(result["success"])
+
+    @patch("tools.dns_tool.dns.resolver.Resolver")
+    def test_nxdomain_returns_without_waiting_for_unrelated_work(
+        self, mock_resolver_class
+    ):
+        import dns.resolver as real_dns
+
+        resolver = Mock()
+        mock_resolver_class.return_value = resolver
+        nxdomain_raised = threading.Event()
+        unrelated_started = threading.Event()
+        unrelated_gate = threading.Event()
+        enumeration_finished = threading.Event()
+        result = {}
+        failure = {}
+
+        def side_effect(name, rtype, lifetime=5, tcp=False):
+            if name == "example.com" and rtype == dns_tool.RECORD_TYPES[0]:
+                nxdomain_raised.set()
+                raise real_dns.NXDOMAIN
+            unrelated_started.set()
+            if not unrelated_gate.wait(timeout=10):
+                raise AssertionError("unrelated lookup gate was not released")
+            raise real_dns.NoAnswer
+
+        resolver.resolve.side_effect = side_effect
+
+        def enumerate_domain():
+            try:
+                result.update(dns_enumeration("example.com"))
+            except Exception as exc:
+                failure["exception"] = exc
+            finally:
+                enumeration_finished.set()
+
+        worker = threading.Thread(target=enumerate_domain)
+        worker.start()
+        try:
+            self.assertTrue(
+                nxdomain_raised.wait(timeout=5),
+                "the target-domain NXDOMAIN lookup did not run",
+            )
+            self.assertTrue(
+                enumeration_finished.wait(timeout=2),
+                "the NXDOMAIN result waited for unrelated lookup work",
+            )
+        finally:
+            unrelated_gate.set()
+            worker.join(timeout=10)
+
+        self.assertFalse(worker.is_alive(), "DNS enumeration did not shut down")
+        if "exception" in failure:
+            raise failure["exception"]
+        self.assertFalse(
+            unrelated_started.is_set(),
+            "unrelated lookup work started after a conclusive NXDOMAIN",
+        )
+        self.assertEqual(
+            result,
+            {"success": False, "error": "Domain example.com does not exist"},
+        )
 
     def test_invalid_domain(self):
         result = dns_enumeration("bad_domain")

--- a/tools/dns_tool.py
+++ b/tools/dns_tool.py
@@ -1,3 +1,5 @@
+from concurrent.futures import ThreadPoolExecutor
+
 import dns.exception
 import dns.name
 import dns.resolver
@@ -10,6 +12,7 @@ PUBLIC_RESOLVERS = ["1.1.1.1", "8.8.8.8"]
 RESOLVER_TIMEOUT = 2.0
 RESOLVER_LIFETIME = 5
 SUBDOMAIN_LIFETIME = 3
+MAX_CONCURRENT_LOOKUPS = 10
 
 # Record types enumerated for the target domain.
 RECORD_TYPES = ["A", "AAAA", "MX", "NS", "TXT", "CNAME", "SOA", "CAA"]
@@ -110,6 +113,19 @@ def _resolver_metadata(resolver) -> dict:
     }
 
 
+def _lookup_subdomain(resolver, full: str) -> tuple[bool, dict]:
+    errors = {}
+    for rtype in SUBDOMAIN_RECORD_TYPES:
+        try:
+            resolver.resolve(full, rtype, lifetime=SUBDOMAIN_LIFETIME)
+            return True, {}
+        except SUBDOMAIN_LOOKUP_ERRORS:
+            continue
+        except Exception as exc:
+            errors[rtype] = f"unexpected: {type(exc).__name__}"
+    return False, errors
+
+
 def dns_enumeration(domain: str) -> dict:
     """
     Enumerate DNS records for a domain.
@@ -129,109 +145,117 @@ def dns_enumeration(domain: str) -> dict:
     ttls = {}
     resolver = _make_resolver()
 
-    for rtype in RECORD_TYPES:
-        try:
-            answers = resolver.resolve(domain, rtype, lifetime=RESOLVER_LIFETIME)
-        except dns.resolver.NXDOMAIN:
-            return {"success": False, "error": f"Domain {domain} does not exist"}
-        except LOOKUP_ERRORS as exc:
-            records[rtype] = []
-            errors[rtype] = type(exc).__name__
-        except Exception as exc:
-            records[rtype] = []
-            errors[rtype] = f"unexpected: {type(exc).__name__}"
-        else:
-            ttl = _record_ttl(answers)
-            if ttl is not None:
-                ttls[rtype] = ttl
+    lookup_count = len(RECORD_TYPES) + len(SRV_SERVICES) + len(COMMON_SUBDOMAINS)
+    max_workers = max(1, min(MAX_CONCURRENT_LOOKUPS, lookup_count))
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        record_futures = [
+            executor.submit(
+                resolver.resolve, domain, rtype, lifetime=RESOLVER_LIFETIME
+            )
+            for rtype in RECORD_TYPES
+        ]
+        srv_futures = [
+            executor.submit(
+                resolver.resolve,
+                f"{service}.{domain}",
+                "SRV",
+                lifetime=RESOLVER_LIFETIME,
+            )
+            for service in SRV_SERVICES
+        ]
+        subdomain_futures = [
+            executor.submit(_lookup_subdomain, resolver, f"{sub}.{domain}")
+            for sub in COMMON_SUBDOMAINS
+        ]
+
+        for rtype, future in zip(RECORD_TYPES, record_futures):
             try:
-                if rtype == "MX":
-                    records[rtype] = [
-                        {"preference": r.preference, "exchange": _clean_name(r.exchange)}
-                        for r in answers
-                    ]
-                elif rtype == "SOA":
-                    r = answers[0]
-                    records[rtype] = {
-                        "mname": _clean_name(r.mname),
-                        "rname": _clean_name(r.rname),
-                        "serial": r.serial,
-                        "refresh": r.refresh,
-                        "retry": r.retry,
-                        "expire": r.expire,
-                        "minimum": r.minimum
-                    }
-                elif rtype == "TXT":
-                    records[rtype] = [_format_txt_record(r) for r in answers]
-                elif rtype == "CAA":
-                    records[rtype] = [_format_caa_record(r) for r in answers]
-                elif rtype in {"NS", "CNAME"}:
-                    records[rtype] = [_clean_name(r) for r in answers]
-                else:
-                    records[rtype] = [str(r) for r in answers]
-            except UnicodeDecodeError as exc:
-                # TXT chunks and CAA values are arbitrary remote octets, not
-                # guaranteed UTF-8. Keep this record type's failure visible
-                # without swallowing defects in our own formatting logic.
+                answers = future.result()
+            except dns.resolver.NXDOMAIN:
+                return {"success": False, "error": f"Domain {domain} does not exist"}
+            except LOOKUP_ERRORS as exc:
                 records[rtype] = []
                 errors[rtype] = type(exc).__name__
-                ttls.pop(rtype, None)
-
-    # SRV enumeration for common enterprise services. Unlike the target
-    # domain itself, an SRV owner name that does not exist (NXDOMAIN) or has
-    # no SRV RRset (NoAnswer) is the ordinary "service not published" outcome,
-    # so it stays an empty list with no error; other anticipated lookup
-    # failures and genuine surprises follow the same error conventions as the
-    # record-type loop above.
-    srv_records = {}
-    srv_errors = {}
-
-    for service in SRV_SERVICES:
-        srv_name = f"{service}.{domain}"
-        try:
-            answers = resolver.resolve(srv_name, "SRV", lifetime=RESOLVER_LIFETIME)
-        except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
-            srv_records[service] = []
-        except SRV_LOOKUP_ERRORS as exc:
-            srv_records[service] = []
-            srv_errors[service] = type(exc).__name__
-        except Exception as exc:
-            srv_records[service] = []
-            srv_errors[service] = f"unexpected: {type(exc).__name__}"
-        else:
-            srv_records[service] = [
-                {
-                    "priority": r.priority,
-                    "weight": r.weight,
-                    "port": r.port,
-                    "target": _clean_name(r.target),
-                }
-                for r in answers
-            ]
-
-    # Subdomain brute-force (common subdomains); a subdomain counts as found
-    # when any of A/AAAA/CNAME resolves, so IPv6-only and aliased hosts are
-    # not missed.
-    found_subdomains = []
-    subdomain_errors = {}
-
-    for sub in COMMON_SUBDOMAINS:
-        full = f"{sub}.{domain}"
-        for rtype in SUBDOMAIN_RECORD_TYPES:
-            try:
-                resolver.resolve(full, rtype, lifetime=SUBDOMAIN_LIFETIME)
-                found_subdomains.append(full)
-                # A name that resolves on any record type is found, so an
-                # error recorded for an earlier record type no longer applies.
-                subdomain_errors.pop(full, None)
-                break
-            except SUBDOMAIN_LOOKUP_ERRORS:
-                continue
             except Exception as exc:
-                subdomain_errors.setdefault(full, {})[rtype] = (
-                    f"unexpected: {type(exc).__name__}"
-                )
-                continue
+                records[rtype] = []
+                errors[rtype] = f"unexpected: {type(exc).__name__}"
+            else:
+                ttl = _record_ttl(answers)
+                if ttl is not None:
+                    ttls[rtype] = ttl
+                try:
+                    if rtype == "MX":
+                        records[rtype] = [
+                            {
+                                "preference": r.preference,
+                                "exchange": _clean_name(r.exchange),
+                            }
+                            for r in answers
+                        ]
+                    elif rtype == "SOA":
+                        r = answers[0]
+                        records[rtype] = {
+                            "mname": _clean_name(r.mname),
+                            "rname": _clean_name(r.rname),
+                            "serial": r.serial,
+                            "refresh": r.refresh,
+                            "retry": r.retry,
+                            "expire": r.expire,
+                            "minimum": r.minimum,
+                        }
+                    elif rtype == "TXT":
+                        records[rtype] = [_format_txt_record(r) for r in answers]
+                    elif rtype == "CAA":
+                        records[rtype] = [_format_caa_record(r) for r in answers]
+                    elif rtype in {"NS", "CNAME"}:
+                        records[rtype] = [_clean_name(r) for r in answers]
+                    else:
+                        records[rtype] = [str(r) for r in answers]
+                except UnicodeDecodeError as exc:
+                    # TXT chunks and CAA values are arbitrary remote octets,
+                    # not guaranteed UTF-8. Keep this record type's failure
+                    # visible without swallowing defects in our formatting.
+                    records[rtype] = []
+                    errors[rtype] = type(exc).__name__
+                    ttls.pop(rtype, None)
+
+        # SRV enumeration for common enterprise services. Unlike the target
+        # domain itself, an absent SRV owner or RRset is an ordinary negative.
+        srv_records = {}
+        srv_errors = {}
+        for service, future in zip(SRV_SERVICES, srv_futures):
+            try:
+                answers = future.result()
+            except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
+                srv_records[service] = []
+            except SRV_LOOKUP_ERRORS as exc:
+                srv_records[service] = []
+                srv_errors[service] = type(exc).__name__
+            except Exception as exc:
+                srv_records[service] = []
+                srv_errors[service] = f"unexpected: {type(exc).__name__}"
+            else:
+                srv_records[service] = [
+                    {
+                        "priority": r.priority,
+                        "weight": r.weight,
+                        "port": r.port,
+                        "target": _clean_name(r.target),
+                    }
+                    for r in answers
+                ]
+
+        # Aggregate completed subdomain work in configured order so execution
+        # timing cannot alter the public result.
+        found_subdomains = []
+        subdomain_errors = {}
+        for sub, future in zip(COMMON_SUBDOMAINS, subdomain_futures):
+            full = f"{sub}.{domain}"
+            found, lookup_errors = future.result()
+            if found:
+                found_subdomains.append(full)
+            elif lookup_errors:
+                subdomain_errors[full] = lookup_errors
 
     return {
         "success": True,

--- a/tools/dns_tool.py
+++ b/tools/dns_tool.py
@@ -1,4 +1,5 @@
 from concurrent.futures import ThreadPoolExecutor
+from itertools import zip_longest
 
 import dns.exception
 import dns.name
@@ -145,32 +146,58 @@ def dns_enumeration(domain: str) -> dict:
     ttls = {}
     resolver = _make_resolver()
 
+    first_record_answers = None
+    first_record_error = None
+    if RECORD_TYPES:
+        try:
+            first_record_answers = resolver.resolve(
+                domain, RECORD_TYPES[0], lifetime=RESOLVER_LIFETIME
+            )
+        except dns.resolver.NXDOMAIN:
+            return {"success": False, "error": f"Domain {domain} does not exist"}
+        except Exception as exc:
+            first_record_error = exc
+
     lookup_count = len(RECORD_TYPES) + len(SRV_SERVICES) + len(COMMON_SUBDOMAINS)
     max_workers = max(1, min(MAX_CONCURRENT_LOOKUPS, lookup_count))
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        record_futures = [
-            executor.submit(
-                resolver.resolve, domain, rtype, lifetime=RESOLVER_LIFETIME
-            )
-            for rtype in RECORD_TYPES
-        ]
-        srv_futures = [
-            executor.submit(
-                resolver.resolve,
-                f"{service}.{domain}",
-                "SRV",
-                lifetime=RESOLVER_LIFETIME,
-            )
-            for service in SRV_SERVICES
-        ]
-        subdomain_futures = [
-            executor.submit(_lookup_subdomain, resolver, f"{sub}.{domain}")
-            for sub in COMMON_SUBDOMAINS
-        ]
+        record_futures = []
+        srv_futures = []
+        subdomain_futures = []
+        for rtype, service, sub in zip_longest(
+            RECORD_TYPES[1:], SRV_SERVICES, COMMON_SUBDOMAINS
+        ):
+            if rtype is not None:
+                record_futures.append(
+                    executor.submit(
+                        resolver.resolve,
+                        domain,
+                        rtype,
+                        lifetime=RESOLVER_LIFETIME,
+                    )
+                )
+            if service is not None:
+                srv_futures.append(
+                    executor.submit(
+                        resolver.resolve,
+                        f"{service}.{domain}",
+                        "SRV",
+                        lifetime=RESOLVER_LIFETIME,
+                    )
+                )
+            if sub is not None:
+                subdomain_futures.append(
+                    executor.submit(_lookup_subdomain, resolver, f"{sub}.{domain}")
+                )
 
-        for rtype, future in zip(RECORD_TYPES, record_futures):
+        for index, rtype in enumerate(RECORD_TYPES):
             try:
-                answers = future.result()
+                if index == 0:
+                    if first_record_error is not None:
+                        raise first_record_error
+                    answers = first_record_answers
+                else:
+                    answers = record_futures[index - 1].result()
             except dns.resolver.NXDOMAIN:
                 return {"success": False, "error": f"Domain {domain} does not exist"}
             except LOOKUP_ERRORS as exc:

--- a/tools/dns_tool.py
+++ b/tools/dns_tool.py
@@ -6,6 +6,16 @@ import dns.name
 import dns.resolver
 from utils.helpers import is_valid_domain, normalize_domain
 
+
+class _DnsExecutor(ThreadPoolExecutor):
+    def cancel_pending(self):
+        self._cancel_pending = True
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        cancel_pending = getattr(self, "_cancel_pending", False)
+        self.shutdown(wait=not cancel_pending, cancel_futures=cancel_pending)
+        return False
+
 # Public resolvers used for every lookup.
 PUBLIC_RESOLVERS = ["1.1.1.1", "8.8.8.8"]
 
@@ -160,7 +170,7 @@ def dns_enumeration(domain: str) -> dict:
 
     lookup_count = len(RECORD_TYPES) + len(SRV_SERVICES) + len(COMMON_SUBDOMAINS)
     max_workers = max(1, min(MAX_CONCURRENT_LOOKUPS, lookup_count))
-    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+    with _DnsExecutor(max_workers=max_workers) as executor:
         record_futures = []
         srv_futures = []
         subdomain_futures = []
@@ -199,6 +209,7 @@ def dns_enumeration(domain: str) -> dict:
                 else:
                     answers = record_futures[index - 1].result()
             except dns.resolver.NXDOMAIN:
+                executor.cancel_pending()
                 return {"success": False, "error": f"Domain {domain} does not exist"}
             except LOOKUP_ERRORS as exc:
                 records[rtype] = []


### PR DESCRIPTION
## Closes

Relates to #144

## Summary

Runs independent DNS work through a bounded, category-fair executor while preserving the conclusive NXDOMAIN short-circuit and deterministic output semantics. This addresses item 2 only; the other issue items remain open.

## What changed

- Kept the first configured target-record lookup ahead of executor creation so a conclusive NXDOMAIN returns before unrelated work starts.
- Interleaved the remaining record, SRV, and common-subdomain tasks through a bounded executor so each category can make progress under production queue depths.
- Aggregated completed work in configured order, preserving prior TTL handling, error classification, parsing, and output ordering.
- Added synchronization regressions for production-depth category starvation and NXDOMAIN shutdown behavior.

## Notes

- The public function signature and result schemas are unchanged.
- This PR is limited to issue #144 item 2; the remaining items are intentionally outside its scope.

## Verification

- [x] Ran locally and confirmed it works as expected
  - The implementer report records assertion-first regressions for production-depth category starvation and NXDOMAIN shutdown.
- [x] Added/updated tests for the changed behavior
  - The implementer report records both single-defect mutations being killed by their intended assertions.
- [x] All tests pass (`python3 -m unittest tests.test_dns_enumeration`: 22 tests)
  - Fork wrapper run `32691463503` had one successful `test` job with exact provenance `1cad4402eee2ac15de1dae0eea2cdc4aadc518d5` and reported `368 passed, 85 subtests passed`.
- [x] No unrelated changes included
  - Independent task and final whole-branch reviews both returned `SHIP 1cad4402eee2ac15de1dae0eea2cdc4aadc518d5`.
- [x] Checked `CONTRIBUTING.md` and applied all changes
- [ ] Updated Documentation (not required; public interfaces and result schemas are unchanged)

Generated by GPT-5.6 Sol (brief, implementation, testing, review, verification), GPT-5.6 Luna (verification)
