### PR TITLE
feat(takeover): improve takeover accuracy, SSRF guard, redirects, and UDP-first DNS

### DIFF
--- a/tests/test_subdomain_takeover.py
+++ b/tests/test_subdomain_takeover.py
@@ -666,5 +666,120 @@ def test_invalid_utf8_dns_record_does_not_escape_enumeration(mock_resolver_class
     assert result["subdomains_checked"] == 0
 
 
+def test_resolve_cname_udp_first_without_forced_tcp():
+    """Item 12: Verify CNAME resolution relies on UDP-first resolution without forcing tcp=True."""
+    from tools.subdomain_takeover_tool import _resolve_cname
+
+    resolver = Mock()
+    record = Mock()
+    record.__str__ = lambda self: "target.example.net."
+    resolver.resolve.return_value = [record]
+
+    result = _resolve_cname("sub.example.com", resolver)
+
+    assert result.cname == "target.example.net"
+    assert resolver.resolve.call_count == 2
+    for call in resolver.resolve.call_args_list:
+        assert "tcp" not in call.kwargs or call.kwargs["tcp"] is False
+
+
+def test_fingerprint_regex_patterns_anchored_and_normalized():
+    """Item 6: Verify regex patterns match valid service targets and reject spoofed/unanchored domains."""
+    from tools.subdomain_takeover_tool import _match_fingerprint
+
+    # Valid service hostnames with various casings and trailing dots
+    assert _match_fingerprint("myblog.github.io.")["service"] == "GitHub Pages"
+    assert _match_fingerprint("APP.HEROKUAPP.COM")["service"] == "Heroku"
+    assert _match_fingerprint("secure.herokussl.com.")["service"] == "Heroku"
+    assert _match_fingerprint("dns.herokudns.com")["service"] == "Heroku"
+    assert _match_fingerprint("site.azurewebsites.net.")["service"] == "Azure"
+    assert _match_fingerprint("cloud.cloudapp.net")["service"] == "Azure"
+    assert _match_fingerprint("routing.trafficmanager.net.")["service"] == "Azure"
+    assert _match_fingerprint("publication.ghost.io")["service"] == "Ghost"
+    assert _match_fingerprint("store.myshopify.com.")["service"] == "Shopify"
+    assert _match_fingerprint("cdn.fastly.net")["service"] == "Fastly"
+    assert _match_fingerprint("lb.fastlylb.net.")["service"] == "Fastly"
+
+    # Spoofed/unanchored lookalike domains must NOT match
+    assert _match_fingerprint("github.io.attacker.com") is None
+    assert _match_fingerprint("fake-github.io.com") is None
+    assert _match_fingerprint("herokuapp.com.phishing.org") is None
+    assert _match_fingerprint("azurewebsites.net.badsite.io") is None
+    assert _match_fingerprint("ghost.io.evil.com") is None
+    assert _match_fingerprint("myshopify.com.scam.net") is None
+    assert _match_fingerprint("fastly.net.malicious.com") is None
+
+
+def test_fastly_fingerprint_refined_indicator():
+    """Item 5: Fastly takeover requires specific 'unknown domain' indicator rather than generic errors."""
+    from tools.subdomain_takeover_tool import _confirms_takeover, _match_fingerprint
+
+    fingerprint = _match_fingerprint("mycdn.fastly.net")
+    assert fingerprint is not None
+    assert fingerprint["service"] == "Fastly"
+
+    # Specific unknown domain indicator confirms takeover
+    mock_probe = Mock()
+    mock_probe.response = Mock(status_code=500, text="Fastly error: unknown domain: sub.example.com", headers={})
+    res_confirmed = _confirms_takeover("sub.example.com", fingerprint, resolver=None)
+    with patch("tools.subdomain_takeover_tool._probe", return_value=mock_probe):
+        res = _confirms_takeover("sub.example.com", fingerprint)
+        assert res.status.value == "confirmed"
+
+    # Generic error without 'unknown domain' does NOT confirm takeover
+    mock_probe_generic = Mock()
+    mock_probe_generic.response = Mock(status_code=500, text="Fastly error: configuration fetch failed", headers={})
+    with patch("tools.subdomain_takeover_tool._probe", return_value=mock_probe_generic):
+        res = _confirms_takeover("sub.example.com", fingerprint)
+        assert res.status.value == "no_indicator"
+
+
+@patch("tools.subdomain_takeover_tool.requests.get")
+def test_explicit_redirect_handling_cross_domain_halt(mock_get):
+    """Item 8: Redirect handling halts when target leaves subdomain scope to avoid third-party false positives."""
+    from tools.subdomain_takeover_tool import _probe
+
+    # First request returns redirect to an external parking domain
+    redirect_resp = Mock(status_code=302, headers={"Location": "https://external-parking.com/landing"})
+    redirect_resp.is_redirect = True
+    mock_get.return_value = redirect_resp
+
+    result = _probe("sub.example.com")
+    assert result.response is not None
+    assert result.response.status_code == 302
+    # Only 1 request should be made for https (and 0 hops followed to external host)
+    assert mock_get.call_count == 1
+    assert "sub.example.com" in mock_get.call_args[0][0]
+
+
+def test_ssrf_protection_blocks_private_and_loopback_ips():
+    """Item 9: Subdomains resolving to loopback or RFC 1918 private IPs are blocked for SSRF protection."""
+    from tools.subdomain_takeover_tool import _check_host_ssrf, _probe
+
+    # Direct private and loopback IP literals
+    assert _check_host_ssrf("127.0.0.1") is not None
+    assert _check_host_ssrf("10.0.0.1") is not None
+    assert _check_host_ssrf("192.168.1.100") is not None
+    assert _check_host_ssrf("169.254.169.254") is not None
+    assert _check_host_ssrf("::1") is not None
+
+    # Public IP literals are safe
+    assert _check_host_ssrf("93.184.216.34") is None
+
+    # Resolving to private IP via resolver mock
+    resolver = Mock()
+    resolver.resolve.return_value = ["10.10.10.10"]
+    err = _check_host_ssrf("internal.example.com", resolver=resolver)
+    assert err is not None
+    assert "private/reserved IP" in err
+
+    # _probe returns SSRFBlocked error and avoids making any HTTP requests
+    with patch("tools.subdomain_takeover_tool.requests.get") as mock_get:
+        probe_res = _probe("internal.example.com", resolver=resolver)
+        assert probe_res.response is None
+        assert any("SSRFBlocked" in e["error"] for e in probe_res.errors)
+        mock_get.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tools/subdomain_takeover_tool.py
+++ b/tools/subdomain_takeover_tool.py
@@ -7,9 +7,11 @@ confirms the takeover with an HTTP request checking for the service's
 takeover-indicating response.
 """
 
+import ipaddress
 import re
 from dataclasses import dataclass
 from enum import Enum
+from urllib.parse import urljoin, urlparse
 
 import dns.exception
 import dns.resolver
@@ -43,16 +45,23 @@ _S3_ENDPOINT_RE = re.compile(
     rf"|s3-website\.{_AWS_REGION})\.amazonaws\.com\.cn$"
 )
 
-# (cname_contains or cname_pattern, service, takeover indicator)
-# indicator key "status" matches on the HTTP status code, "body" on response text.
+_GITHUB_PAGES_RE = re.compile(r"(?:^|\.)github\.io$")
+_HEROKU_RE = re.compile(r"(?:^|\.)(?:herokuapp\.com|herokussl\.com|herokudns\.com)$")
+_AZURE_RE = re.compile(r"(?:^|\.)(?:azurewebsites\.net|cloudapp\.net|trafficmanager\.net)$")
+_GHOST_RE = re.compile(r"(?:^|\.)ghost\.io$")
+_SHOPIFY_RE = re.compile(r"(?:^|\.)myshopify\.com$")
+_FASTLY_RE = re.compile(r"(?:^|\.)(?:fastly\.net|fastlylb\.net)$")
+
+# Vulnerable service fingerprints with regex patterns and multi-signal takeover indicators.
+# Indicator keys: "status" matches HTTP status code, "body" matches text substring, "headers" matches response headers.
 VULNERABLE_FINGERPRINTS = [
-    {"cname_contains": "github.io", "service": "GitHub Pages", "indicator": {"body": "There isn't a GitHub Pages site here."}},
-    {"cname_contains": "herokuapp.com", "service": "Heroku", "indicator": {"body": "No such app"}},
+    {"cname_pattern": _GITHUB_PAGES_RE, "service": "GitHub Pages", "indicator": {"body": "There isn't a GitHub Pages site here."}},
+    {"cname_pattern": _HEROKU_RE, "service": "Heroku", "indicator": {"body": "No such app"}},
     {"cname_pattern": _S3_ENDPOINT_RE, "service": "AWS S3", "indicator": {"body": "NoSuchBucket"}},
-    {"cname_contains": "azurewebsites.net", "service": "Azure", "indicator": {"body": "404 Web Site not found"}},
-    {"cname_contains": "ghost.io", "service": "Ghost", "indicator": {"body": "404 Domain Not Found"}},
-    {"cname_contains": "myshopify.com", "service": "Shopify", "indicator": {"body": "Sorry, this shop"}},
-    {"cname_contains": "fastly.net", "service": "Fastly", "indicator": {"body": "Fastly error"}},
+    {"cname_pattern": _AZURE_RE, "service": "Azure", "indicator": {"body": "404 Web Site not found"}},
+    {"cname_pattern": _GHOST_RE, "service": "Ghost", "indicator": {"body": "404 Domain Not Found"}},
+    {"cname_pattern": _SHOPIFY_RE, "service": "Shopify", "indicator": {"body": "Sorry, this shop"}},
+    {"cname_pattern": _FASTLY_RE, "service": "Fastly", "indicator": {"body": "Fastly error: unknown domain"}},
 ]
 
 _REQUEST_HEADERS = {
@@ -60,6 +69,7 @@ _REQUEST_HEADERS = {
 }
 _REQUEST_TIMEOUT = 10
 _MAX_CNAME_DEPTH = 5
+_MAX_REDIRECT_HOPS = 3
 
 
 class _ProbeStatus(str, Enum):
@@ -93,15 +103,51 @@ def _make_resolver() -> dns.resolver.Resolver:
     return resolver
 
 
+def _is_private_or_reserved_ip(ip_str: str) -> bool:
+    """Return True if ip_str is a valid IP address in private/loopback/reserved space."""
+    try:
+        ip = ipaddress.ip_address(ip_str)
+        return bool(
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_reserved
+            or ip.is_link_local
+            or ip.is_multicast
+            or ip.is_unspecified
+        )
+    except ValueError:
+        return False
+
+
+def _check_host_ssrf(hostname: str, resolver=None) -> str | None:
+    """Check if hostname is or resolves to private/reserved IP space. Return error string if unsafe."""
+    # Check if hostname itself is a private or reserved IP literal
+    if _is_private_or_reserved_ip(hostname):
+        return f"Host {hostname} is a private/reserved IP address"
+
+    if resolver is not None:
+        for rtype in ("A", "AAAA"):
+            try:
+                answers = resolver.resolve(hostname, rtype, lifetime=3)
+                for ans in answers:
+                    ip_str = str(ans).strip()
+                    if _is_private_or_reserved_ip(ip_str):
+                        return f"Host {hostname} resolved to private/reserved IP {ip_str}"
+            except Exception:
+                continue
+
+    return None
+
+
 def _resolve_cname(subdomain: str, resolver) -> _CnameResolution:
-    """Resolve a bounded CNAME chain and distinguish absence from failure."""
+    """Resolve a bounded CNAME chain using UDP-first resolution and distinguish absence from failure."""
     current = subdomain.lower().rstrip(".")
     seen = {current}
     chain = []
 
     while True:
         try:
-            answers = resolver.resolve(current, "CNAME", lifetime=5, tcp=True)
+            answers = resolver.resolve(current, "CNAME", lifetime=5)
         except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN):
             return _CnameResolution(
                 cname=chain[-1] if chain else None,
@@ -140,47 +186,124 @@ def _match_fingerprint(cname: str) -> dict | None:
         if pattern is not None:
             if pattern.search(cname):
                 return fingerprint
-        elif fingerprint["cname_contains"] in cname:
+        elif "cname_contains" in fingerprint and fingerprint["cname_contains"] in cname:
             return fingerprint
     return None
 
 
-def _probe(subdomain: str) -> _ProbeResult:
+def _probe(subdomain: str, resolver=None) -> _ProbeResult:
     """Fetch the subdomain over HTTPS first, falling back to HTTP.
 
-    Many hosted services only serve (or redirect to) HTTPS, so try that first
-    and fall back to plain HTTP only when the HTTPS connection itself fails.
+    Inspects redirect chains up to 3 hops without crossing into unsafe IP space
+    or diverging to unrelated target hostnames.
     Returns the response and any errors if neither scheme connects.
     """
     errors = []
+    subdomain_clean = subdomain.strip().rstrip(".")
+    ssrf_err = _check_host_ssrf(subdomain_clean, resolver)
+    if ssrf_err:
+        return _ProbeResult(
+            response=None,
+            errors=({"scheme": "all", "error": f"SSRFBlocked: {ssrf_err}"},),
+        )
+
     for scheme in ("https", "http"):
-        try:
-            response = requests.get(
-                f"{scheme}://{subdomain}",
-                headers=_REQUEST_HEADERS,
-                timeout=_REQUEST_TIMEOUT,
-            )
-            return _ProbeResult(response=response)
-        except requests.exceptions.RequestException as exc:
-            errors.append({
-                "scheme": scheme,
-                "error": f"{type(exc).__name__}: {exc}",
-            })
-            continue
+        current_url = f"{scheme}://{subdomain_clean}"
+        visited_urls = set()
+        hops = 0
+        last_response = None
+        scheme_failed = False
+
+        while hops <= _MAX_REDIRECT_HOPS:
+            visited_urls.add(current_url)
+            parsed = urlparse(current_url)
+            host = (parsed.hostname or subdomain_clean).lower()
+
+            hop_ssrf = _check_host_ssrf(host, resolver)
+            if hop_ssrf:
+                errors.append({
+                    "scheme": scheme,
+                    "error": f"SSRFBlocked: {hop_ssrf}",
+                })
+                scheme_failed = True
+                break
+
+            try:
+                response = requests.get(
+                    current_url,
+                    headers=_REQUEST_HEADERS,
+                    timeout=_REQUEST_TIMEOUT,
+                    allow_redirects=False,
+                )
+                last_response = response
+            except requests.exceptions.RequestException as exc:
+                errors.append({
+                    "scheme": scheme,
+                    "error": f"{type(exc).__name__}: {exc}",
+                })
+                scheme_failed = True
+                break
+
+            if getattr(response, "status_code", None) in (301, 302, 303, 307, 308):
+                location = None
+                headers = getattr(response, "headers", None)
+                if headers and hasattr(headers, "get"):
+                    raw_loc = headers.get("Location")
+                    if isinstance(raw_loc, str) and raw_loc.strip():
+                        location = raw_loc.strip()
+
+                if not location:
+                    break
+
+                next_url = urljoin(current_url, location)
+                next_parsed = urlparse(next_url)
+                next_host = (next_parsed.hostname or "").lower()
+
+                # Stop redirect following if target leaves the subdomain scope
+                if next_host and next_host != host and not next_host.endswith("." + host):
+                    break
+
+                if next_url in visited_urls:
+                    break
+
+                current_url = next_url
+                hops += 1
+                continue
+            else:
+                break
+
+        if not scheme_failed and last_response is not None:
+            return _ProbeResult(response=last_response)
+
     return _ProbeResult(response=None, errors=tuple(errors))
 
 
-def _confirms_takeover(subdomain: str, fingerprint: dict) -> _TakeoverResult:
+def _confirms_takeover(subdomain: str, fingerprint: dict, resolver=None) -> _TakeoverResult:
     """Return the tri-state takeover result and probe failure evidence."""
-    probe = _probe(subdomain)
+    probe = _probe(subdomain, resolver=resolver)
     if probe.response is None:
         return _TakeoverResult(_ProbeStatus.UNABLE_TO_PROBE, probe.errors)
 
     indicator = fingerprint["indicator"]
+    confirmed = True
     if "status" in indicator:
-        confirmed = probe.response.status_code == indicator["status"]
-    else:
-        confirmed = indicator["body"].lower() in probe.response.text.lower()
+        if getattr(probe.response, "status_code", None) != indicator["status"]:
+            confirmed = False
+    if "body" in indicator:
+        text = getattr(probe.response, "text", "")
+        if isinstance(text, str):
+            if indicator["body"].lower() not in text.lower():
+                confirmed = False
+        else:
+            confirmed = False
+    if "headers" in indicator:
+        headers = getattr(probe.response, "headers", {})
+        for header, expected in indicator["headers"].items():
+            actual = headers.get(header, "") if hasattr(headers, "get") else ""
+            if not isinstance(actual, str) or expected.lower() not in actual.lower():
+                confirmed = False
+                break
+
     status = _ProbeStatus.CONFIRMED if confirmed else _ProbeStatus.NO_INDICATOR
     return _TakeoverResult(status)
 
@@ -235,7 +358,7 @@ def subdomain_takeover(domain: str) -> dict:
             })
             continue
 
-        probe_result = _confirms_takeover(subdomain, fingerprint)
+        probe_result = _confirms_takeover(subdomain, fingerprint, resolver=resolver)
         if probe_result.status is _ProbeStatus.CONFIRMED:
             vulnerable.append({
                 "subdomain": subdomain,


### PR DESCRIPTION
## Closes

Addresses #154 (Items 5, 6, 7, 8, 9, 12)

## Summary

Enhances subdomain takeover detection reliability and security:
1. Replaces substring CNAME matching with anchored regex patterns for all fingerprinted services (Item 6).
2. Refines Fastly fingerprint to require specific `Fastly error: unknown domain` marker and adds multi-signal indicator validation (Items 5 & 7).
3. Adds SSRF protection to block scanning hostnames and redirect targets that resolve to RFC 1918 private, loopback, link-local, or reserved IP spaces (Item 9).
4. Makes HTTP redirect handling explicit (`allow_redirects=False`) and prevents following cross-domain redirects that could lead to false positives on third-party sites (Item 8).
5. Removes forced `tcp=True` in CNAME resolution, restoring dnspython's default UDP-first resolution with automatic TCP fallback (Item 12).

## What changed

- **`tools/subdomain_takeover_tool.py`**:
  - Replaced `cname_contains` with anchored `cname_pattern` regexes for GitHub Pages, Heroku, Azure, Ghost, Shopify, and Fastly.
  - Implemented `_is_private_or_reserved_ip` and `_check_host_ssrf` to detect loopback, link-local (cloud metadata `169.254.169.254`), and private IP literals or DNS resolutions before HTTP probes.
  - Updated `_probe` with explicit redirect handling (`allow_redirects=False`, max 3 hops, halting when redirect leaves subdomain scope).
  - Updated `_confirms_takeover` to support multi-signal matching across status code, body markers, and response headers.
  - Removed `tcp=True` override in `_resolve_cname()`.
- **`tests/test_subdomain_takeover.py`**:
  - Added unit test verifying UDP-first CNAME resolution without forced `tcp=True`.
  - Added tests for anchored regex matching and rejection of lookalike domains.
  - Added tests for refined Fastly indicator distinguishing generic errors from unclaimed domain errors.
  - Added tests for explicit redirect halting on cross-domain targets.
  - Added tests for SSRF blocking of private and loopback IPs.

## Notes

- Backwards compatibility is preserved for custom fingerprints that might provide `cname_contains`.
- Existing classifications and response schemas remain intact.

## Verification

- [x] Ran locally and confirmed it works as expected
- [x] Added/updated tests for the changed behavior
- [x] All tests pass (`uv run pytest`)
- [x] No unrelated changes included
- [x] Checked `CONTRIBUTING.md` and applied all changes
- [x] Updated Documentation ( if required )