### PR TITLE
docs(port-scan): add port_scan reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ reference pages and the current registration inventory.
 |---|---|
 | [`whois_lookup`](docs/tools/whois_lookup.md) | Domain registration data — registrant organization, registrar, creation date, expiry, name servers |
 | [`dns_enumeration`](docs/tools/dns_enumeration.md) | A, AAAA, MX, NS, TXT, CNAME, SOA, CAA, and common SRV records (SIP, LDAP, XMPP, Kerberos, Autodiscover) + common subdomain brute-forcing |
-| [`port_scan`](docs/tools/port_scan.md) | Nmap-powered scanner with service/version detection and security warnings |
+| [`port_scan`](docs/tools/port_scan.md) | Nmap-powered scanner with basic, service, OS, full-port, and vulnerability modes. |
 | `ssl_inspect` | SSL/TLS certificate — issuer, expiry, cipher strength, SANs, TLS version |
 | `email_security_check` | Checks SPF, DKIM, and DMARC DNS records — returns a security_score, rating, and actionable recommendations for missing or weak configurations |
 | `tech_stack_detect` | Web server, CMS, JS frameworks, CDN, and analytics |

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ reference pages and the current registration inventory.
 |---|---|
 | [`whois_lookup`](docs/tools/whois_lookup.md) | Domain registration data — registrant organization, registrar, creation date, expiry, name servers |
 | [`dns_enumeration`](docs/tools/dns_enumeration.md) | A, AAAA, MX, NS, TXT, CNAME, SOA, CAA, and common SRV records (SIP, LDAP, XMPP, Kerberos, Autodiscover) + common subdomain brute-forcing |
-| `port_scan` | Nmap-powered scanner with service/version detection and security warnings |
+| [`port_scan`](docs/tools/port_scan.md) | Nmap-powered scanner with service/version detection and security warnings |
 | `ssl_inspect` | SSL/TLS certificate — issuer, expiry, cipher strength, SANs, TLS version |
 | `email_security_check` | Checks SPF, DKIM, and DMARC DNS records — returns a security_score, rating, and actionable recommendations for missing or weak configurations |
 | `tech_stack_detect` | Web server, CMS, JS frameworks, CDN, and analytics |

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -1,8 +1,8 @@
 # AynOps tools
 
 This index lists the tools currently registered by the MCP server. Dedicated
-pages are being added incrementally; `whois_lookup` is documented in this
-slice, and the remaining pages are planned follow-ups.
+pages are being added incrementally; entries marked `Available` link to
+completed pages.
 
 ## Included in `full_recon`
 

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -10,7 +10,7 @@ slice, and the remaining pages are planned follow-ups.
 |---|---|---|
 | [`whois_lookup`](whois_lookup.md) | Domain registration data — registrant organization, registrar, creation date, expiry, and name servers | Available |
 | [`dns_enumeration`](dns_enumeration.md) | Enumerates DNS records and common subdomains | Available |
-| `port_scan` | Nmap-powered port scanner with service and version detection | Pending |
+| [`port_scan`](port_scan.md) | Nmap-powered port scanner with service and version detection | Available |
 | `ssl_inspect` | Inspects SSL/TLS certificates, cipher strength, SANs, and TLS version | Pending |
 | `email_security_check` | Checks SPF, DKIM, and DMARC configuration | Pending |
 | `tech_stack_detect` | Detects web servers, CMSs, JavaScript frameworks, CDNs, and analytics | Pending |

