### PR TITLE
Fix CSP wildcard token matching

### DIFF
--- a/tests/test_headers_tool.py
+++ b/tests/test_headers_tool.py
@@ -188,6 +188,34 @@ class TestHeadersAnalyzer(unittest.TestCase):
         self.assertEqual(csp["severity"], "high")
 
     @patch("tools.headers_tool.requests.get")
+    def test_csp_wildcard_source_scoped_not_flagged(self, mock_get):
+        mock_get.return_value = _resp(200, {
+            "Content-Security-Policy": "script-src *.trusted-cdn.com; default-src *.example.com",
+        })
+        result = headers_analyzer("example.com")
+        csp = result["headers"]["content-security-policy"]
+        self.assertNotIn("Wildcard", csp["issue"])
+
+    @patch("tools.headers_tool.requests.get")
+    def test_csp_wildcard_irregular_whitespace_flagged(self, mock_get):
+        mock_get.return_value = _resp(200, {
+            "Content-Security-Policy": "script-src   * ;",
+        })
+        result = headers_analyzer("example.com")
+        csp = result["headers"]["content-security-policy"]
+        self.assertIn("Wildcard", csp["issue"])
+        self.assertEqual(csp["severity"], "high")
+
+    @patch("tools.headers_tool.requests.get")
+    def test_csp_wildcard_in_unrelated_directive(self, mock_get):
+        mock_get.return_value = _resp(200, {
+            "Content-Security-Policy": "img-src *; script-src 'self'",
+        })
+        result = headers_analyzer("example.com")
+        csp = result["headers"]["content-security-policy"]
+        self.assertNotIn("Wildcard", csp["issue"])
+
+    @patch("tools.headers_tool.requests.get")
     def test_csp_missing_default_src_flagged_once(self, mock_get):
         mock_get.return_value = _resp(200, {
             "Content-Security-Policy": "script-src 'self'",

--- a/tools/headers_tool.py
+++ b/tools/headers_tool.py
@@ -351,7 +351,17 @@ def _analyze_raw_headers(raw_headers: dict) -> dict:
         if "'unsafe-eval'" in csp_lower:
             issues.append("Contains 'unsafe-eval' which allows eval()")
             severity = "high"
-        if "default-src *" in csp_lower or "script-src *" in csp_lower:
+        has_wildcard = False
+        for directive_str in csp_lower.split(';'):
+            tokens = directive_str.split()
+            if not tokens:
+                continue
+            name = tokens[0]
+            if name in ('default-src', 'script-src') and '*' in tokens[1:]:
+                has_wildcard = True
+                break
+
+        if has_wildcard:
             issues.append("Wildcard (*) source defeats the purpose of CSP")
             severity = "high"
         # A CSP without a restrictive default-src (neither 'self' nor


### PR DESCRIPTION
This PR resolves #186 by properly tokenizing the CSP directive value to check for a standalone `*` wildcard, avoiding false positives on scoped wildcards like `*.trusted.com` and false negatives on irregular whitespace.