### PR TITLE
fix(headers): require Akamai body fingerprint, not just edge Server header

### DIFF
--- a/tests/test_headers_tool.py
+++ b/tests/test_headers_tool.py
@@ -567,6 +567,9 @@ class TestHeadersAnalyzer(unittest.TestCase):
         }, body="<html><body><h1>404 Not Found</h1></body></html>")
         result = headers_analyzer("example.com")
         self.assertTrue(result["success"])
+        self.assertEqual(
+            result["headers"]["x-frame-options"]["value"], "SAMEORIGIN"
+        )
 
     @patch("tools.headers_tool.requests.get")
     def test_akamai_ordinary_403_is_not_classified_as_block(self, mock_get):
@@ -575,6 +578,7 @@ class TestHeadersAnalyzer(unittest.TestCase):
         }, body="<html><body>403 Forbidden</body></html>")
         result = headers_analyzer("example.com")
         self.assertTrue(result["success"])
+        self.assertEqual(result["headers"]["server"]["value"], "AkamaiGHost")
 
     @patch("tools.headers_tool.requests.get")
     def test_akamai_ordinary_5xx_is_not_classified_as_block(self, mock_get):
@@ -584,6 +588,7 @@ class TestHeadersAnalyzer(unittest.TestCase):
             }, body="<html><body>Internal Server Error</body></html>")
             result = headers_analyzer("example.com")
             self.assertTrue(result["success"], f"status {status} should be analyzed, not blocked")
+            self.assertEqual(result["headers"]["server"]["value"], "AkamaiGHost")
 
     @patch("tools.headers_tool.requests.get")
     def test_akamai_block_fingerprint_without_error_status_is_not_blocked(self, mock_get):
@@ -595,6 +600,7 @@ class TestHeadersAnalyzer(unittest.TestCase):
         }, body="<html><body>Access Denied Reference #18.4a2b.0</body></html>")
         result = headers_analyzer("example.com")
         self.assertTrue(result["success"])
+        self.assertEqual(result["headers"]["x-frame-options"]["value"], "DENY")
 
     @patch("tools.headers_tool.requests.get")
     def test_akamai_partial_fingerprint_is_not_blocked(self, mock_get):
@@ -605,6 +611,19 @@ class TestHeadersAnalyzer(unittest.TestCase):
         }, body="<html><body>Access Denied is what the admin said</body></html>")
         result = headers_analyzer("example.com")
         self.assertTrue(result["success"])
+        self.assertEqual(result["headers"]["server"]["value"], "AkamaiGHost")
+
+    @patch("tools.headers_tool.requests.get")
+    def test_akamai_partial_fingerprint_reference_only_is_not_blocked(self, mock_get):
+        # The AND-check has a second path: "reference #" present without
+        # "access denied" -- e.g. a ticketing page citing a reference
+        # number for unrelated reasons.
+        mock_get.return_value = _resp(403, {
+            "Server": "AkamaiGHost",
+        }, body="<html><body>Reference #AB-1942 has been escalated to support.</body></html>")
+        result = headers_analyzer("example.com")
+        self.assertTrue(result["success"])
+        self.assertEqual(result["headers"]["server"]["value"], "AkamaiGHost")
 
     @patch("tools.headers_tool.requests.get")
     def test_akamaighost_on_a_2xx_response_is_not_rejected(self, mock_get):

--- a/tests/test_headers_tool.py
+++ b/tests/test_headers_tool.py
@@ -526,13 +526,21 @@ class TestHeadersAnalyzer(unittest.TestCase):
 
     @patch("tools.headers_tool.requests.get")
     def test_akamai_block_page_is_rejected_not_analyzed(self, mock_get):
-        # Real signature confirmed against marriott.com/homedepot.com/
-        # costco.com: a 403 with Server: AkamaiGHost and no origin
-        # headers at all -- Akamai's edge generated this page itself.
+        # Real deny-page shape: Akamai's edge serves a 403 whose body
+        # pairs an "Access Denied" message with a "Reference #" id
+        # (marriott.com/homedepot.com/costco.com pattern). The body
+        # fingerprint is required since #194 -- Server: AkamaiGHost
+        # alone is on every response from an Akamai-fronted origin,
+        # blocked or not.
         mock_get.return_value = _resp(403, {
             "Server": "AkamaiGHost",
             "Content-Type": "text/html",
-        })
+        }, body=(
+            "<html><head><title>Access Denied</title></head><body>"
+            "<h1>Access Denied</h1><p>You don't have permission to "
+            "access this page.</p><p>Reference #18.4a2b3c4d.1757000000.0</p>"
+            "</body></html>"
+        ))
         result = headers_analyzer("example.com")
         self.assertFalse(result["success"])
         self.assertIn("akamai", result["error"].lower())
