### PR TITLE
fix(headers): standardize header analysis result keys to hyphenated format

### DIFF
--- a/tests/test_headers_tool.py
+++ b/tests/test_headers_tool.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import patch, Mock
 from curl_cffi.requests.errors import RequestsError
 from curl_cffi.requests.headers import Headers
-from tools.headers_tool import headers_analyzer
+from tools.headers_tool import _analyze_raw_headers, headers_analyzer
 
 
 def _resp(status_code: int, headers: dict, body: str = ""):
@@ -299,6 +299,61 @@ class TestHeadersAnalyzer(unittest.TestCase):
         result = headers_analyzer("example.com")
         self.assertIn("server", result["headers"])
         self.assertIn("exposes technology", result["headers"]["server"]["issue"])
+
+    @patch("tools.headers_tool.requests.get")
+    def test_information_disclosure_headers_use_hyphenated_keys(self, mock_get):
+        mock_get.return_value = _resp(200, {
+            "Server": "Apache/2.4.41",
+            "X-Powered-By": "Express",
+            "X-AspNet-Version": "4.0.30319",
+            "X-Generator": "Drupal 7",
+        })
+        result = headers_analyzer("example.com")
+        headers = result["headers"]
+        # Hyphenated keys should be present
+        self.assertIn("server", headers)
+        self.assertIn("x-powered-by", headers)
+        self.assertIn("x-aspnet-version", headers)
+        self.assertIn("x-generator", headers)
+        # Underscore keys should NOT be present
+        self.assertNotIn("x_powered_by", headers)
+        self.assertNotIn("x_aspnet_version", headers)
+        self.assertNotIn("x_generator", headers)
+        self.assertEqual(headers["x-powered-by"]["value"], "Express")
+        self.assertEqual(headers["x-aspnet-version"]["value"], "4.0.30319")
+        self.assertEqual(headers["x-generator"]["value"], "Drupal 7")
+
+    def test_analyze_raw_headers_standardized_keys_and_no_underscores(self):
+        raw_headers = {
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "content-security-policy": "default-src 'self'",
+            "x-frame-options": "DENY",
+            "x-content-type-options": "nosniff",
+            "referrer-policy": "strict-origin-when-cross-origin",
+            "permissions-policy": "camera=()",
+            "server": "nginx/1.18.0",
+            "x-powered-by": "PHP/7.4.3",
+            "x-aspnet-version": "4.0.30319",
+            "x-generator": "WordPress 6.0",
+        }
+        analyzed = _analyze_raw_headers(raw_headers)
+        expected_keys = {
+            "strict-transport-security",
+            "content-security-policy",
+            "x-frame-options",
+            "x-content-type-options",
+            "referrer-policy",
+            "permissions-policy",
+            "server",
+            "x-powered-by",
+            "x-aspnet-version",
+            "x-generator",
+        }
+        self.assertEqual(set(analyzed.keys()), expected_keys)
+        # Structural assertion: no header-derived keys contain underscores
+        for key in analyzed:
+            self.assertNotIn("_", key, f"Header key '{key}' should not contain underscores")
+            self.assertEqual(key, key.lower(), f"Header key '{key}' should be lowercased")
 
     @patch("tools.headers_tool.requests.get")
     def test_referrer_policy_good_value_accepted(self, mock_get):

--- a/tools/headers_tool.py
+++ b/tools/headers_tool.py
@@ -482,7 +482,7 @@ def _analyze_raw_headers(raw_headers: dict) -> dict:
     for hdr in ("server", "x-powered-by", "x-aspnet-version", "x-generator"):
         val = raw_headers.get(hdr, "")
         if val:
-            headers[hdr.lower().replace("-", "_")] = {
+            headers[hdr.lower()] = {
                 "present": True,
                 "value": val,
                 "issue": f"{hdr} header exposes technology information",

--- a/tools/signals/headers.py
+++ b/tools/signals/headers.py
@@ -4,7 +4,7 @@ def headers_extractor(result, signals) -> None:
     headers_analyzer reports every checked header as
     ``{"present": bool, "value": ..., "issue": ..., "severity": ...}``;
     the ones it marks absent are what `missing_security_headers` means.
-    Information-disclosure headers (``server``, ``x_powered_by``, …) only
+    Information-disclosure headers (``server``, ``x-powered-by``, …) only
     appear when they ARE present, so they never enter the missing list.
 
     A result that did not reach real page content is insufficient data, not


### PR DESCRIPTION
## Closes

Closes #187

## Summary

Standardize header analysis result keys to use native hyphenated HTTP header names rather than converting to underscores in information disclosure headers.

## What changed

- Updated headers dict assignment in tools/headers_tool.py to use hdr.lower() instead of replacing hyphens with underscores
- Updated comment reference in tools/signals/headers.py
- Added unit tests in tests/test_headers_tool.py validating hyphenated keys for information disclosure headers and confirming no underscore keys exist

## Notes

None

## Verification

- [x] Ran locally and confirmed it works as expected
- [x] Added/updated tests for the changed behavior
- [x] All tests pass (uv run pytest tests/ -v)
- [x] No unrelated changes included
- [x] Checked CONTRIBUTING.md and applied all changes
- [x] Updated Documentation ( if required )