### PR TITLE
fix(helpers): try remaining candidates in list-typed date fields in safe_parse_datetime

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -109,10 +109,29 @@ class TestHelpers(unittest.TestCase):
         """An empty list returns None, not a crash."""
         self.assertIsNone(safe_parse_datetime([]))
 
-    def test_safe_parse_datetime_list_with_empty_first_element(self):
-        """A list whose first element is empty/None falls through to None."""
-        self.assertIsNone(safe_parse_datetime([None, "2025-12-25"]))
-        self.assertIsNone(safe_parse_datetime(["", "2025-12-25"]))
+    def test_safe_parse_datetime_single_element_list(self):
+        """A single-element list parses correctly."""
+        result = safe_parse_datetime(["2025-12-25 00:00:00"])
+        self.assertEqual(result, datetime(2025, 12, 25, 0, 0, 0))
+
+    def test_safe_parse_datetime_list_fallback_when_earlier_elements_invalid(self):
+        """A list falls back to subsequent candidates when earlier elements are invalid, empty, or None."""
+        self.assertEqual(
+            safe_parse_datetime([None, "2025-12-25 00:00:00"]),
+            datetime(2025, 12, 25, 0, 0, 0),
+        )
+        self.assertEqual(
+            safe_parse_datetime(["", "2025-12-25 00:00:00"]),
+            datetime(2025, 12, 25, 0, 0, 0),
+        )
+        self.assertEqual(
+            safe_parse_datetime(["not-a-real-date", "2028-09-14 04:00:00+00:00"]),
+            datetime(2028, 9, 14, 4, 0, 0, tzinfo=timezone.utc),
+        )
+
+    def test_safe_parse_datetime_list_all_elements_unparseable_returns_none(self):
+        """A list where all candidates are unparseable returns None."""
+        self.assertIsNone(safe_parse_datetime([None, "", "not-a-date", "invalid-date-string"]))
 
     def test_safe_parse_datetime_invalid_string_returns_none(self):
         """A genuinely unparseable string returns None, not a crash."""

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -74,18 +74,15 @@ def safe_parse_datetime(date_input) -> datetime | None:
         return date_input
 
     # python-whois returns a list of datetimes for some TLDs (e.g. when the
-    # registrar exposes both registry and registrar expiration dates). Take
-    # the first element — they are typically identical, and the alternative
-    # (str(list)) yields "['2025-12-25 00:00:00']" which matches no format
-    # and silently suppresses domain-expiry warnings downstream.
+    # registrar exposes both registry and registrar expiration dates). Try
+    # each candidate in sequence until one parses successfully, avoiding
+    # str(list) which yields "['...']" and matches no format.
     if isinstance(date_input, list):
-        if not date_input:
-            return None
-        date_input = date_input[0]
-        if not date_input:
-            return None
-        if isinstance(date_input, datetime):
-            return date_input
+        for item in date_input:
+            parsed = safe_parse_datetime(item)
+            if parsed is not None:
+                return parsed
+        return None
 
     clean_str = str(date_input).strip().replace("Z", "+00:00")
     


### PR DESCRIPTION
## Closes

Closes #202

## Summary

Fixes `safe_parse_datetime` to sequentially attempt each element in a list-typed date input until one parses successfully, rather than committing strictly to `date_input[0]` and returning `None` if the first element is empty, invalid, or malformed.

## What changed

- **`utils/helpers.py`**:
  - Replaced the single-element unwrapping `date_input = date_input[0]` with an iterative loop over `date_input`.
  - Attempts `safe_parse_datetime(item)` for each element in sequence; returns the first non-`None` parsed `datetime`.
  - Preserves immediate return for valid first elements and returns `None` only if all candidate elements fail to parse or the list is empty.
- **`tests/test_helpers.py`**:
  - Added test for single-element lists (`test_safe_parse_datetime_single_element_list`).
  - Added test verifying fallback when earlier elements are `None`, `""`, or unparseable strings, and subsequent elements contain valid dates (`test_safe_parse_datetime_list_fallback_when_earlier_elements_invalid`).
  - Added test confirming `None` is returned when all candidates in a list are unparseable (`test_safe_parse_datetime_list_all_elements_unparseable_returns_none`).
  - Maintained existing tests for single date strings, empty lists, and already-parsed datetime objects.

## Notes

- This ensures consumers such as `whois_extractor` do not lose `domain_expiry_days` telemetry when registrars return multiple expiration date records where the first candidate is empty or malformed.

## Verification

- [x] Ran locally and confirmed it works as expected
- [x] Added/updated tests for the changed behavior
- [x] All tests pass (`uv run pytest`)
- [x] No unrelated changes included
- [x] Checked `CONTRIBUTING.md` and applied all changes
- [x] Updated Documentation ( if required )