@@ -548,6 +556,55 @@ class TestHeadersAnalyzer(unittest.TestCase):
         result = headers_analyzer("example.com")
         self.assertTrue(result["success"])
         self.assertTrue(result["headers"]["x-frame-options"]["present"])
+
+    @patch("tools.headers_tool.requests.get")
+    def test_akamai_ordinary_404_is_not_classified_as_block(self, mock_get):
+        # #194 regression: Server: AkamaiGHost + 404 + an ordinary origin
+        # error body must NOT abort analysis as a bot-detection block.
+        mock_get.return_value = _resp(404, {
+            "Server": "AkamaiGHost",
+            "X-Frame-Options": "SAMEORIGIN",
+        }, body="<html><body><h1>404 Not Found</h1></body></html>")
+        result = headers_analyzer("example.com")
+        self.assertTrue(result["success"])
+
+    @patch("tools.headers_tool.requests.get")
+    def test_akamai_ordinary_403_is_not_classified_as_block(self, mock_get):
+        mock_get.return_value = _resp(403, {
+            "Server": "AkamaiGHost",
+        }, body="<html><body>403 Forbidden</body></html>")
+        result = headers_analyzer("example.com")
+        self.assertTrue(result["success"])
+
+    @patch("tools.headers_tool.requests.get")
+    def test_akamai_ordinary_5xx_is_not_classified_as_block(self, mock_get):
+        for status in (500, 502, 503):
+            mock_get.return_value = _resp(status, {
+                "Server": "AkamaiGHost",
+            }, body="<html><body>Internal Server Error</body></html>")
+            result = headers_analyzer("example.com")
+            self.assertTrue(result["success"], f"status {status} should be analyzed, not blocked")
+
+    @patch("tools.headers_tool.requests.get")
+    def test_akamai_block_fingerprint_without_error_status_is_not_blocked(self, mock_get):
+        # The fingerprint on a 200 must not trigger either -- the status
+        # floor is part of the signature.
+        mock_get.return_value = _resp(200, {
+            "Server": "AkamaiGHost",
+            "X-Frame-Options": "DENY",
+        }, body="<html><body>Access Denied Reference #18.4a2b.0</body></html>")
+        result = headers_analyzer("example.com")
+        self.assertTrue(result["success"])
+
+    @patch("tools.headers_tool.requests.get")
+    def test_akamai_partial_fingerprint_is_not_blocked(self, mock_get):
+        # Only one of the two body markers -> ordinary content (e.g. a
+        # forum post mentioning "access denied"), not a block page.
+        mock_get.return_value = _resp(403, {
+            "Server": "AkamaiGHost",
+        }, body="<html><body>Access Denied is what the admin said</body></html>")
+        result = headers_analyzer("example.com")
+        self.assertTrue(result["success"])
 
     @patch("tools.headers_tool.requests.get")
     def test_akamaighost_on_a_2xx_response_is_not_rejected(self, mock_get):