--- a/docs/tools/port_scan.md
+++ b/docs/tools/port_scan.md
@@ -1,0 +1,215 @@
+# `port_scan`
+
+## Overview
+
+`port_scan` runs Nmap against a target domain or IP address and returns the
+hosts Nmap found, their protocol and port data, and (for OS scans) operating
+system matches. It is registered as a public MCP tool and does not require an
+API key.
+
+The callable is:
+
+```python
+port_scan(target, scan_type="basic", timeout=None)
+```
+
+The implementation passes `target` directly to Nmap. It does not normalize the
+target or perform domain, IP-address, ownership, or authorization validation.
+
+## Purpose and common use cases
+
+Use this tool to identify reachable hosts, open ports, and the service data
+that Nmap reports for an authorized target. Choose a service scan when service
+and version information is useful, an OS scan when operating-system detection
+is needed, a full scan when all ports must be considered, or a vulnerability
+scan when the Nmap `vuln` script set is appropriate for the engagement.
+
+## Parameters
+
+The MCP tool has one required parameter and two optional parameters:
+
+| Name | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `target` | string | Yes | — | Domain name or IP address passed directly to Nmap. The tool does not validate its format. |
+| `scan_type` | string | No | `"basic"` | One of exactly `basic`, `service`, `os`, `full`, or `vuln`. |
+| `timeout` | integer or null | No | Derived | Optional positive application-level timeout in seconds. `null` uses the mode's derived default. |
+
+## Optional parameters
+
+`scan_type` selects one of the five fixed Nmap configurations. `timeout`, when
+provided, must be positive and replaces the derived application-level timeout
+passed to `scanner.scan`; it does not change the mode's Nmap argument string.
+
+The derived default is the mode's Nmap `--host-timeout` multiplied by the
+application's 20% margin and converted to an integer number of seconds:
+
+| Mode | Nmap arguments | Nmap semantics | Derived application timeout |
+|---|---|---|---:|
+| `basic` | `-F --host-timeout 30s` | Fast scan of the top 100 ports. | 36 seconds |
+| `service` | `-sV -F --host-timeout 120s` | Service and version detection over the fast port set. | 144 seconds |
+| `os` | `-O -F --host-timeout 60s` | Operating-system detection over the fast port set. | 72 seconds |
+| `full` | `-p- --host-timeout 15m` | Scan all 65,535 ports. | 1,080 seconds |
+| `vuln` | `--script vuln -F --host-timeout 15m --script-timeout 5m` | Run Nmap's `vuln` scripts over the fast port set, with a five-minute script timeout. | 1,080 seconds |
+
+The derived values are application timeouts; the `--host-timeout` and, for
+`vuln`, `--script-timeout` values remain part of the Nmap arguments shown above.
+
+## Example MCP request
+
+The public MCP registration uses the callable name and parameter names shown
+in the signature:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "port_scan",
+    "arguments": {
+      "target": "scanme.nmap.org",
+      "scan_type": "service",
+      "timeout": 300
+    }
+  }
+}
+```
+
+This is a request shape example only; it does not perform a scan here.
+
+## Example successful response
+
+The following is an illustrative response using the shape returned by the
+focused mocked test suite. Values are examples, not the result of a live
+scan:
+
+```json
+{
+  "success": true,
+  "target": "scanme.nmap.org",
+  "scan_type": "service",
+  "hosts_found": 1,
+  "duration_seconds": 1.23,
+  "results": [
+    {
+      "host": "93.184.216.34",
+      "hostname": "example.com",
+      "state": "up",
+      "protocols": {
+        "tcp": [
+          {
+            "port": 80,
+            "state": "open",
+            "service": "http",
+            "product": "nginx",
+            "version": "1.18",
+            "scripts": {
+              "http-title": "Example Domain"
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "host_timeout_status": {
+    "93.184.216.34": false
+  }
+}
+```
+
+For an `os` scan, a host result can additionally contain the OS matches that
+Nmap returned:
+
+```json
+{
+  "os_matches": [
+    {
+      "name": "Linux 4.19 - 5.15",
+      "accuracy": "98"
+    }
+  ]
+}
+```
+
+The `os_matches` key is omitted for non-OS scans and when Nmap returns an empty
+`osmatch` list for an OS scan. If Nmap returns source entries without a
+non-empty `name` or `accuracy`, the key is present with an empty list.
+
+## Response field descriptions
+
+On success, the response contains `success: true` and these fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `success` | boolean | `true` when Nmap completed and the result was assembled. |
+| `target` | string | The exact target value passed to the callable and Nmap; it is not normalized. |
+| `scan_type` | string | The selected mode: `basic`, `service`, `os`, `full`, or `vuln`. |
+| `hosts_found` | integer | Number of host entries in `results`; it can be zero. |
+| `duration_seconds` | number or null | Nmap's elapsed scan time parsed as a floating-point number. It is `null` when scan statistics are unavailable or cannot be read. |
+| `results` | array of objects | One entry for each host returned by Nmap. An empty scan returns an empty array. |
+| `host_timeout_status` | object or null | A map from IPv4 (preferred) or IPv6 host address to a boolean parsed from Nmap XML. `true` means the host has `timedout="true"`; `false` means the host element does not have that value. It is `null` when XML is unavailable, invalid, or contains no usable host address. |
+
+Each object in `results` contains:
+
+| Field | Type | Description |
+|---|---|---|
+| `host` | string | Host address/key returned by Nmap. |
+| `hostname` | string | Hostname returned by Nmap's host record. |
+| `state` | string | Nmap host state, such as `up`. |
+| `protocols` | object | Maps each protocol reported by Nmap, such as `tcp`, to an array of port entries. |
+| `os_matches` | array of objects, OS scans only | Included only when `scan_type` is `os` and Nmap's `osmatch` list is non-empty. Each retained item contains any non-empty `name` and/or `accuracy` fields from Nmap; the output list can therefore be empty if every source match lacks those fields. |
+
+Each port entry inside a protocol array contains:
+
+| Field | Type | Description |
+|---|---|---|
+| `port` | integer | Port number reported by Nmap. |
+| `state` | string | Port state, such as `open`. |
+| `service` | string | Nmap's service name (`name` in the underlying record). |
+| `product` | string, optional | Product name when Nmap reports one. |
+| `version` | string, optional | Product version when Nmap reports one. |
+| `scripts` | object, optional | Nmap script output (`script` in the underlying record), included when script data is present. |
+
+## Errors and timeouts
+
+Failure responses contain `success: false` and an `error` string. The normal
+failure shapes are:
+
+| Situation | Response |
+|---|---|
+| Invalid scan type | `{"success": false, "error": "Invalid scan_type 'invalid'. Valid options are: basic, service, os, full, vuln", "valid_scan_types": ["basic", "service", "os", "full", "vuln"]}` |
+| Invalid timeout (`timeout < 1`) | `{"success": false, "error": "Invalid timeout '0'. Must be a positive number of seconds."}` |
+| Application or Nmap timeout | `{"success": false, "error": "Port scan timed out"}` |
+| Nmap is missing or raises `nmap.PortScannerError` | `{"success": false, "error": "Nmap not found or not installed: <message>"}` |
+| Any other unexpected exception | `{"success": false, "error": "<exception message>"}` |
+
+The invalid scan-type response includes the complete valid-mode list. A target
+that Nmap cannot process is not rejected by a separate target-validation layer;
+its resulting Nmap error follows the Nmap or unexpected-error shapes above.
+
+## Notes and limitations
+
+- Nmap must be installed and available to the Python `nmap` binding. Install
+  Nmap separately as a system prerequisite, or use the repository's Docker
+  image, which includes Nmap.
+- OS detection (`-O`) may require administrator/root privileges. Without the
+  necessary privilege, Nmap may fail or return no OS matches.
+- `full` and `vuln` scans can take substantially longer than the fast modes;
+  their application defaults are derived from a 15-minute Nmap host timeout.
+- Only scan domains and IP addresses that you own or are explicitly authorized
+  to test. The repository rule permits `scanme.nmap.org` as its sole public
+  live-test target; do not use other public hosts for live tests.
+- No live Nmap scan is part of this documentation page or its verification.
+
+## API key requirements
+
+None required. The tool invokes the local Nmap executable and has no API-key
+parameter.
+
+## Related tools
+
+`dns_enumeration` provides DNS records and common-subdomain results, while
+`whois_lookup` provides registration data. `full_recon` combines the core
+reconnaissance tools, and `ssl_inspect` provides complementary certificate and
+TLS details. See the [tools index](README.md) for the registration inventory
+and documentation status.


### PR DESCRIPTION
## Closes

Refs #143

## Summary

Adds a dedicated `port_scan` reference grounded in the tool's production and test contracts, then links it from both documentation indexes. This is the claimed `port_scan` slice only; the remaining tool pages stay open under issue 143.

## What changed

- Added `docs/tools/port_scan.md` covering modes, parameters, timeouts, request/response shapes, errors, prerequisites, authorization limits, and related tools.
- Linked `port_scan` from the root README and marked its tools-index entry Available.
- Replaced stale page-count prose with status-driven index wording and corrected the root summary to describe the five supported scan modes.

## Notes

- No live Nmap scan was performed; the examples and contract were checked against `tools/portscan_tool.py` and `tests/test_port_scan.py`.
- Nmap availability, target reachability, and OS privileges remain runtime requirements documented on the new page.

## Verification

- [x] Ran locally and confirmed it works as expected
- [ ] Added/updated tests for the changed behavior (documentation-only change; no executable behavior changed)
- [x] All tests pass (`uv run pytest tests/ -v`: 377 passed, 85 subtests passed in exact-SHA fork CI)
- [x] No unrelated changes included
- [x] Checked `CONTRIBUTING.md` and applied all changes
- [x] Updated Documentation ( if required )

## Footer

Generated by GPT-5.6 Luna (implementation, testing, verification), GPT-5.6 Sol (brief, review)
