### PR TITLE
fix(headers): standardize disclosure header keys to hyphenated form

### DIFF
--- a/tests/test_headers_tool.py
+++ b/tests/test_headers_tool.py
@@ -301,6 +301,39 @@ class TestHeadersAnalyzer(unittest.TestCase):
         self.assertIn("exposes technology", result["headers"]["server"]["issue"])
 
     @patch("tools.headers_tool.requests.get")
+    def test_disclosure_headers_use_hyphenated_keys(self, mock_get):
+        """x-powered-by and similar headers must appear under their native
+        hyphenated key, not an underscore-converted form (regression guard
+        for the hdr.lower().replace('-', '_') bug reported in issue #187)."""
+        mock_get.return_value = _resp(200, {
+            "X-Powered-By": "PHP/8.1",
+            "X-AspNet-Version": "4.0.30319",
+        })
+        result = headers_analyzer("example.com")
+        headers = result["headers"]
+        self.assertIn("x-powered-by", headers)
+        self.assertIn("x-aspnet-version", headers)
+        self.assertNotIn("x_powered_by", headers)
+        self.assertNotIn("x_aspnet_version", headers)
+        self.assertIn("exposes technology", headers["x-powered-by"]["issue"])
+
+    @patch("tools.headers_tool.requests.get")
+    def test_disclosure_headers_all_use_hyphenated_keys(self, mock_get):
+        """All four disclosure headers must appear under their native
+        hyphenated keys; no underscore-converted variants must be present."""
+        mock_get.return_value = _resp(200, {
+            "X-Powered-By": "Express",
+            "X-Generator": "Drupal 9",
+            "X-AspNet-Version": "4.0.30319",
+            "Server": "nginx",
+        })
+        result = headers_analyzer("example.com")
+        headers = result["headers"]
+        underscore_keys = {"x_powered_by", "x_aspnet_version", "x_generator"}
+        for bad_key in underscore_keys:
+            self.assertNotIn(bad_key, headers, f"Underscore-form key {bad_key!r} found")
+
+    @patch("tools.headers_tool.requests.get")
     def test_referrer_policy_good_value_accepted(self, mock_get):
         mock_get.return_value = _resp(200, {"Referrer-Policy": "strict-origin-when-cross-origin"})
         result = headers_analyzer("example.com")

--- a/tools/headers_tool.py
+++ b/tools/headers_tool.py
@@ -482,7 +482,7 @@ def _analyze_raw_headers(raw_headers: dict) -> dict:
     for hdr in ("server", "x-powered-by", "x-aspnet-version", "x-generator"):
         val = raw_headers.get(hdr, "")
         if val:
-            headers[hdr.lower().replace("-", "_")] = {
+            headers[hdr.lower()] = {
                 "present": True,
                 "value": val,
                 "issue": f"{hdr} header exposes technology information",


### PR DESCRIPTION
## Closes

Closes #187

## Summary

`_analyze_raw_headers()` stored information-disclosure headers (`x-powered-by`, `x-aspnet-version`, `x-generator`) under underscore-converted keys while all security headers used their native hyphenated HTTP form. This removes the `.replace("-", "_")` so every key in the returned dict is consistently hyphenated.

## What changed

- `tools/headers_tool.py`: Remove `.replace("-", "_")` from the information-disclosure loop (one-char fix at line 485)
- `tests/test_headers_tool.py`: Add two regression tests
  - `test_disclosure_headers_use_hyphenated_keys` — verifies `x-powered-by` / `x-aspnet-version` appear under hyphenated keys and their underscore variants are absent
  - `test_disclosure_headers_all_use_hyphenated_keys` — covers all four disclosure headers together

## Notes

The `server` key was never affected (no hyphens to convert); only multi-word header names like `x-powered-by` produced the mixed-format output. No callers inside this repo were relying on the underscore form.

## Verification

- [x] Ran locally and confirmed it works as expected
- [x] Added/updated tests for the changed behavior
- [x] All tests pass (`python -m pytest tests/test_headers_tool.py` → 53 passed)
- [x] No unrelated changes included
- [x] Checked `CONTRIBUTING.md` and applied all changes
- [x] Updated Documentation ( if required )
