### PR TITLE
fix: respect fallback list ordering in Referrer-Policy header check

### DIFF
--- a/tests/test_headers_tool.py
+++ b/tests/test_headers_tool.py
@@ -401,6 +401,59 @@ class TestHeadersAnalyzer(unittest.TestCase):
         self.assertIn("may leak", rp["issue"])
         self.assertEqual(rp["severity"], "medium")
 
+    @patch("tools.headers_tool.requests.get")
+    def test_referrer_policy_fallback_list_safe_last(self, mock_get):
+        mock_get.return_value = _resp(200, {
+            "Referrer-Policy": "unsafe-url, strict-origin-when-cross-origin",
+        })
+        result = headers_analyzer("example.com")
+        rp = result["headers"]["referrer-policy"]
+        self.assertTrue(rp["present"])
+        self.assertEqual(rp["issue"], "None")
+        self.assertEqual(rp["severity"], "low")
+
+    @patch("tools.headers_tool.requests.get")
+    def test_referrer_policy_fallback_list_unsafe_last(self, mock_get):
+        mock_get.return_value = _resp(200, {
+            "Referrer-Policy": "strict-origin-when-cross-origin, unsafe-url",
+        })
+        result = headers_analyzer("example.com")
+        rp = result["headers"]["referrer-policy"]
+        self.assertTrue(rp["present"])
+        self.assertIn("may leak", rp["issue"])
+        self.assertEqual(rp["severity"], "medium")
+
+    @patch("tools.headers_tool.requests.get")
+    def test_referrer_policy_fallback_list_whitespace_tolerant(self, mock_get):
+        mock_get.return_value = _resp(200, {
+            "Referrer-Policy": "no-referrer ,  unsafe-url",
+        })
+        result = headers_analyzer("example.com")
+        rp = result["headers"]["referrer-policy"]
+        self.assertTrue(rp["present"])
+        self.assertIn("may leak", rp["issue"])
+        self.assertEqual(rp["severity"], "medium")
+
+        mock_get.return_value = _resp(200, {
+            "Referrer-Policy": "unsafe-url ,  no-referrer",
+        })
+        result2 = headers_analyzer("example.com")
+        rp2 = result2["headers"]["referrer-policy"]
+        self.assertTrue(rp2["present"])
+        self.assertEqual(rp2["issue"], "None")
+        self.assertEqual(rp2["severity"], "low")
+
+    @patch("tools.headers_tool.requests.get")
+    def test_referrer_policy_fallback_list_unknown_token_ignored(self, mock_get):
+        mock_get.return_value = _resp(200, {
+            "Referrer-Policy": "strict-origin-when-cross-origin, future-unknown-policy",
+        })
+        result = headers_analyzer("example.com")
+        rp = result["headers"]["referrer-policy"]
+        self.assertTrue(rp["present"])
+        self.assertEqual(rp["issue"], "None")
+        self.assertEqual(rp["severity"], "low")
+
     # ------------------------------------------------------------------
     # Permissions-Policy content analysis
     # ------------------------------------------------------------------

--- a/tools/headers_tool.py
+++ b/tools/headers_tool.py
@@ -22,6 +22,24 @@ _SENSITIVE_PERMISSIONS_FEATURES = (
     "camera", "microphone", "geolocation", "payment", "usb",
 )
 
+_GOOD_REFERRER_POLICIES = {
+    "no-referrer",
+    "strict-origin-when-cross-origin",
+    "same-origin",
+    "strict-origin",
+}
+
+_ALL_VALID_REFERRER_POLICIES = {
+    "no-referrer",
+    "no-referrer-when-downgrade",
+    "origin",
+    "origin-when-cross-origin",
+    "same-origin",
+    "strict-origin",
+    "strict-origin-when-cross-origin",
+    "unsafe-url",
+}
+
 _WAF_BLOCK_PAGE_HEADER_SIGNATURES = (
     ("cf-mitigated", "challenge", "Cloudflare", None),
     ("server", "akamaighost", "Akamai", 400),
@@ -435,9 +453,16 @@ def _analyze_raw_headers(raw_headers: dict) -> dict:
     # --- Referrer-Policy ---
     rp = raw_headers.get("referrer-policy", "")
     if rp:
-        rp_lower = rp.lower().strip()
-        good_policies = ["no-referrer", "strict-origin-when-cross-origin", "same-origin", "strict-origin"]
-        if any(p in rp_lower for p in good_policies):
+        tokens = [t.strip() for t in rp.lower().split(",") if t.strip()]
+        effective_policy = None
+        for token in reversed(tokens):
+            if token in _ALL_VALID_REFERRER_POLICIES:
+                effective_policy = token
+                break
+        if effective_policy is None and tokens:
+            effective_policy = tokens[-1]
+
+        if effective_policy in _GOOD_REFERRER_POLICIES:
             headers["referrer-policy"] = {
                 "present": True,
                 "value": rp,


### PR DESCRIPTION
## Closes

Closes #192

## Summary

Parses comma-separated Referrer-Policy tokens and resolves the effective policy per spec ordering instead of checking substring matches across the raw header string.

## What changed

- Added module constants for valid and recommended referrer policies
- Split comma-separated tokens, stripped whitespace, and resolved the rightmost recognized policy
- Matched the resolved policy directly against recommended policies
- Added unit tests for fallback lists, single values, whitespace tolerance, and unknown token handling

## Notes

None

## Verification

- [x] Ran locally and confirmed it works as expected
- [x] Added/updated tests for the changed behavior
- [x] All tests pass (`pytest`)
- [x] No unrelated changes included
- [x] Checked `CONTRIBUTING.md` and applied all changes
- [x] Updated Documentation ( if required )