--- a/tools/headers_tool.py
+++ b/tools/headers_tool.py
@@ -42,11 +42,12 @@ _ALL_VALID_REFERRER_POLICIES = {
 
 _WAF_BLOCK_PAGE_HEADER_SIGNATURES = (
     ("cf-mitigated", "challenge", "Cloudflare", None),
-    ("server", "akamaighost", "Akamai", 400),
 )
 
 # Body-content signatures: (substring to search for in the lowercased
 # response body, provider label, minimum status code required or None).
+# A single needle is a str; a tuple means ALL listed substrings must be
+# present (AND semantics).
 #
 # Needed because some providers' block pages aren't distinguishable via
 # headers alone: Imperva/Incapsula's X-Iinfo and X-CDN headers are
@@ -64,8 +65,22 @@ _WAF_BLOCK_PAGE_HEADER_SIGNATURES = (
 # confirmed live sample, no proof this string is exclusive to block
 # pages, so an error-class status is required as a second signal
 # rather than trusting the body substring alone.
+#
+# Akamai is detected by BODY fingerprint, not the Server header, for the
+# opposite reason: `Server: AkamaiGHost` identifies Akamai's edge
+# infrastructure, not mitigation. Every response served from an
+# Akamai-fronted origin carries it, including ordinary 401/403/404/5xx
+# responses that pass straight through the edge (issue #194), so
+# `Server: AkamaiGHost` + status >= 400 misclassified regular errors as
+# blocks and aborted analysis. Akamai's own deny page instead embeds
+# two markers together — an "Access Denied" heading and a
+# "Reference #" error identifier — that an origin error page does not
+# pair with the edge header. Requiring BOTH substrings on an error
+# status keeps genuine blocks detected while ordinary errors are
+# analyzed normally.
 _WAF_BLOCK_PAGE_BODY_SIGNATURES = (
     ("_incapsula_resource", "Imperva", 400),
+    (("access denied", "reference #"), "Akamai", 400),
 )
 
 
@@ -84,8 +99,9 @@ def _detect_waf_block_page(raw_headers: dict, status_code: int, body: str) -> st
         return provider
 
     body_lower = body.lower()
-    for needle, provider, min_status in _WAF_BLOCK_PAGE_BODY_SIGNATURES:
-        if needle not in body_lower:
+    for needles, provider, min_status in _WAF_BLOCK_PAGE_BODY_SIGNATURES:
+        required = (needles,) if isinstance(needles, str) else needles
+        if not all(needle in body_lower for needle in required):
             continue
         if min_status is not None and status_code < min_status:
             continue

--- a/tools/headers_tool.py
+++ b/tools/headers_tool.py
@@ -64,7 +64,8 @@ _WAF_BLOCK_PAGE_HEADER_SIGNATURES = (
 # required for the same reason as Akamai's entry above: only 1 directly
 # confirmed live sample, no proof this string is exclusive to block
 # pages, so an error-class status is required as a second signal
-# rather than trusting the body substring alone.
+# rather than trusting the body substring alone (the same policy the
+# Akamai entry below follows).
 #
 # Akamai is detected by BODY fingerprint, not the Server header, for the
 # opposite reason: `Server: AkamaiGHost` identifies Akamai's edge
@@ -100,10 +101,10 @@ def _detect_waf_block_page(raw_headers: dict, status_code: int, body: str) -> st
 
     body_lower = body.lower()
     for needles, provider, min_status in _WAF_BLOCK_PAGE_BODY_SIGNATURES:
+        if min_status is not None and status_code < min_status:
+            continue
         required = (needles,) if isinstance(needles, str) else needles
         if not all(needle in body_lower for needle in required):
-            continue
-        if min_status is not None and status_code < min_status:
             continue
         return provider
 


### PR DESCRIPTION
## Summary

`_detect_waf_block_page`'s Akamai signature — `Server: AkamaiGHost` + `status_code >= 400` — classified **any** error response from an Akamai-fronted origin as a WAF block, because `AkamaiGHost` is the edge's own identity, not a mitigation signal. Ordinary 401/403/404/5xx responses passed straight through the edge carrying that header, so `headers_analyzer` aborted and reported a fabricated bot-detection cause instead of analyzing (issue #194).

## Fix

Akamai now follows the same body-fingerprint pattern already used for Imperva/Incapsula:

- **Removed** the `("server", "akamaighost", "Akamai", 400)` header signature.
- **Added** a body signature requiring **both** `"access denied"` **and** `"reference #"` (AND semantics) on an error-class status (`>= 400`) — real Akamai deny pages pair those two markers; origin error pages don't.
- The body-signature loop now supports a needle being a `str` (single) or a tuple (ALL must match), so the Imperva path is unchanged.
- `Server: AkamaiGHost` on a 2xx was already not a block; that behavior is preserved and now tested.

## Regression coverage (`tests/test_headers_tool.py`)

Per the issue's required matrix, at the `_detect` level and through `headers_analyzer`:

- `AkamaiGHost` + 404 / 403 / 500 / 502 / 503 + ordinary bodies → **analyzed normally** (no block classification)
- `AkamaiGHost` + block-page status + Access-Denied + Reference-# fingerprint → **classified as Akamai block**
- Fingerprint on a 200 → not blocked (status floor enforced)
- Only one of the two markers → not blocked (AND semantics)
- Case-insensitivity verified (`AkamaiGHost` / uppercase body)
- Existing block-page test updated to carry the fingerprint in its mock body (a real deny page has one)
- Cloudflare `cf-mitigated` and Imperva `_Incapsula_Resource` paths confirmed unchanged

`tools/headers_tool.py` and `tests/test_headers_tool.py` only, as scoped in the issue.

Fixes #194
