### PR TITLE
fix(helpers): fall back to later list candidates in safe_parse_datetime

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -110,9 +110,22 @@ class TestHelpers(unittest.TestCase):
         self.assertIsNone(safe_parse_datetime([]))
 
     def test_safe_parse_datetime_list_with_empty_first_element(self):
-        """A list whose first element is empty/None falls through to None."""
-        self.assertIsNone(safe_parse_datetime([None, "2025-12-25"]))
-        self.assertIsNone(safe_parse_datetime(["", "2025-12-25"]))
+        """A list whose first element is empty/None falls through to a later valid element."""
+        self.assertEqual(safe_parse_datetime([None, "2025-12-25"]), datetime(2025, 12, 25))
+        self.assertEqual(safe_parse_datetime(["", "2025-12-25"]), datetime(2025, 12, 25))
+
+    def test_safe_parse_datetime_list_falls_back_to_later_element(self):
+        """An unparseable first element falls back to a later parseable one."""
+        result = safe_parse_datetime(["not-a-real-date", "2028-09-14 04:00:00+00:00"])
+        self.assertEqual(result, datetime(2028, 9, 14, 4, 0, 0, tzinfo=timezone.utc))
+
+    def test_safe_parse_datetime_list_all_unparseable(self):
+        """A list with no parseable elements returns None."""
+        self.assertIsNone(safe_parse_datetime(["not-a-date", "also-not-a-date"]))
+
+    def test_safe_parse_datetime_single_element_list(self):
+        """A single-element list parses its only candidate."""
+        self.assertEqual(safe_parse_datetime(["2025-12-25"]), datetime(2025, 12, 25))
 
     def test_safe_parse_datetime_invalid_string_returns_none(self):
         """A genuinely unparseable string returns None, not a crash."""

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -74,18 +74,18 @@ def safe_parse_datetime(date_input) -> datetime | None:
         return date_input
 
     # python-whois returns a list of datetimes for some TLDs (e.g. when the
-    # registrar exposes both registry and registrar expiration dates). Take
-    # the first element — they are typically identical, and the alternative
-    # (str(list)) yields "['2025-12-25 00:00:00']" which matches no format
-    # and silently suppresses domain-expiry warnings downstream.
+    # registrar exposes both registry and registrar expiration dates). Treat
+    # the list as an ordered set of candidates and return the first element
+    # that parses successfully, rather than committing to the first element
+    # and discarding the rest. The alternative (str(list)) yields
+    # "['2025-12-25 00:00:00']" which matches no format and silently
+    # suppresses domain-expiry warnings downstream.
     if isinstance(date_input, list):
-        if not date_input:
-            return None
-        date_input = date_input[0]
-        if not date_input:
-            return None
-        if isinstance(date_input, datetime):
-            return date_input
+        for candidate in date_input:
+            result = safe_parse_datetime(candidate)
+            if result is not None:
+                return result
+        return None
 
     clean_str = str(date_input).strip().replace("Z", "+00:00")
     


### PR DESCRIPTION
Closes #202

## Summary
Fix safe_parse_datetime so that a list input falls back to later
elements when the first candidate is unparseable, instead of returning
None immediately.

## What changed
- utils/helpers.py: iterate list candidates recursively, return first
  successfully parsed datetime.
- tests/test_helpers.py: update the empty-first-element test and add
  coverage for fallback / all-unparseable / single-element cases.

## Verification
python -m pytest tests/test_helpers.py  →  23 passed